### PR TITLE
Upstream pr 21 drone routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,16 @@ Prometheus metrics are exposed at `http://localhost:2112/metrics`:
 - **`/healthz`** - Liveness probe (always 200 if process is running)
 - **`/readyz`** - Readiness probe (200 once sinks are initialized)
 
+## Control-Plane API Contract
+
+Building `aeroarc-api` (or any other control-plane client) against the relay?
+
+Start here:
+
+- `docs/control_plane_contract.md`
+
+It documents what the relay **actually guarantees today** (supported RPCs, who “owns” session state, failure semantics, and Redis routing behavior), so you don’t have to infer behavior from code.
+
 ## Contributing
 
 1. Fork the repository

--- a/cmd/aero-arc-relay/main.go
+++ b/cmd/aero-arc-relay/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/makinje/aero-arc-relay/internal/config"
+	"github.com/makinje/aero-arc-relay/internal/redisconn"
 	"github.com/makinje/aero-arc-relay/internal/relay"
 )
 
@@ -45,6 +46,14 @@ func main() {
 		fmt.Println("\nShutting down...")
 		cancel()
 	}()
+
+	// Initialise Redis connectivity (optional, controlled via environment).
+	// Failures are logged but do not abort relay startup.
+	redisClient := redisconn.InitFromEnv(ctx)
+	if redisClient != nil {
+		slog.LogAttrs(ctx, slog.LevelInfo, "Redis client initialised", slog.String("addr", os.Getenv("REDIS_ADDR")))
+	}
+	relayInstance.SetRedisClient(redisClient)
 
 	// Start the relay
 	if err := relayInstance.Start(ctx); err != nil {

--- a/cmd/aero-arc-relay/main.go
+++ b/cmd/aero-arc-relay/main.go
@@ -10,7 +10,6 @@ import (
 	"syscall"
 
 	"github.com/makinje/aero-arc-relay/internal/config"
-	"github.com/makinje/aero-arc-relay/internal/redisconn"
 	"github.com/makinje/aero-arc-relay/internal/relay"
 )
 
@@ -46,14 +45,6 @@ func main() {
 		fmt.Println("\nShutting down...")
 		cancel()
 	}()
-
-	// Initialise Redis connectivity (optional, controlled via environment).
-	// Failures are logged but do not abort relay startup.
-	redisClient := redisconn.InitFromEnv(ctx)
-	if redisClient != nil {
-		slog.LogAttrs(ctx, slog.LevelInfo, "Redis client initialised", slog.String("addr", os.Getenv("REDIS_ADDR")))
-	}
-	relayInstance.SetRedisClient(redisClient)
 
 	// Start the relay
 	if err := relayInstance.Start(ctx); err != nil {

--- a/docs/control_plane_contract.md
+++ b/docs/control_plane_contract.md
@@ -1,0 +1,151 @@
+# Relay Control-Plane Contract
+
+This document describes the relay’s **control-plane responsibilities and guarantees**, based on the **currently implemented behavior** in this repository.
+
+It is intended for **API/backend developers** integrating with the relay (e.g. `aeroarc-api`) so they can consume it **without guessing**.
+
+## Scope
+
+The relay exposes two control-plane surfaces:
+
+- **gRPC AgentGateway** (`aeroarc.agent.v1.AgentGateway`): agent registration + bidirectional telemetry streaming.
+- **gRPC RelayControl** (`aeroarc.relay.v1.RelayControl`): fleet/session status APIs (**registered**, but currently **stubbed** / empty responses in code).
+
+The relay also optionally publishes session routing metadata to **Redis** for topology/routing lookups.
+
+## Endpoints
+
+- **gRPC**: `0.0.0.0:${relay.grpc_port}` (default `50051`)
+- **HTTP metrics**: `:2112/metrics`
+- **Health**: `:2112/healthz`
+- **Ready**: `:2112/readyz`
+
+## Data ownership rules
+
+- **Relay is the source of truth** for **in-memory session state** during process lifetime.
+- Session state is keyed by **Agent ID** (`agent_id`) in the current implementation.
+- The relay does **not** guarantee persistence of session state across restarts.
+- Redis (if enabled) is used only for **best-effort publication** of routing metadata; Redis is **not** authoritative for session truth.
+
+## Supported RPCs
+
+### AgentGateway.Register
+
+**RPC**: `Register(RegisterRequest) returns (RegisterResponse)`
+
+**Purpose**: Establishes an agent session in relay memory and returns a server-issued `session_id`.
+
+**Current behavior**
+- Creates/overwrites an in-memory session record keyed by `RegisterRequest.agent_id`.
+- Returns:
+  - `RegisterResponse.agent_id` = request `agent_id`
+  - `RegisterResponse.session_id` = currently `"sess-" + agent_id` (placeholder; not cryptographically random)
+  - `RegisterResponse.max_inflight` = currently a fixed default in code
+
+**Failure semantics**
+- If required fields are missing, the relay may return a gRPC error (implementation-specific).
+
+**Side effects**
+- If Redis routing publication is enabled, the relay writes the mapping described in [Redis usage guarantees](#redis-usage-guarantees).
+
+### AgentGateway.TelemetryStream
+
+**RPC**: `TelemetryStream(stream TelemetryFrame) returns (stream TelemetryAck)`
+
+**Purpose**: Bidirectional streaming telemetry ingest; relay acks each received frame and forwards it to sinks.
+
+**Request requirements**
+- The incoming gRPC metadata **must** include: `aero-arc-agent-id: <agent_id>`
+- The agent should call `Register()` first so a session exists in relay memory.
+
+**Current behavior**
+- On stream start, the relay associates the server stream with the in-memory session keyed by `aero-arc-agent-id`.
+- For each received `TelemetryFrame`:
+  - Converts it into a `TelemetryEnvelope`
+  - Forwards it to all configured sinks (implementation may be synchronous per sink)
+  - Sends a `TelemetryAck` (currently per-frame ack)
+
+**Failure semantics**
+- Missing metadata → `InvalidArgument`
+- Missing `aero-arc-agent-id` header → `InvalidArgument`
+- Unregistered agent/session → the stream returns an error (exact code depends on implementation path; callers should treat this as “must register first”)
+- Stream `io.EOF` → treated as clean client close
+
+**Disconnect semantics**
+- On clean disconnect, the relay ends the stream.
+- If Redis routing publication is enabled, the relay best-effort removes the routing mapping (see [Redis usage guarantees](#redis-usage-guarantees)).
+
+### RelayControl.ListActiveDrones
+
+**RPC**: `ListActiveDrones(ListActiveDronesRequest) returns (ListActiveDronesResponse)`
+
+**Current behavior**
+- RPC is **registered** on the gRPC server.
+- Implementation is currently a **stub** and returns an empty response.
+
+### RelayControl.GetDroneStatus
+
+**RPC**: `GetDroneStatus(GetDroneStatusRequest) returns (GetDroneStatusResponse)`
+
+**Current behavior**
+- RPC is **registered** on the gRPC server.
+- Implementation is currently a **stub** and returns an empty response.
+
+## Failure semantics (general)
+
+- **No hard dependency on Redis**: Redis failures should not prevent the relay from starting or serving gRPC.
+- **Crash/restart**: in-memory session state is lost; any routing metadata relies on TTL expiry in Redis.
+
+## Redis usage guarantees
+
+Redis is optional and is enabled only if `REDIS_ADDR` is set.
+
+### Redis connection configuration
+
+Environment variables:
+
+- `REDIS_ADDR`: host:port (enables Redis)
+- `REDIS_PASSWORD`: optional
+- `REDIS_DB`: optional integer DB index
+
+Startup:
+- Relay attempts a short `PING` on startup and logs warnings on failure.
+- Relay continues running even if Redis is unreachable.
+
+### Routing metadata publication
+
+When an agent session is active, the relay publishes:
+
+**Key**
+
+- `drone:{drone_id}`
+- In the current implementation, `drone_id` == `agent_id`
+
+**Value**
+
+JSON payload:
+
+```json
+{
+  "relay_id": "…",
+  "session_id": "…"
+}
+```
+
+`relay_id` selection:
+- `RELAY_ID` env var if set, else hostname, else `"relay"`
+
+**TTL**
+- TTL-based, defaulting to **45s**.
+
+**Refresh**
+- While the session is active, the relay refreshes the TTL periodically (currently every `TTL/2`).
+
+**Disconnect + crash**
+- On clean disconnect, the relay best-effort deletes the key.
+- On crash/restart, refresh stops and the key should expire via TTL.
+
+**Guarantee level**
+- Publication is **best-effort**. Consumers must tolerate missing/late updates and should treat Redis as a cache of routing hints, not an authoritative source of truth.
+
+

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f // indirect
 	github.com/confluentinc/confluent-kafka-go v1.9.2 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/elastic/elastic-transport-go/v8 v8.6.0 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.35.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
@@ -65,6 +66,7 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/redis/go-redis/v9 v9.7.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/elastic/elastic-transport-go/v8 v8.6.0 h1:Y2S/FBjx1LlCv5m6pWAF2kDJAHoSjSRSJCApolgfthA=
 github.com/elastic/elastic-transport-go/v8 v8.6.0/go.mod h1:YLHer5cj0csTzNFXoNQ8qhtGY1GTvSqPnKWKaqQE3Hk=
 github.com/elastic/go-elasticsearch/v8 v8.15.0 h1:IZyJhe7t7WI3NEFdcHnf6IJXqpRf+8S8QWLtZYYyBYk=
@@ -239,6 +241,8 @@ github.com/prometheus/common v0.55.0 h1:KEi6DK7lXW/m7Ig5i47x0vRzuBsHuvJdi5ee6Y3G
 github.com/prometheus/common v0.55.0/go.mod h1:2SECS4xJG1kd8XF9IcM1gMX6510RAEL65zxzNImwdc8=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=
+github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
 github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a/go.mod h1:4r5QyqhjIWCcK8DO4KMclc5Iknq5qVBAlbYYzAbUScQ=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=

--- a/internal/redisconn/errors.go
+++ b/internal/redisconn/errors.go
@@ -12,4 +12,7 @@ var (
 
 	// ErrRedisPingFailed indicates the initial connectivity check to Redis failed.
 	ErrRedisPingFailed = errors.New("redis ping failed")
+
+	// ErrRedisClientUninitialized indicates the Client has no underlying redis.Client.
+	ErrRedisClientUninitialized = errors.New("redis client is uninitialized")
 )

--- a/internal/redisconn/errors.go
+++ b/internal/redisconn/errors.go
@@ -1,0 +1,15 @@
+package redisconn
+
+import "errors"
+
+var (
+	// ErrRedisAddrNotSet indicates the Redis address was not provided.
+	// The caller can decide whether this means "Redis disabled" or is fatal.
+	ErrRedisAddrNotSet = errors.New("redis address not set (REDIS_ADDR)")
+
+	// ErrRedisDBInvalid indicates REDIS_DB is present but not a valid integer DB index.
+	ErrRedisDBInvalid = errors.New("redis db invalid (REDIS_DB)")
+
+	// ErrRedisPingFailed indicates the initial connectivity check to Redis failed.
+	ErrRedisPingFailed = errors.New("redis ping failed")
+)

--- a/internal/redisconn/redisconn.go
+++ b/internal/redisconn/redisconn.go
@@ -2,6 +2,7 @@ package redisconn
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -9,6 +10,13 @@ import (
 
 	"github.com/redis/go-redis/v9"
 )
+
+// DroneRoutingStore publishes routing metadata for a drone to Redis.
+// This is intentionally narrow to avoid leaking the underlying Redis client.
+type DroneRoutingStore interface {
+	UpsertDroneRouting(ctx context.Context, droneID, relayID, sessionID string, ttl time.Duration) error
+	DeleteDroneRouting(ctx context.Context, droneID string) error
+}
 
 // Client wraps a go-redis client and can be shared across components.
 type Client struct {
@@ -91,18 +99,56 @@ func Get() *Client {
 	return global
 }
 
-// parseDB converts a REDIS_DB string into an integer index.
-func parseDB(value string) (int, error) {
-	// Small, local parse to avoid pulling in strconv here unnecessarily.
-	var n int
-	for i := 0; i < len(value); i++ {
-		ch := value[i]
-		if ch < '0' || ch > '9' {
-			return 0, fmt.Errorf("non-digit character %q in DB index", ch)
-		}
-		n = n*10 + int(ch-'0')
+type droneRoutingValue struct {
+	RelayID   string `json:"relay_id"`
+	SessionID string `json:"session_id"`
+}
+
+func droneRoutingKey(droneID string) string {
+	return "drone:" + droneID
+}
+
+// UpsertDroneRouting writes drone routing metadata with a TTL.
+// It is safe to call repeatedly; each call refreshes the TTL.
+func (c *Client) UpsertDroneRouting(ctx context.Context, droneID, relayID, sessionID string, ttl time.Duration) error {
+	if c == nil || c.rdb == nil {
+		return nil
 	}
-	return n, nil
+	if droneID == "" {
+		return fmt.Errorf("drone_id is required")
+	}
+	if relayID == "" {
+		return fmt.Errorf("relay_id is required")
+	}
+	if sessionID == "" {
+		return fmt.Errorf("session_id is required")
+	}
+	if ttl <= 0 {
+		return fmt.Errorf("ttl must be > 0")
+	}
+
+	payload, err := json.Marshal(droneRoutingValue{RelayID: relayID, SessionID: sessionID})
+	if err != nil {
+		return err
+	}
+
+	opCtx, cancel := context.WithTimeout(ctx, 750*time.Millisecond)
+	defer cancel()
+	return c.rdb.Set(opCtx, droneRoutingKey(droneID), payload, ttl).Err()
+}
+
+// DeleteDroneRouting best-effort deletes drone routing metadata.
+// TTL-based expiry still acts as a safety net on crashes.
+func (c *Client) DeleteDroneRouting(ctx context.Context, droneID string) error {
+	if c == nil || c.rdb == nil {
+		return nil
+	}
+	if droneID == "" {
+		return fmt.Errorf("drone_id is required")
+	}
+	opCtx, cancel := context.WithTimeout(ctx, 750*time.Millisecond)
+	defer cancel()
+	return c.rdb.Del(opCtx, droneRoutingKey(droneID)).Err()
 }
 
 // parseDB converts a REDIS_DB string into an integer index.

--- a/internal/redisconn/redisconn.go
+++ b/internal/redisconn/redisconn.go
@@ -1,0 +1,120 @@
+package redisconn
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Client wraps a go-redis client and can be shared across components.
+type Client struct {
+	rdb *redis.Client
+}
+
+// Close closes the underlying Redis client.
+func (c *Client) Close() error {
+	if c == nil || c.rdb == nil {
+		return nil
+	}
+	return c.rdb.Close()
+}
+
+// Ping checks connectivity to Redis.
+func (c *Client) Ping(ctx context.Context) error {
+	if c == nil || c.rdb == nil {
+		return nil
+	}
+	return c.rdb.Ping(ctx).Err()
+}
+
+// global holds the process-wide Redis client instance, if configured.
+var global *Client
+
+// InitFromEnv initialises a Redis client from environment variables.
+//
+// Environment variables:
+//   - REDIS_ADDR      (required to enable Redis, e.g. "localhost:6379")
+//   - REDIS_PASSWORD  (optional)
+//   - REDIS_DB        (optional, integer DB index; defaults to 0)
+//
+// Behaviour:
+//   - If REDIS_ADDR is not set, Redis is treated as disabled and nil is returned.
+//   - If connection or ping fails, a warning is logged but the relay continues
+//     running; the client is still returned so components can implement their
+//     own retry/backoff logic.
+func InitFromEnv(ctx context.Context) *Client {
+	addr := os.Getenv("REDIS_ADDR")
+	if addr == "" {
+		slog.LogAttrs(ctx, slog.LevelInfo, "Redis disabled (REDIS_ADDR not set)")
+		return nil
+	}
+
+	password := os.Getenv("REDIS_PASSWORD")
+	db := 0
+	if dbStr := os.Getenv("REDIS_DB"); dbStr != "" {
+		// Ignore parse errors and keep db=0; this avoids crashing on bad input.
+		if parsed, err := parseDB(dbStr); err == nil {
+			db = parsed
+		} else {
+			slog.LogAttrs(ctx, slog.LevelWarn, "Invalid REDIS_DB value, defaulting to 0", slog.String("error", err.Error()))
+		}
+	}
+
+	opts := &redis.Options{
+		Addr:     addr,
+		Password: password,
+		DB:       db,
+	}
+
+	rdb := redis.NewClient(opts)
+
+	// Perform a short ping on startup to surface connectivity issues without
+	// crashing the relay.
+	pingCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	if err := rdb.Ping(pingCtx).Err(); err != nil {
+		slog.LogAttrs(ctx, slog.LevelWarn, "Redis ping failed; continuing without aborting relay", slog.String("error", err.Error()))
+	}
+
+	client := &Client{rdb: rdb}
+	global = client
+	return client
+}
+
+// Get returns the process-wide Redis client, if initialised.
+// It may be nil when Redis is disabled or misconfigured.
+func Get() *Client {
+	return global
+}
+
+// parseDB converts a REDIS_DB string into an integer index.
+func parseDB(value string) (int, error) {
+	// Small, local parse to avoid pulling in strconv here unnecessarily.
+	var n int
+	for i := 0; i < len(value); i++ {
+		ch := value[i]
+		if ch < '0' || ch > '9' {
+			return 0, fmt.Errorf("non-digit character %q in DB index", ch)
+		}
+		n = n*10 + int(ch-'0')
+	}
+	return n, nil
+}
+
+// parseDB converts a REDIS_DB string into an integer index.
+func parseDB(value string) (int, error) {
+	// Small, local parse to avoid pulling in strconv here unnecessarily.
+	var n int
+	for i := 0; i < len(value); i++ {
+		ch := value[i]
+		if ch < '0' || ch > '9' {
+			return 0, fmt.Errorf("non-digit character %q in DB index", ch)
+		}
+		n = n*10 + int(ch-'0')
+	}
+	return n, nil
+}

--- a/internal/redisconn/redisconn.go
+++ b/internal/redisconn/redisconn.go
@@ -39,9 +39,6 @@ func (c *Client) Ping(ctx context.Context) error {
 	return c.rdb.Ping(ctx).Err()
 }
 
-// global holds the process-wide Redis client instance, if configured.
-var global *Client
-
 // InitFromEnv initialises a Redis client from environment variables.
 //
 // Environment variables:
@@ -89,14 +86,7 @@ func InitFromEnv(ctx context.Context) *Client {
 	}
 
 	client := &Client{rdb: rdb}
-	global = client
 	return client
-}
-
-// Get returns the process-wide Redis client, if initialised.
-// It may be nil when Redis is disabled or misconfigured.
-func Get() *Client {
-	return global
 }
 
 type droneRoutingValue struct {

--- a/internal/redisconn/redisconn_test.go
+++ b/internal/redisconn/redisconn_test.go
@@ -1,0 +1,73 @@
+package redisconn
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestNewClientFromEnv_ErrRedisAddrNotSet(t *testing.T) {
+	t.Setenv("REDIS_ADDR", "")
+	t.Setenv("REDIS_PASSWORD", "")
+	t.Setenv("REDIS_DB", "")
+
+	client, err := NewClientFromEnv(context.Background())
+	if client != nil {
+		t.Fatalf("expected nil client, got %#v", client)
+	}
+	if !errors.Is(err, ErrRedisAddrNotSet) {
+		t.Fatalf("expected ErrRedisAddrNotSet, got %v", err)
+	}
+}
+
+func TestNewClientFromEnv_ErrRedisDBInvalid(t *testing.T) {
+	t.Setenv("REDIS_ADDR", "127.0.0.1:6379")
+	t.Setenv("REDIS_PASSWORD", "")
+	t.Setenv("REDIS_DB", "not-an-int")
+
+	client, err := NewClientFromEnv(context.Background())
+	if client != nil {
+		t.Fatalf("expected nil client, got %#v", client)
+	}
+	if !errors.Is(err, ErrRedisDBInvalid) {
+		t.Fatalf("expected ErrRedisDBInvalid, got %v", err)
+	}
+}
+
+func TestNewClientFromEnv_PingFailureReturnsClientAndErrRedisPingFailed(t *testing.T) {
+	// Pick a local port and close it so connection should reliably fail.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()
+
+	t.Setenv("REDIS_ADDR", addr)
+	t.Setenv("REDIS_PASSWORD", "")
+	t.Setenv("REDIS_DB", "0")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	client, err := NewClientFromEnv(ctx)
+	if client == nil {
+		t.Fatalf("expected non-nil client on ping failure")
+	}
+	if !errors.Is(err, ErrRedisPingFailed) {
+		t.Fatalf("expected ErrRedisPingFailed, got %v", err)
+	}
+}
+
+func TestClient_PingAndClose_Uninitialized(t *testing.T) {
+	var c Client // rdb is nil
+
+	if err := c.Ping(context.Background()); !errors.Is(err, ErrRedisClientUninitialized) {
+		t.Fatalf("expected ErrRedisClientUninitialized, got %v", err)
+	}
+	if err := c.Close(); !errors.Is(err, ErrRedisClientUninitialized) {
+		t.Fatalf("expected ErrRedisClientUninitialized, got %v", err)
+	}
+}

--- a/internal/relay/gatewayserver_redis_routing_test.go
+++ b/internal/relay/gatewayserver_redis_routing_test.go
@@ -1,0 +1,130 @@
+package relay
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
+	"google.golang.org/grpc/metadata"
+)
+
+type fakeRoutingStore struct {
+	mu          sync.Mutex
+	upserts     int
+	deletes     int
+	lastDroneID string
+	lastSession string
+	ch          chan struct{}
+}
+
+func (f *fakeRoutingStore) UpsertDroneRouting(ctx context.Context, droneID, relayID, sessionID string, ttl time.Duration) error {
+	f.mu.Lock()
+	f.upserts++
+	f.lastDroneID = droneID
+	f.lastSession = sessionID
+	f.mu.Unlock()
+	select {
+	case f.ch <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (f *fakeRoutingStore) DeleteDroneRouting(ctx context.Context, droneID string) error {
+	f.mu.Lock()
+	f.deletes++
+	f.lastDroneID = droneID
+	f.mu.Unlock()
+	select {
+	case f.ch <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func TestRedisRouting_RegisterPublishesAndRefreshes(t *testing.T) {
+	store := &fakeRoutingStore{ch: make(chan struct{}, 10)}
+	r := &Relay{
+		grpcSessions:                make(map[string]*DroneSession),
+		redisRoutingStore:           store,
+		redisRoutingTTL:             40 * time.Millisecond,
+		redisRoutingCancelByDroneID: make(map[string]context.CancelFunc),
+	}
+
+	resp, err := r.Register(context.Background(), &agentv1.RegisterRequest{AgentId: "agent-1"})
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if resp.SessionId == "" {
+		t.Fatalf("expected session id")
+	}
+
+	// Expect immediate publish.
+	select {
+	case <-store.ch:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatalf("expected redis upsert")
+	}
+
+	// Expect at least one refresh tick.
+	select {
+	case <-store.ch:
+	case <-time.After(300 * time.Millisecond):
+		t.Fatalf("expected redis refresh upsert")
+	}
+
+	store.mu.Lock()
+	lastSession := store.lastSession
+	store.mu.Unlock()
+	if lastSession != resp.SessionId {
+		t.Fatalf("expected latest session in upsert; got %q want %q", lastSession, resp.SessionId)
+	}
+}
+
+func TestRedisRouting_TelemetryStreamDisconnectDeletesMapping(t *testing.T) {
+	store := &fakeRoutingStore{ch: make(chan struct{}, 10)}
+	r := &Relay{
+		grpcSessions:                make(map[string]*DroneSession),
+		redisRoutingStore:           store,
+		redisRoutingTTL:             50 * time.Millisecond,
+		redisRoutingCancelByDroneID: make(map[string]context.CancelFunc),
+	}
+
+	_, err := r.Register(context.Background(), &agentv1.RegisterRequest{AgentId: "agent-2"})
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("aero-arc-agent-id", "agent-2"))
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	stream := &mockTelemetryStream{
+		ctx:         ctx,
+		recvChan:    make(chan *agentv1.TelemetryFrame, 1),
+		sentAckChan: make(chan *agentv1.TelemetryAck, 1),
+		errChan:     make(chan error, 1),
+	}
+
+	// Close stream to trigger io.EOF -> deferred delete runs.
+	close(stream.recvChan)
+	_ = r.TelemetryStream(stream)
+
+	// Expect a delete call (best-effort).
+	deadline := time.After(250 * time.Millisecond)
+	for {
+		store.mu.Lock()
+		deletes := store.deletes
+		store.mu.Unlock()
+		if deletes > 0 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("expected redis delete on disconnect")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -20,6 +20,7 @@ import (
 	"github.com/bluenviron/gomavlib/v2/pkg/dialect"
 	"github.com/bluenviron/gomavlib/v2/pkg/dialects/common"
 	"github.com/makinje/aero-arc-relay/internal/config"
+	"github.com/makinje/aero-arc-relay/internal/redisconn"
 	"github.com/makinje/aero-arc-relay/internal/sinks"
 	"github.com/makinje/aero-arc-relay/pkg/telemetry"
 	"github.com/prometheus/client_golang/prometheus"
@@ -34,6 +35,7 @@ type Relay struct {
 	sinks            []sinks.Sink
 	connections      sync.Map // map[string]*gomavlib.Node
 	sinksInitialized bool
+	redisClient      *redisconn.Client
 	grpcServer       *grpc.Server
 	grpcSessions     map[string]*DroneSession
 	sessionsMu       sync.RWMutex
@@ -80,6 +82,17 @@ func New(cfg *config.Config) (*Relay, error) {
 	}
 
 	return relay, nil
+}
+
+// SetRedisClient wires an optional Redis client into the relay.
+// It is safe to pass nil (Redis disabled).
+func (r *Relay) SetRedisClient(client *redisconn.Client) {
+	r.redisClient = client
+}
+
+// RedisClient returns the currently configured Redis client (may be nil).
+func (r *Relay) RedisClient() *redisconn.Client {
+	return r.redisClient
 }
 
 // Start begins the relay operation


### PR DESCRIPTION
Publishes drone:{agent_id} → {relay_id, session_id} to Redis with 45s TTL, refreshes every TTL/2
Cancels refresh + best-effort DEL on TelemetryStream disconnect (TTL still covers crashes)
Adds a focused unit test (internal/relay/gatewayserver_redis_routing_test.go)