### PR TITLE
[Relay] Enable TLS in Debug Mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ release: clean build-all test-all quality security
 # Generate local TLS certs for development
 # https://letsencrypt.org/docs/certificates-for-localhost/
 local-tls-certs:
-	@if [ -f ~/.aeroarc/local-certs/localhost.crt ] && [ -f ~/.aeroarc/local-keys/localhost.key ]; then \
+	@if [ -f ~/.aeroarc/local-certs/localhost.crt ] && [ -f ~/.aeroarc/local-certs/localhost.key ]; then \
 		echo "Local TLS certs already exist at ~/.aeroarc/local-certs."; \
 	else \
 		mkdir -p ~/.aeroarc/local-certs; \

--- a/cmd/aero-arc-relay/main.go
+++ b/cmd/aero-arc-relay/main.go
@@ -27,7 +27,7 @@ var relayCommand = cli.Command{
 		&cli.BoolFlag{
 			Name:  "debug",
 			Usage: "run the relay in debug mode. Useful for local testing",
-			Value: true,
+			Value: false,
 		},
 	},
 }

--- a/cmd/aero-arc-relay/main.go
+++ b/cmd/aero-arc-relay/main.go
@@ -24,6 +24,16 @@ var relayCommand = cli.Command{
 			Usage: "path to the configuration file",
 			Value: "configs/config.yaml",
 		},
