### PR TITLE
relay: add optional Redis client (env-configured)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,28 @@ export AWS_ACCESS_KEY_ID="your-key"
 export AWS_SECRET_ACCESS_KEY="your-secret"
 ```
 
+### Redis (optional)
+
+The relay can optionally connect to Redis on startup (best-effort) for publishing topology/routing metadata in higher-level features.
+
+- **Enable**: set `REDIS_ADDR` (e.g. `localhost:6379`)
+- **Optional**: `REDIS_PASSWORD`, `REDIS_DB`
+
+**Local Redis (Docker):**
+
+```bash
+docker run --rm -p 6379:6379 redis:7
+REDIS_ADDR=localhost:6379 go run cmd/aero-arc-relay/main.go -config configs/config.yaml
+```
+
+**Example relay logs when Redis is enabled:**
+
+```text
+INFO Starting aero-arc-relay...
+INFO Redis client initialised addr=localhost:6379
+INFO serving gRPC server port=:50051
+```
+
 ## Telemetry Data Format
 
 The relay uses a unified `TelemetryEnvelope` format for all messages:

--- a/cmd/aero-arc-relay/main.go
+++ b/cmd/aero-arc-relay/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/makinje/aero-arc-relay/internal/config"
+	"github.com/makinje/aero-arc-relay/internal/redisconn"
 	"github.com/makinje/aero-arc-relay/internal/relay"
 )
 
@@ -45,6 +46,14 @@ func main() {
 		fmt.Println("\nShutting down...")
 		cancel()
 	}()
+
+	// Initialise Redis connectivity (optional, controlled via environment).
+	// Failures are logged but do not abort relay startup.
+	redisClient := redisconn.InitFromEnv(ctx)
+	if redisClient != nil {
+		slog.LogAttrs(ctx, slog.LevelInfo, "Redis client initialised", slog.String("addr", os.Getenv("REDIS_ADDR")))
+	}
+	relayInstance.SetRedisClient(redisClient)
 
 	// Start the relay
 	if err := relayInstance.Start(ctx); err != nil {

--- a/cmd/aero-arc-relay/main.go
+++ b/cmd/aero-arc-relay/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -11,7 +10,6 @@ import (
 	"syscall"
 
 	"github.com/makinje/aero-arc-relay/internal/config"
-	"github.com/makinje/aero-arc-relay/internal/redisconn"
 	"github.com/makinje/aero-arc-relay/internal/relay"
 )
 
@@ -47,18 +45,6 @@ func main() {
 		fmt.Println("\nShutting down...")
 		cancel()
 	}()
-
-	// Initialise Redis connectivity (optional, controlled via environment).
-	// Failures are logged but do not abort relay startup.
-	redisClient, redisErr := redisconn.NewClientFromEnv(ctx)
-	if redisErr != nil && !errors.Is(redisErr, redisconn.ErrDisabled) {
-		slog.LogAttrs(ctx, slog.LevelWarn, "Redis init failed; continuing without aborting relay", slog.String("error", redisErr.Error()))
-		// If we got a non-nil client despite the error (e.g. ping failure), keep it wired.
-	}
-	if redisClient != nil {
-		slog.LogAttrs(ctx, slog.LevelInfo, "Redis client initialised", slog.String("addr", os.Getenv("REDIS_ADDR")))
-	}
-	relayInstance.SetRedisClient(redisClient)
 
 	// Start the relay
 	if err := relayInstance.Start(ctx); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f // indirect
 	github.com/confluentinc/confluent-kafka-go v1.9.2 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/elastic/elastic-transport-go/v8 v8.6.0 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.35.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
@@ -65,6 +66,7 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/redis/go-redis/v9 v9.7.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/elastic/elastic-transport-go/v8 v8.6.0 h1:Y2S/FBjx1LlCv5m6pWAF2kDJAHoSjSRSJCApolgfthA=
 github.com/elastic/elastic-transport-go/v8 v8.6.0/go.mod h1:YLHer5cj0csTzNFXoNQ8qhtGY1GTvSqPnKWKaqQE3Hk=
 github.com/elastic/go-elasticsearch/v8 v8.15.0 h1:IZyJhe7t7WI3NEFdcHnf6IJXqpRf+8S8QWLtZYYyBYk=
@@ -239,6 +241,8 @@ github.com/prometheus/common v0.55.0 h1:KEi6DK7lXW/m7Ig5i47x0vRzuBsHuvJdi5ee6Y3G
 github.com/prometheus/common v0.55.0/go.mod h1:2SECS4xJG1kd8XF9IcM1gMX6510RAEL65zxzNImwdc8=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=
+github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
 github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a/go.mod h1:4r5QyqhjIWCcK8DO4KMclc5Iknq5qVBAlbYYzAbUScQ=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=

--- a/internal/redisconn/errors.go
+++ b/internal/redisconn/errors.go
@@ -12,4 +12,7 @@ var (
 
 	// ErrRedisPingFailed indicates the initial connectivity check to Redis failed.
 	ErrRedisPingFailed = errors.New("redis ping failed")
+
+	// ErrRedisClientUninitialized indicates the Client has no underlying redis.Client.
+	ErrRedisClientUninitialized = errors.New("redis client is uninitialized")
 )

--- a/internal/redisconn/errors.go
+++ b/internal/redisconn/errors.go
@@ -1,0 +1,15 @@
+package redisconn
+
+import "errors"
+
+var (
+	// ErrRedisAddrNotSet indicates the Redis address was not provided.
+	// The caller can decide whether this means "Redis disabled" or is fatal.
+	ErrRedisAddrNotSet = errors.New("redis address not set (REDIS_ADDR)")
+
+	// ErrRedisDBInvalid indicates REDIS_DB is present but not a valid integer DB index.
+	ErrRedisDBInvalid = errors.New("redis db invalid (REDIS_DB)")
+
+	// ErrRedisPingFailed indicates the initial connectivity check to Redis failed.
+	ErrRedisPingFailed = errors.New("redis ping failed")
+)

--- a/internal/redisconn/redisconn.go
+++ b/internal/redisconn/redisconn.go
@@ -1,0 +1,120 @@
+package redisconn
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Client wraps a go-redis client and can be shared across components.
+type Client struct {
+	rdb *redis.Client
+}
+
+// Close closes the underlying Redis client.
+func (c *Client) Close() error {
+	if c == nil || c.rdb == nil {
+		return nil
+	}
+	return c.rdb.Close()
+}
+
+// Ping checks connectivity to Redis.
+func (c *Client) Ping(ctx context.Context) error {
+	if c == nil || c.rdb == nil {
+		return nil
+	}
+	return c.rdb.Ping(ctx).Err()
+}
+
+// global holds the process-wide Redis client instance, if configured.
+var global *Client
+
+// InitFromEnv initialises a Redis client from environment variables.
+//
+// Environment variables:
+//   - REDIS_ADDR      (required to enable Redis, e.g. "localhost:6379")
+//   - REDIS_PASSWORD  (optional)
+//   - REDIS_DB        (optional, integer DB index; defaults to 0)
+//
+// Behaviour:
+//   - If REDIS_ADDR is not set, Redis is treated as disabled and nil is returned.
+//   - If connection or ping fails, a warning is logged but the relay continues
+//     running; the client is still returned so components can implement their
+//     own retry/backoff logic.
+func InitFromEnv(ctx context.Context) *Client {
+	addr := os.Getenv("REDIS_ADDR")
+	if addr == "" {
+		slog.LogAttrs(ctx, slog.LevelInfo, "Redis disabled (REDIS_ADDR not set)")
+		return nil
+	}
+
+	password := os.Getenv("REDIS_PASSWORD")
+	db := 0
+	if dbStr := os.Getenv("REDIS_DB"); dbStr != "" {
+		// Ignore parse errors and keep db=0; this avoids crashing on bad input.
+		if parsed, err := parseDB(dbStr); err == nil {
+			db = parsed
+		} else {
+			slog.LogAttrs(ctx, slog.LevelWarn, "Invalid REDIS_DB value, defaulting to 0", slog.String("error", err.Error()))
+		}
+	}
+
+	opts := &redis.Options{
+		Addr:     addr,
+		Password: password,
+		DB:       db,
+	}
+
+	rdb := redis.NewClient(opts)
+
+	// Perform a short ping on startup to surface connectivity issues without
+	// crashing the relay.
+	pingCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	if err := rdb.Ping(pingCtx).Err(); err != nil {
+		slog.LogAttrs(ctx, slog.LevelWarn, "Redis ping failed; continuing without aborting relay", slog.String("error", err.Error()))
+	}
+
+	client := &Client{rdb: rdb}
+	global = client
+	return client
+}
+
+// Get returns the process-wide Redis client, if initialised.
+// It may be nil when Redis is disabled or misconfigured.
+func Get() *Client {
+	return global
+}
+
+// parseDB converts a REDIS_DB string into an integer index.
+func parseDB(value string) (int, error) {
+	// Small, local parse to avoid pulling in strconv here unnecessarily.
+	var n int
+	for i := 0; i < len(value); i++ {
+		ch := value[i]
+		if ch < '0' || ch > '9' {
+			return 0, fmt.Errorf("non-digit character %q in DB index", ch)
+		}
+		n = n*10 + int(ch-'0')
+	}
+	return n, nil
+}
+
+// parseDB converts a REDIS_DB string into an integer index.
+func parseDB(value string) (int, error) {
+	// Small, local parse to avoid pulling in strconv here unnecessarily.
+	var n int
+	for i := 0; i < len(value); i++ {
+		ch := value[i]
+		if ch < '0' || ch > '9' {
+			return 0, fmt.Errorf("non-digit character %q in DB index", ch)
+		}
+		n = n*10 + int(ch-'0')
+	}
+	return n, nil
+}

--- a/internal/redisconn/redisconn.go
+++ b/internal/redisconn/redisconn.go
@@ -31,9 +31,6 @@ func (c *Client) Ping(ctx context.Context) error {
 	return c.rdb.Ping(ctx).Err()
 }
 
-// global holds the process-wide Redis client instance, if configured.
-var global *Client
-
 // InitFromEnv initialises a Redis client from environment variables.
 //
 // Environment variables:
@@ -81,28 +78,7 @@ func InitFromEnv(ctx context.Context) *Client {
 	}
 
 	client := &Client{rdb: rdb}
-	global = client
 	return client
-}
-
-// Get returns the process-wide Redis client, if initialised.
-// It may be nil when Redis is disabled or misconfigured.
-func Get() *Client {
-	return global
-}
-
-// parseDB converts a REDIS_DB string into an integer index.
-func parseDB(value string) (int, error) {
-	// Small, local parse to avoid pulling in strconv here unnecessarily.
-	var n int
-	for i := 0; i < len(value); i++ {
-		ch := value[i]
-		if ch < '0' || ch > '9' {
-			return 0, fmt.Errorf("non-digit character %q in DB index", ch)
-		}
-		n = n*10 + int(ch-'0')
-	}
-	return n, nil
 }
 
 // parseDB converts a REDIS_DB string into an integer index.

--- a/internal/redisconn/redisconn.go
+++ b/internal/redisconn/redisconn.go
@@ -2,16 +2,13 @@ package redisconn
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"log/slog"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 )
-
-var ErrDisabled = errors.New("redis disabled (REDIS_ADDR not set)")
 
 // Client wraps a go-redis client and can be shared across components.
 type Client struct {
@@ -42,24 +39,22 @@ func (c *Client) Ping(ctx context.Context) error {
 //   - REDIS_DB        (optional, integer DB index; defaults to 0)
 //
 // Behaviour:
-//   - If REDIS_ADDR is not set, Redis is treated as disabled and ErrDisabled is returned.
-//   - If ping fails, the client is returned alongside an error; callers may continue
-//     running and implement retry/backoff logic as needed.
+//   - If REDIS_ADDR is not set, ErrRedisAddrNotSet is returned.
+//   - If ping fails, the client is returned alongside an error.
 func NewClientFromEnv(ctx context.Context) (*Client, error) {
 	addr := os.Getenv("REDIS_ADDR")
 	if addr == "" {
-		return nil, ErrDisabled
+		return nil, ErrRedisAddrNotSet
 	}
 
 	password := os.Getenv("REDIS_PASSWORD")
 	db := 0
 	if dbStr := os.Getenv("REDIS_DB"); dbStr != "" {
-		// Ignore parse errors and keep db=0; this avoids crashing on bad input.
-		if parsed, err := parseDB(dbStr); err == nil {
-			db = parsed
-		} else {
-			slog.LogAttrs(ctx, slog.LevelWarn, "Invalid REDIS_DB value, defaulting to 0", slog.String("error", err.Error()))
+		parsed, err := strconv.Atoi(dbStr)
+		if err != nil || parsed < 0 {
+			return nil, fmt.Errorf("%w: %q", ErrRedisDBInvalid, dbStr)
 		}
+		db = parsed
 	}
 
 	opts := &redis.Options{
@@ -74,23 +69,10 @@ func NewClientFromEnv(ctx context.Context) (*Client, error) {
 	// crashing the relay.
 	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
+
 	client := &Client{rdb: rdb}
 	if err := rdb.Ping(pingCtx).Err(); err != nil {
-		return client, fmt.Errorf("redis ping failed: %w", err)
+		return client, fmt.Errorf("%w: %v", ErrRedisPingFailed, err)
 	}
 	return client, nil
-}
-
-// parseDB converts a REDIS_DB string into an integer index.
-func parseDB(value string) (int, error) {
-	// Small, local parse to avoid pulling in strconv here unnecessarily.
-	var n int
-	for i := 0; i < len(value); i++ {
-		ch := value[i]
-		if ch < '0' || ch > '9' {
-			return 0, fmt.Errorf("non-digit character %q in DB index", ch)
-		}
-		n = n*10 + int(ch-'0')
-	}
-	return n, nil
 }

--- a/internal/redisconn/redisconn_test.go
+++ b/internal/redisconn/redisconn_test.go
@@ -23,10 +23,7 @@ func TestNewClientFromEnv_ErrRedisAddrNotSet(t *testing.T) {
 }
 
 func TestNewClientFromEnv_ErrRedisDBInvalid(t *testing.T) {
-<<<<<<< HEAD
 	// addr doesn't need to be reachable for this test; DB parse should fail first.
-=======
->>>>>>> e3ba6cf (relay/redisconn: address review notes)
 	t.Setenv("REDIS_ADDR", "127.0.0.1:6379")
 	t.Setenv("REDIS_PASSWORD", "")
 	t.Setenv("REDIS_DB", "not-an-int")
@@ -63,10 +60,6 @@ func TestNewClientFromEnv_PingFailureReturnsClientAndErrRedisPingFailed(t *testi
 	if !errors.Is(err, ErrRedisPingFailed) {
 		t.Fatalf("expected ErrRedisPingFailed, got %v", err)
 	}
-<<<<<<< HEAD
-	if closeErr := client.Close(); closeErr != nil {
-		t.Fatalf("expected nil close error, got %v", closeErr)
-=======
 }
 
 func TestClient_PingAndClose_Uninitialized(t *testing.T) {
@@ -77,6 +70,5 @@ func TestClient_PingAndClose_Uninitialized(t *testing.T) {
 	}
 	if err := c.Close(); !errors.Is(err, ErrRedisClientUninitialized) {
 		t.Fatalf("expected ErrRedisClientUninitialized, got %v", err)
->>>>>>> e3ba6cf (relay/redisconn: address review notes)
 	}
 }

--- a/internal/redisconn/redisconn_test.go
+++ b/internal/redisconn/redisconn_test.go
@@ -23,7 +23,10 @@ func TestNewClientFromEnv_ErrRedisAddrNotSet(t *testing.T) {
 }
 
 func TestNewClientFromEnv_ErrRedisDBInvalid(t *testing.T) {
+<<<<<<< HEAD
 	// addr doesn't need to be reachable for this test; DB parse should fail first.
+=======
+>>>>>>> e3ba6cf (relay/redisconn: address review notes)
 	t.Setenv("REDIS_ADDR", "127.0.0.1:6379")
 	t.Setenv("REDIS_PASSWORD", "")
 	t.Setenv("REDIS_DB", "not-an-int")
@@ -60,7 +63,20 @@ func TestNewClientFromEnv_PingFailureReturnsClientAndErrRedisPingFailed(t *testi
 	if !errors.Is(err, ErrRedisPingFailed) {
 		t.Fatalf("expected ErrRedisPingFailed, got %v", err)
 	}
+<<<<<<< HEAD
 	if closeErr := client.Close(); closeErr != nil {
 		t.Fatalf("expected nil close error, got %v", closeErr)
+=======
+}
+
+func TestClient_PingAndClose_Uninitialized(t *testing.T) {
+	var c Client // rdb is nil
+
+	if err := c.Ping(context.Background()); !errors.Is(err, ErrRedisClientUninitialized) {
+		t.Fatalf("expected ErrRedisClientUninitialized, got %v", err)
+	}
+	if err := c.Close(); !errors.Is(err, ErrRedisClientUninitialized) {
+		t.Fatalf("expected ErrRedisClientUninitialized, got %v", err)
+>>>>>>> e3ba6cf (relay/redisconn: address review notes)
 	}
 }

--- a/internal/redisconn/redisconn_test.go
+++ b/internal/redisconn/redisconn_test.go
@@ -1,0 +1,66 @@
+package redisconn
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestNewClientFromEnv_ErrRedisAddrNotSet(t *testing.T) {
+	t.Setenv("REDIS_ADDR", "")
+	t.Setenv("REDIS_PASSWORD", "")
+	t.Setenv("REDIS_DB", "")
+
+	client, err := NewClientFromEnv(context.Background())
+	if client != nil {
+		t.Fatalf("expected nil client, got %#v", client)
+	}
+	if !errors.Is(err, ErrRedisAddrNotSet) {
+		t.Fatalf("expected ErrRedisAddrNotSet, got %v", err)
+	}
+}
+
+func TestNewClientFromEnv_ErrRedisDBInvalid(t *testing.T) {
+	// addr doesn't need to be reachable for this test; DB parse should fail first.
+	t.Setenv("REDIS_ADDR", "127.0.0.1:6379")
+	t.Setenv("REDIS_PASSWORD", "")
+	t.Setenv("REDIS_DB", "not-an-int")
+
+	client, err := NewClientFromEnv(context.Background())
+	if client != nil {
+		t.Fatalf("expected nil client, got %#v", client)
+	}
+	if !errors.Is(err, ErrRedisDBInvalid) {
+		t.Fatalf("expected ErrRedisDBInvalid, got %v", err)
+	}
+}
+
+func TestNewClientFromEnv_PingFailureReturnsClientAndErrRedisPingFailed(t *testing.T) {
+	// Pick a local port and close it so connection should reliably fail.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()
+
+	t.Setenv("REDIS_ADDR", addr)
+	t.Setenv("REDIS_PASSWORD", "")
+	t.Setenv("REDIS_DB", "0")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	client, err := NewClientFromEnv(ctx)
+	if client == nil {
+		t.Fatalf("expected non-nil client on ping failure")
+	}
+	if !errors.Is(err, ErrRedisPingFailed) {
+		t.Fatalf("expected ErrRedisPingFailed, got %v", err)
+	}
+	if closeErr := client.Close(); closeErr != nil {
+		t.Fatalf("expected nil close error, got %v", closeErr)
+	}
+}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -20,6 +20,7 @@ import (
 	"github.com/bluenviron/gomavlib/v2/pkg/dialect"
 	"github.com/bluenviron/gomavlib/v2/pkg/dialects/common"
 	"github.com/makinje/aero-arc-relay/internal/config"
+	"github.com/makinje/aero-arc-relay/internal/redisconn"
 	"github.com/makinje/aero-arc-relay/internal/sinks"
 	"github.com/makinje/aero-arc-relay/pkg/telemetry"
 	"github.com/prometheus/client_golang/prometheus"
@@ -34,6 +35,7 @@ type Relay struct {
 	sinks            []sinks.Sink
 	connections      sync.Map // map[string]*gomavlib.Node
 	sinksInitialized bool
+	redisClient      *redisconn.Client
 	grpcServer       *grpc.Server
 	grpcSessions     map[string]*DroneSession
 	sessionsMu       sync.RWMutex
@@ -80,6 +82,17 @@ func New(cfg *config.Config) (*Relay, error) {
 	}
 
 	return relay, nil
+}
+
+// SetRedisClient wires an optional Redis client into the relay.
+// It is safe to pass nil (Redis disabled).
+func (r *Relay) SetRedisClient(client *redisconn.Client) {
+	r.redisClient = client
+}
+
+// RedisClient returns the currently configured Redis client (may be nil).
+func (r *Relay) RedisClient() *redisconn.Client {
+	return r.redisClient
 }
 
 // Start begins the relay operation

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -88,15 +88,6 @@ func New(cfg *config.Config) (*Relay, error) {
 func (r *Relay) initRedis(ctx context.Context) {
 	client, err := redisconn.NewClientFromEnv(ctx)
 	if err != nil {
-<<<<<<< HEAD
-		level := slog.LevelWarn
-		msg := "Redis init failed; continuing without aborting relay"
-		if errors.Is(err, redisconn.ErrRedisAddrNotSet) {
-			level = slog.LevelInfo
-			msg = "Redis disabled (REDIS_ADDR not set)"
-		}
-		slog.LogAttrs(ctx, level, msg, slog.String("error", err.Error()))
-=======
 		// Keep the client on ping failure so it can recover when Redis comes back.
 		if errors.Is(err, redisconn.ErrRedisPingFailed) && client != nil {
 			r.redisClient = client
@@ -104,15 +95,11 @@ func (r *Relay) initRedis(ctx context.Context) {
 		}
 
 		slog.LogAttrs(ctx, slog.LevelWarn, err.Error())
->>>>>>> e3ba6cf (relay/redisconn: address review notes)
 		return
 	}
 
 	r.redisClient = client
-<<<<<<< HEAD
-=======
 	r.redisRoutingStore = client
->>>>>>> e3ba6cf (relay/redisconn: address review notes)
 	slog.LogAttrs(ctx, slog.LevelInfo, "Redis client initialised", slog.String("addr", os.Getenv("REDIS_ADDR")))
 }
 

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -88,13 +88,13 @@ func New(cfg *config.Config) (*Relay, error) {
 func (r *Relay) initOptionalRedis(ctx context.Context) {
 	client, err := redisconn.NewClientFromEnv(ctx)
 	if err != nil {
-		// Any error means initialization failed; the relay continues without Redis.
-		// The relay is responsible for interpreting "disabled" vs "misconfigured".
+		level := slog.LevelWarn
+		msg := "Redis init failed; continuing without aborting relay"
 		if errors.Is(err, redisconn.ErrRedisAddrNotSet) {
-			slog.LogAttrs(ctx, slog.LevelInfo, "Redis disabled (REDIS_ADDR not set)")
-		} else {
-			slog.LogAttrs(ctx, slog.LevelWarn, "Redis init failed; continuing without aborting relay", slog.String("error", err.Error()))
+			level = slog.LevelInfo
+			msg = "Redis disabled (REDIS_ADDR not set)"
 		}
+		slog.LogAttrs(ctx, level, msg, slog.String("error", err.Error()))
 		return
 	}
 

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -91,7 +91,6 @@ func (r *Relay) initRedis(ctx context.Context) {
 		// Keep the client on ping failure so it can recover when Redis comes back.
 		if errors.Is(err, redisconn.ErrRedisPingFailed) && client != nil {
 			r.redisClient = client
-			r.redisRoutingStore = client
 		}
 
 		slog.LogAttrs(ctx, slog.LevelWarn, err.Error())
@@ -99,7 +98,6 @@ func (r *Relay) initRedis(ctx context.Context) {
 	}
 
 	r.redisClient = client
-	r.redisRoutingStore = client
 	slog.LogAttrs(ctx, slog.LevelInfo, "Redis client initialised", slog.String("addr", os.Getenv("REDIS_ADDR")))
 }
 

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -90,11 +90,6 @@ func (r *Relay) SetRedisClient(client *redisconn.Client) {
 	r.redisClient = client
 }
 
-// RedisClient returns the currently configured Redis client (may be nil).
-func (r *Relay) RedisClient() *redisconn.Client {
-	return r.redisClient
-}
-
 // Start begins the relay operation
 func (r *Relay) Start(ctx context.Context) error {
 	slog.Info("Starting aero-arc-relay...")

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -85,9 +85,10 @@ func New(cfg *config.Config) (*Relay, error) {
 	return relay, nil
 }
 
-func (r *Relay) initOptionalRedis(ctx context.Context) {
+func (r *Relay) initRedis(ctx context.Context) {
 	client, err := redisconn.NewClientFromEnv(ctx)
 	if err != nil {
+<<<<<<< HEAD
 		level := slog.LevelWarn
 		msg := "Redis init failed; continuing without aborting relay"
 		if errors.Is(err, redisconn.ErrRedisAddrNotSet) {
@@ -95,10 +96,23 @@ func (r *Relay) initOptionalRedis(ctx context.Context) {
 			msg = "Redis disabled (REDIS_ADDR not set)"
 		}
 		slog.LogAttrs(ctx, level, msg, slog.String("error", err.Error()))
+=======
+		// Keep the client on ping failure so it can recover when Redis comes back.
+		if errors.Is(err, redisconn.ErrRedisPingFailed) && client != nil {
+			r.redisClient = client
+			r.redisRoutingStore = client
+		}
+
+		slog.LogAttrs(ctx, slog.LevelWarn, err.Error())
+>>>>>>> e3ba6cf (relay/redisconn: address review notes)
 		return
 	}
 
 	r.redisClient = client
+<<<<<<< HEAD
+=======
+	r.redisRoutingStore = client
+>>>>>>> e3ba6cf (relay/redisconn: address review notes)
 	slog.LogAttrs(ctx, slog.LevelInfo, "Redis client initialised", slog.String("addr", os.Getenv("REDIS_ADDR")))
 }
 
@@ -106,7 +120,7 @@ func (r *Relay) initOptionalRedis(ctx context.Context) {
 func (r *Relay) Start(ctx context.Context) error {
 	slog.Info("Starting aero-arc-relay...")
 
-	r.initOptionalRedis(ctx)
+	r.initRedis(ctx)
 
 	// Initialize MAVLink node with all endpoints if in 1:1 mode
 	if r.config.Relay.Mode == config.MAVLinkMode1To1 {


### PR DESCRIPTION
Initialise Redis from REDIS_ADDR/REDIS_PASSWORD/REDIS_DB on startup, keep outages non-fatal, and store a reusable client on the relay for other components.

Fixes #20