+		&cli.StringFlag{
+			Name:  "tls-cert-path",
+			Usage: "path to tls cert file",
+			Value: relay.DebugTLSCertPath,
+		},
+		&cli.StringFlag{
+			Name:  "tls-key-path",
+			Usage: "path to tls key file",
+			Value: relay.DebugTLSKeyPath,
+		},
 		&cli.BoolFlag{
 			Name:  "debug",
 			Usage: "run the relay in debug mode. Useful for local testing",
@@ -41,6 +51,8 @@ func RunRelay(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	cfg.Debug = cmd.Bool("debug")
+	cfg.TLSCertPath = cmd.String("tls-cert-path")
+	cfg.TLSKeyPath = cmd.String("tls-key-path")
 
 	// Create relay instance
 	relayInstance, err := relay.New(cfg)

--- a/cmd/aero-arc-relay/main.go
+++ b/cmd/aero-arc-relay/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
+	"log"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -11,19 +11,36 @@ import (
 
 	"github.com/makinje/aero-arc-relay/internal/config"
 	"github.com/makinje/aero-arc-relay/internal/relay"
+	"github.com/urfave/cli/v3"
 )
 
-func main() {
-	var configPath string
-	flag.StringVar(&configPath, "config", "configs/config.yaml", "Path to configuration file")
-	flag.Parse()
+var relayCommand = cli.Command{
+	Usage:  "run the relay process",
+	Action: RunRelay,
 
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "config-path",
+			Usage: "path to the configuration file",
+			Value: "configs/config.yaml",
+		},
+		&cli.BoolFlag{
+			Name:  "debug",
+			Usage: "run the relay in debug mode. Useful for local testing",
+			Value: true,
+		},
+	},
+}
+
+func RunRelay(ctx context.Context, cmd *cli.Command) error {
 	// Load configuration
-	cfg, err := config.Load(configPath)
+	cfg, err := config.Load(cmd.String("config-path"))
 	if err != nil {
 		slog.LogAttrs(context.Background(), slog.LevelError, "Failed to load configuration", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
+
+	cfg.Debug = cmd.Bool("debug")
 
 	// Create relay instance
 	relayInstance, err := relay.New(cfg)
@@ -33,7 +50,7 @@ func main() {
 	}
 
 	// Create context for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	// Handle shutdown signals
@@ -50,5 +67,13 @@ func main() {
 	if err := relayInstance.Start(ctx); err != nil {
 		slog.LogAttrs(context.Background(), slog.LevelError, "Failed to start relay", slog.String("error", err.Error()))
 		os.Exit(1)
+	}
+
+	return nil
+}
+
+func main() {
+	if err := relayCommand.Run(context.Background(), os.Args); err != nil {
+		log.Fatal(err)
 	}
 }

--- a/cmd/aero-arc-relay/main.go
+++ b/cmd/aero-arc-relay/main.go
@@ -27,12 +27,12 @@ var relayCommand = cli.Command{
 		&cli.StringFlag{
 			Name:  "tls-cert-path",
 			Usage: "path to tls cert file",
-			Value: relay.DebugTLSCertPath,
+			Value: fmt.Sprintf("~/%s", relay.DebugTLSCertPath),
 		},
 		&cli.StringFlag{
 			Name:  "tls-key-path",
 			Usage: "path to tls key file",
-			Value: relay.DebugTLSKeyPath,
+			Value: fmt.Sprintf("~/%s", relay.DebugTLSKeyPath),
 		},
 		&cli.BoolFlag{
 			Name:  "debug",

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.13.0
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/common v0.55.0
+	github.com/urfave/cli/v3 v3.6.1
 	google.golang.org/api v0.250.0
 	google.golang.org/grpc v1.77.0
 	google.golang.org/protobuf v1.36.10

--- a/go.sum
+++ b/go.sum
@@ -263,6 +263,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07 h1:UyzmZLoiDWMRywV4DUYb9Fbt8uiOSooupjTq10vpvnU=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
+github.com/urfave/cli/v3 v3.6.1 h1:j8Qq8NyUawj/7rTYdBGrxcH7A/j7/G8Q5LhWEW4G3Mo=
+github.com/urfave/cli/v3 v3.6.1/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	MAVLink MAVLinkConfig `yaml:"mavlink"`
 	Sinks   SinksConfig   `yaml:"sinks"`
 	Logging LoggingConfig `yaml:"logging"`
+	Debug   bool
 }
 
 // RelayConfig contains relay-specific configuration
@@ -65,12 +66,10 @@ const (
 	MAVLinkModeMulti MAVLinkMode = "multi"
 )
 
-var (
-	MAVLinkModeNames = map[MAVLinkMode]string{
-		MAVLinkMode1To1:  "1:1",
-		MAVLinkModeMulti: "multi",
-	}
-)
+var MAVLinkModeNames = map[MAVLinkMode]string{
+	MAVLinkMode1To1:  "1:1",
+	MAVLinkModeMulti: "multi",
+}
 
 // SinksConfig contains configuration for all data sinks
 type SinksConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,11 +18,13 @@ import (
 
 // Config represents the application configuration
 type Config struct {
-	Relay   RelayConfig   `yaml:"relay"`
-	MAVLink MAVLinkConfig `yaml:"mavlink"`
-	Sinks   SinksConfig   `yaml:"sinks"`
-	Logging LoggingConfig `yaml:"logging"`
-	Debug   bool
+	Relay       RelayConfig   `yaml:"relay"`
+	MAVLink     MAVLinkConfig `yaml:"mavlink"`
+	Sinks       SinksConfig   `yaml:"sinks"`
+	Logging     LoggingConfig `yaml:"logging"`
+	Debug       bool
+	TLSCertPath string
+	TLSKeyPath  string
 }
 
 // RelayConfig contains relay-specific configuration

--- a/internal/relay/constants.go
+++ b/internal/relay/constants.go
@@ -1,0 +1,6 @@
+package relay
+
+const (
+	DebugTLSCertPath = ".aeroarc/local-certs/localhost.crt"
+	DebugTLSKeyPath  = ".aeroarc/local-certs/localhost.key"
+)

--- a/internal/relay/errors.go
+++ b/internal/relay/errors.go
@@ -3,5 +3,8 @@ package relay
 import "errors"
 
 var (
-	ErrSessionNotFound = errors.New("session not found")
+	ErrSessionNotFound        = errors.New("session not found")
+	ErrCreatingTLSCredentials = errors.New("error creating TLS credentials")
+	ErrCreatingTCPListener    = errors.New("error creating tcp listener")
+	ErrGettingHomeDir         = errors.New("error getting user home directory")
 )

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -117,14 +117,14 @@ func (r *Relay) Start(ctx context.Context) error {
 
 	var creds credentials.TransportCredentials
 
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		slog.LogAttrs(ctx, slog.LevelError, ErrGettingHomeDir.Error(), slog.String("error", err.Error()))
-		return ErrGettingHomeDir
-	}
-
 	creds, err = credentials.NewServerTLSFromFile(r.tlsCertPath, r.tlsKeyPath)
 	if r.config.Debug {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			slog.LogAttrs(ctx, slog.LevelError, ErrGettingHomeDir.Error(), slog.String("error", err.Error()))
+			return ErrGettingHomeDir
+		}
+
 		certPath := fmt.Sprintf("%s/%s", homeDir, DebugTLSCertPath)
 		keyPath := fmt.Sprintf("%s/%s", homeDir, DebugTLSKeyPath)
 		creds, err = credentials.NewServerTLSFromFile(certPath, keyPath)

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -38,8 +38,6 @@ type Relay struct {
 	grpcServer       *grpc.Server
 	grpcSessions     map[string]*DroneSession
 	sessionsMu       sync.RWMutex
-	tlsKeyPath       string
-	tlsCertPath      string
 	relayv1.UnimplementedRelayControlServer
 	agentv1.UnimplementedAgentGatewayServer
 }
@@ -118,7 +116,7 @@ func (r *Relay) Start(ctx context.Context) error {
 	var creds credentials.TransportCredentials
 	var homeDir string
 
-	creds, err = credentials.NewServerTLSFromFile(r.tlsCertPath, r.tlsKeyPath)
+	creds, err = credentials.NewServerTLSFromFile(r.config.TLSCertPath, r.config.TLSKeyPath)
 	if r.config.Debug {
 		homeDir, err = os.UserHomeDir()
 		if err != nil {
@@ -155,7 +153,7 @@ func (r *Relay) Start(ctx context.Context) error {
 	http.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"ok"}`))
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	}))
 	http.Handle("/readyz", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if !r.ready() {
@@ -164,7 +162,7 @@ func (r *Relay) Start(ctx context.Context) error {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"ok"}`))
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	}))
 
 	metricsServer := &http.Server{

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -116,10 +116,11 @@ func (r *Relay) Start(ctx context.Context) error {
 	}
 
 	var creds credentials.TransportCredentials
+	var homeDir string
 
 	creds, err = credentials.NewServerTLSFromFile(r.tlsCertPath, r.tlsKeyPath)
 	if r.config.Debug {
-		homeDir, err := os.UserHomeDir()
+		homeDir, err = os.UserHomeDir()
 		if err != nil {
 			slog.LogAttrs(ctx, slog.LevelError, ErrGettingHomeDir.Error(), slog.String("error", err.Error()))
 			return ErrGettingHomeDir

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -26,6 +26,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 // Relay manages MAVLink connections and data forwarding to sinks
@@ -37,6 +38,8 @@ type Relay struct {
 	grpcServer       *grpc.Server
 	grpcSessions     map[string]*DroneSession
 	sessionsMu       sync.RWMutex
+	tlsKeyPath       string
+	tlsCertPath      string
 	relayv1.UnimplementedRelayControlServer
 	agentv1.UnimplementedAgentGatewayServer
 }
@@ -108,10 +111,31 @@ func (r *Relay) Start(ctx context.Context) error {
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", r.config.Relay.GRPCPort))
 	if err != nil {
-		return fmt.Errorf("failed to listen on port %d: %w", r.config.Relay.GRPCPort, err)
+		slog.LogAttrs(ctx, slog.LevelError, "ErrCreatingTCPListener", slog.String("error", err.Error()))
+		return ErrCreatingTCPListener
 	}
 
-	r.grpcServer = grpc.NewServer()
+	var creds credentials.TransportCredentials
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		slog.LogAttrs(ctx, slog.LevelError, ErrGettingHomeDir.Error(), slog.String("error", err.Error()))
+		return ErrGettingHomeDir
+	}
+
+	creds, err = credentials.NewServerTLSFromFile(r.tlsCertPath, r.tlsKeyPath)
+	if r.config.Debug {
+		certPath := fmt.Sprintf("%s/%s", homeDir, DebugTLSCertPath)
+		keyPath := fmt.Sprintf("%s/%s", homeDir, DebugTLSKeyPath)
+		creds, err = credentials.NewServerTLSFromFile(certPath, keyPath)
+	}
+
+	if err != nil {
+		slog.LogAttrs(ctx, slog.LevelError, "ErrCreatingTLSCredentials", slog.String("error", err.Error()))
+		return ErrCreatingTLSCredentials
+	}
+
+	r.grpcServer = grpc.NewServer(grpc.Creds(creds))
 
 	// Register gRPC servers
 	relayv1.RegisterRelayControlServer(r.grpcServer, r)

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -54,10 +54,6 @@ func TestRelayCreation(t *testing.T) {
 		t.Errorf("Failed to create relay: %v", err)
 	}
 
-	if relay == nil {
-		t.Error("Relay should not be nil")
-	}
-
 	if len(relay.sinks) == 0 {
 		t.Error("Relay should have sinks configured")
 	}
@@ -392,7 +388,7 @@ func TestConcurrentMessageHandling(t *testing.T) {
 	numMessages := 100
 	done := make(chan bool, numMessages)
 
-	for i := 0; i < numMessages; i++ {
+	for i := range numMessages {
 		go func(id int) {
 			heartbeat := &common.MessageHeartbeat{
 				CustomMode: uint32(id % 10),
@@ -403,7 +399,7 @@ func TestConcurrentMessageHandling(t *testing.T) {
 	}
 
 	// Wait for all messages to be processed
-	for i := 0; i < numMessages; i++ {
+	for range 100 {
 		<-done
 	}
 


### PR DESCRIPTION
## Description
This PR enables TLS for the communication between the agent and relay services in debug mode.
## Why
Dev and Prod should have parity. With the inclusion of #40 we can generate locally signed certs so using them in debug mode makes total sense.
## Testing
- [x] Ran Agent -> Relay and verified data transmission