### PR TITLE
Refactor Relay Telemetry Delivery Around Configurable Output Routing

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -1,17 +1,10 @@
 registry:
   enabled: false
   address: "localhost:9090"
-  include_messages:
-    - "Heartbeat"
-    - "GlobalPositionInt"
 
 telemetry:
   enabled: false
   backend: "noop"
-  include_messages:
-    - "GlobalPositionInt"
-    - "VFR_HUD"
-    - "SystemStatus"
 
 sinks:
   file:

--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -20,6 +20,8 @@ sinks:
   #   credentials: "/home/makinje/aero-arc-relay/secrets/service-account.json"  # Path to GCP service account JSON file
   #   prefix: "telemetry"
   #   flush_interval: "30s"
+  #   include_messages:
+  #     - "*"
   # s3:
   #   bucket: "aero-arc-relay-telemetry"
   #   region: "us-east-1"
@@ -27,6 +29,8 @@ sinks:
   #   secret_key: "${AWS_SECRET_ACCESS_KEY}"
   #   prefix: "telemetry"
   #   flush_interval: "1m"
+  #   include_messages:
+  #     - "*"
   # kafka:
   #   brokers:
   #     - "localhost:9092"  # For local Kafka container

--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -1,9 +1,26 @@
+registry:
+  enabled: false
+  address: "localhost:9090"
+  include_messages:
+    - "Heartbeat"
+    - "GlobalPositionInt"
+
+telemetry:
+  enabled: false
+  backend: "noop"
+  include_messages:
+    - "GlobalPositionInt"
+    - "VFR_HUD"
+    - "SystemStatus"
+
 sinks:
   file:
     path: "/tmp/log/aero-arc-relay"
     prefix: "telemetry"
     format: "json"
     rotation_interval: "24h"
+    include_messages:
+      - "*"
   # gcs:
   #   bucket: "aero-arc-telemetry-data-dev"
   #   project_id: "aero-arc-relay"
@@ -21,6 +38,8 @@ sinks:
   #   brokers:
   #     - "localhost:9092"  # For local Kafka container
   #   topic: "quickstart-events"  # Choose your topic name
+  #   include_messages:
+  #     - "GlobalPositionInt"
 
 logging:
   level: "info"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,7 +37,8 @@ type SinksConfig struct {
 }
 
 // MessageFilterConfig controls which MAVLink message names an output receives.
-// Empty includes mean all messages, while excludes are always removed.
+// Empty or omitted includes match nothing; use "*" to include all messages.
+// Excludes take precedence over includes.
 type MessageFilterConfig struct {
 	IncludeMessages []string `yaml:"include_messages,omitempty"`
 	ExcludeMessages []string `yaml:"exclude_messages,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,8 +12,10 @@ import (
 
 // Config represents the application configuration
 type Config struct {
-	Sinks       SinksConfig   `yaml:"sinks"`
-	Logging     LoggingConfig `yaml:"logging"`
+	Sinks       SinksConfig     `yaml:"sinks"`
+	Registry    RegistryConfig  `yaml:"registry"`
+	Telemetry   TelemetryConfig `yaml:"telemetry"`
+	Logging     LoggingConfig   `yaml:"logging"`
 	Debug       bool
 	TLSCertPath string
 	TLSKeyPath  string
@@ -34,110 +36,140 @@ type SinksConfig struct {
 	File          *FileConfig          `yaml:"file,omitempty"`
 }
 
+// MessageFilterConfig controls which MAVLink message names an output receives.
+// Empty includes mean all messages, while excludes are always removed.
+type MessageFilterConfig struct {
+	IncludeMessages []string `yaml:"include_messages,omitempty"`
+	ExcludeMessages []string `yaml:"exclude_messages,omitempty"`
+}
+
+// RegistryConfig contains control-plane registry reporting configuration.
+type RegistryConfig struct {
+	Enabled             bool   `yaml:"enabled"`
+	Address             string `yaml:"address"`
+	MessageFilterConfig `yaml:",inline"`
+}
+
+// TelemetryConfig contains normalized hot telemetry writer configuration.
+type TelemetryConfig struct {
+	Enabled             bool   `yaml:"enabled"`
+	Backend             string `yaml:"backend"`
+	MessageFilterConfig `yaml:",inline"`
+}
+
 // S3Config contains S3 sink configuration
 type S3Config struct {
-	Bucket             string        `yaml:"bucket"`
-	Region             string        `yaml:"region"`
-	AccessKey          string        `yaml:"access_key"`
-	SecretKey          string        `yaml:"secret_key"`
-	Prefix             string        `yaml:"prefix"`
-	FlushInterval      time.Duration `yaml:"flush_interval"`
-	QueueSize          int           `yaml:"queue_size"`
-	BackpressurePolicy string        `yaml:"backpressure_policy"`
+	Bucket              string        `yaml:"bucket"`
+	Region              string        `yaml:"region"`
+	AccessKey           string        `yaml:"access_key"`
+	SecretKey           string        `yaml:"secret_key"`
+	Prefix              string        `yaml:"prefix"`
+	FlushInterval       time.Duration `yaml:"flush_interval"`
+	QueueSize           int           `yaml:"queue_size"`
+	BackpressurePolicy  string        `yaml:"backpressure_policy"`
+	MessageFilterConfig `yaml:",inline"`
 }
 
 // GCSConfig contains Google Cloud Storage sink configuration
 type GCSConfig struct {
-	Bucket             string        `yaml:"bucket"`
-	ProjectID          string        `yaml:"project_id"`
-	Credentials        string        `yaml:"credentials"` // Path to service account JSON file
-	Prefix             string        `yaml:"prefix"`
-	FlushInterval      time.Duration `yaml:"flush_interval"` // How often to flush buffered data (e.g., "30s")
-	QueueSize          int           `yaml:"queue_size"`
-	BackpressurePolicy string        `yaml:"backpressure_policy"`
+	Bucket              string        `yaml:"bucket"`
+	ProjectID           string        `yaml:"project_id"`
+	Credentials         string        `yaml:"credentials"` // Path to service account JSON file
+	Prefix              string        `yaml:"prefix"`
+	FlushInterval       time.Duration `yaml:"flush_interval"` // How often to flush buffered data (e.g., "30s")
+	QueueSize           int           `yaml:"queue_size"`
+	BackpressurePolicy  string        `yaml:"backpressure_policy"`
+	MessageFilterConfig `yaml:",inline"`
 }
 
 // BigQueryConfig contains BigQuery sink configuration
 type BigQueryConfig struct {
-	ProjectID          string `yaml:"project_id"`
-	Dataset            string `yaml:"dataset"`
-	Table              string `yaml:"table"`
-	Credentials        string `yaml:"credentials"`    // Path to service account JSON file
-	BatchSize          int    `yaml:"batch_size"`     // Number of messages to batch before insert
-	FlushInterval      string `yaml:"flush_interval"` // How often to flush (e.g., "30s", "1m")
-	QueueSize          int    `yaml:"queue_size"`
-	BackpressurePolicy string `yaml:"backpressure_policy"`
+	ProjectID           string `yaml:"project_id"`
+	Dataset             string `yaml:"dataset"`
+	Table               string `yaml:"table"`
+	Credentials         string `yaml:"credentials"`    // Path to service account JSON file
+	BatchSize           int    `yaml:"batch_size"`     // Number of messages to batch before insert
+	FlushInterval       string `yaml:"flush_interval"` // How often to flush (e.g., "30s", "1m")
+	QueueSize           int    `yaml:"queue_size"`
+	BackpressurePolicy  string `yaml:"backpressure_policy"`
+	MessageFilterConfig `yaml:",inline"`
 }
 
 // TimestreamConfig contains AWS Timestream sink configuration
 type TimestreamConfig struct {
-	Database           string `yaml:"database"`
-	Table              string `yaml:"table"`
-	Region             string `yaml:"region"`
-	AccessKey          string `yaml:"access_key"`
-	SecretKey          string `yaml:"secret_key"`
-	SessionToken       string `yaml:"session_token,omitempty"` // For temporary credentials
-	BatchSize          int    `yaml:"batch_size"`              // Number of records to batch
-	FlushInterval      string `yaml:"flush_interval"`          // How often to flush (e.g., "30s", "1m")
-	QueueSize          int    `yaml:"queue_size"`
-	BackpressurePolicy string `yaml:"backpressure_policy"`
+	Database            string `yaml:"database"`
+	Table               string `yaml:"table"`
+	Region              string `yaml:"region"`
+	AccessKey           string `yaml:"access_key"`
+	SecretKey           string `yaml:"secret_key"`
+	SessionToken        string `yaml:"session_token,omitempty"` // For temporary credentials
+	BatchSize           int    `yaml:"batch_size"`              // Number of records to batch
+	FlushInterval       string `yaml:"flush_interval"`          // How often to flush (e.g., "30s", "1m")
+	QueueSize           int    `yaml:"queue_size"`
+	BackpressurePolicy  string `yaml:"backpressure_policy"`
+	MessageFilterConfig `yaml:",inline"`
 }
 
 // InfluxDBConfig contains InfluxDB sink configuration
 type InfluxDBConfig struct {
-	URL                string `yaml:"url"`
-	Database           string `yaml:"database"`
-	Username           string `yaml:"username"`
-	Password           string `yaml:"password"`
-	Token              string `yaml:"token"`        // For InfluxDB 2.x
-	Organization       string `yaml:"organization"` // For InfluxDB 2.x
-	Bucket             string `yaml:"bucket"`       // For InfluxDB 2.x
-	BatchSize          int    `yaml:"batch_size"`
-	FlushInterval      string `yaml:"flush_interval"`
-	QueueSize          int    `yaml:"queue_size"`
-	BackpressurePolicy string `yaml:"backpressure_policy"`
+	URL                 string `yaml:"url"`
+	Database            string `yaml:"database"`
+	Username            string `yaml:"username"`
+	Password            string `yaml:"password"`
+	Token               string `yaml:"token"`        // For InfluxDB 2.x
+	Organization        string `yaml:"organization"` // For InfluxDB 2.x
+	Bucket              string `yaml:"bucket"`       // For InfluxDB 2.x
+	BatchSize           int    `yaml:"batch_size"`
+	FlushInterval       string `yaml:"flush_interval"`
+	QueueSize           int    `yaml:"queue_size"`
+	BackpressurePolicy  string `yaml:"backpressure_policy"`
+	MessageFilterConfig `yaml:",inline"`
 }
 
 // PrometheusConfig contains Prometheus sink configuration
 type PrometheusConfig struct {
-	URL                string `yaml:"url"`
-	Job                string `yaml:"job"`
-	Instance           string `yaml:"instance"`
-	BatchSize          int    `yaml:"batch_size"`
-	FlushInterval      string `yaml:"flush_interval"`
-	QueueSize          int    `yaml:"queue_size"`
-	BackpressurePolicy string `yaml:"backpressure_policy"`
+	URL                 string `yaml:"url"`
+	Job                 string `yaml:"job"`
+	Instance            string `yaml:"instance"`
+	BatchSize           int    `yaml:"batch_size"`
+	FlushInterval       string `yaml:"flush_interval"`
+	QueueSize           int    `yaml:"queue_size"`
+	BackpressurePolicy  string `yaml:"backpressure_policy"`
+	MessageFilterConfig `yaml:",inline"`
 }
 
 // ElasticsearchConfig contains Elasticsearch sink configuration
 type ElasticsearchConfig struct {
-	URLs               []string `yaml:"urls"`
-	Index              string   `yaml:"index"`
-	Username           string   `yaml:"username"`
-	Password           string   `yaml:"password"`
-	APIKey             string   `yaml:"api_key"`
-	BatchSize          int      `yaml:"batch_size"`
-	FlushInterval      string   `yaml:"flush_interval"`
-	QueueSize          int      `yaml:"queue_size"`
-	BackpressurePolicy string   `yaml:"backpressure_policy"`
+	URLs                []string `yaml:"urls"`
+	Index               string   `yaml:"index"`
+	Username            string   `yaml:"username"`
+	Password            string   `yaml:"password"`
+	APIKey              string   `yaml:"api_key"`
+	BatchSize           int      `yaml:"batch_size"`
+	FlushInterval       string   `yaml:"flush_interval"`
+	QueueSize           int      `yaml:"queue_size"`
+	BackpressurePolicy  string   `yaml:"backpressure_policy"`
+	MessageFilterConfig `yaml:",inline"`
 }
 
 // KafkaConfig contains Kafka sink configuration
 type KafkaConfig struct {
-	Brokers            []string `yaml:"brokers"`
-	Topic              string   `yaml:"topic"`
-	QueueSize          int      `yaml:"queue_size"`
-	BackpressurePolicy string   `yaml:"backpressure_policy"`
+	Brokers             []string `yaml:"brokers"`
+	Topic               string   `yaml:"topic"`
+	QueueSize           int      `yaml:"queue_size"`
+	BackpressurePolicy  string   `yaml:"backpressure_policy"`
+	MessageFilterConfig `yaml:",inline"`
 }
 
 // FileConfig contains file-based sink configuration
 type FileConfig struct {
-	Path               string        `yaml:"path"`              // Path to the file, without the filename
-	Prefix             string        `yaml:"prefix"`            // Prefix for the filename, will be appended to the path
-	Format             string        `yaml:"format"`            // json, csv, binary
-	RotationInterval   time.Duration `yaml:"rotation_interval"` // 24h, 1h, 10m, etc.
-	QueueSize          int           `yaml:"queue_size"`
-	BackpressurePolicy string        `yaml:"backpressure_policy"`
+	Path                string        `yaml:"path"`              // Path to the file, without the filename
+	Prefix              string        `yaml:"prefix"`            // Prefix for the filename, will be appended to the path
+	Format              string        `yaml:"format"`            // json, csv, binary
+	RotationInterval    time.Duration `yaml:"rotation_interval"` // 24h, 1h, 10m, etc.
+	QueueSize           int           `yaml:"queue_size"`
+	BackpressurePolicy  string        `yaml:"backpressure_policy"`
+	MessageFilterConfig `yaml:",inline"`
 }
 
 // LoggingConfig contains logging configuration

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,16 +46,14 @@ type MessageFilterConfig struct {
 
 // RegistryConfig contains control-plane registry reporting configuration.
 type RegistryConfig struct {
-	Enabled             bool   `yaml:"enabled"`
-	Address             string `yaml:"address"`
-	MessageFilterConfig `yaml:",inline"`
+	Enabled bool   `yaml:"enabled"`
+	Address string `yaml:"address"`
 }
 
 // TelemetryConfig contains normalized hot telemetry writer configuration.
 type TelemetryConfig struct {
-	Enabled             bool   `yaml:"enabled"`
-	Backend             string `yaml:"backend"`
-	MessageFilterConfig `yaml:",inline"`
+	Enabled bool   `yaml:"enabled"`
+	Backend string `yaml:"backend"`
 }
 
 // S3Config contains S3 sink configuration

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,17 +12,10 @@ func TestConfigLoad(t *testing.T) {
 registry:
   enabled: true
   address: "localhost:9090"
-  include_messages:
-    - "Heartbeat"
-    - "GlobalPositionInt"
 
 telemetry:
   enabled: true
   backend: "noop"
-  include_messages:
-    - "GlobalPositionInt"
-    - "VFR_HUD"
-    - "SystemStatus"
 
 sinks:
   s3:
@@ -75,20 +68,12 @@ logging:
 	if cfg.Registry.Address != "localhost:9090" {
 		t.Errorf("Expected registry address 'localhost:9090', got '%s'", cfg.Registry.Address)
 	}
-	if len(cfg.Registry.IncludeMessages) != 2 {
-		t.Errorf("Expected 2 registry include messages, got %d", len(cfg.Registry.IncludeMessages))
-	}
-
 	if !cfg.Telemetry.Enabled {
 		t.Error("Telemetry should be enabled")
 	}
 	if cfg.Telemetry.Backend != "noop" {
 		t.Errorf("Expected telemetry backend 'noop', got '%s'", cfg.Telemetry.Backend)
 	}
-	if len(cfg.Telemetry.IncludeMessages) != 3 {
-		t.Errorf("Expected 3 telemetry include messages, got %d", len(cfg.Telemetry.IncludeMessages))
-	}
-
 	if cfg.Sinks.S3 == nil {
 		t.Error("S3 sink should be configured")
 	} else {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,6 +9,21 @@ import (
 // TestConfigLoad tests loading configuration from YAML.
 func TestConfigLoad(t *testing.T) {
 	configContent := `
+registry:
+  enabled: true
+  address: "localhost:9090"
+  include_messages:
+    - "Heartbeat"
+    - "GlobalPositionInt"
+
+telemetry:
+  enabled: true
+  backend: "noop"
+  include_messages:
+    - "GlobalPositionInt"
+    - "VFR_HUD"
+    - "SystemStatus"
+
 sinks:
   s3:
     bucket: "test-bucket"
@@ -21,11 +36,15 @@ sinks:
       - "localhost:9092"
       - "localhost:9093"
     topic: "telemetry-data"
+    include_messages:
+      - "GlobalPositionInt"
   file:
     path: "/var/log/telemetry"
     prefix: "telemetry"
     format: "json"
     rotation_interval: "24h"
+    include_messages:
+      - "*"
 
 logging:
   level: "debug"
@@ -48,6 +67,26 @@ logging:
 	cfg, err := Load(tmpFile.Name())
 	if err != nil {
 		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	if !cfg.Registry.Enabled {
+		t.Error("Registry should be enabled")
+	}
+	if cfg.Registry.Address != "localhost:9090" {
+		t.Errorf("Expected registry address 'localhost:9090', got '%s'", cfg.Registry.Address)
+	}
+	if len(cfg.Registry.IncludeMessages) != 2 {
+		t.Errorf("Expected 2 registry include messages, got %d", len(cfg.Registry.IncludeMessages))
+	}
+
+	if !cfg.Telemetry.Enabled {
+		t.Error("Telemetry should be enabled")
+	}
+	if cfg.Telemetry.Backend != "noop" {
+		t.Errorf("Expected telemetry backend 'noop', got '%s'", cfg.Telemetry.Backend)
+	}
+	if len(cfg.Telemetry.IncludeMessages) != 3 {
+		t.Errorf("Expected 3 telemetry include messages, got %d", len(cfg.Telemetry.IncludeMessages))
 	}
 
 	if cfg.Sinks.S3 == nil {
@@ -73,6 +112,9 @@ logging:
 		if cfg.Sinks.Kafka.Topic != "telemetry-data" {
 			t.Errorf("Expected Kafka topic 'telemetry-data', got '%s'", cfg.Sinks.Kafka.Topic)
 		}
+		if len(cfg.Sinks.Kafka.IncludeMessages) != 1 || cfg.Sinks.Kafka.IncludeMessages[0] != "GlobalPositionInt" {
+			t.Errorf("Expected Kafka include_messages [GlobalPositionInt], got %#v", cfg.Sinks.Kafka.IncludeMessages)
+		}
 	}
 
 	if cfg.Sinks.File == nil {
@@ -86,6 +128,9 @@ logging:
 		}
 		if cfg.Sinks.File.RotationInterval != 24*time.Hour {
 			t.Errorf("Expected file rotation '24h', got '%s'", cfg.Sinks.File.RotationInterval)
+		}
+		if len(cfg.Sinks.File.IncludeMessages) != 1 || cfg.Sinks.File.IncludeMessages[0] != "*" {
+			t.Errorf("Expected file include_messages [*], got %#v", cfg.Sinks.File.IncludeMessages)
 		}
 	}
 

--- a/internal/outputs/consumer.go
+++ b/internal/outputs/consumer.go
@@ -1,0 +1,17 @@
+package outputs
+
+import (
+	"context"
+
+	"github.com/makinje/aero-arc-relay/pkg/telemetry"
+)
+
+// EnvelopeConsumer receives telemetry envelopes from the relay router.
+//
+// Internal Aero Arc paths such as registry reporting and telemetry writing can
+// implement this interface alongside generic export sinks.
+type EnvelopeConsumer interface {
+	Name() string
+	WriteEnvelope(ctx context.Context, envelope telemetry.TelemetryEnvelope) error
+	Close(ctx context.Context) error
+}

--- a/internal/outputs/filters.go
+++ b/internal/outputs/filters.go
@@ -5,22 +5,19 @@ import "strings"
 const wildcardMessage = "*"
 
 // MessageFilter controls which normalized MAVLink message names reach a
-// consumer. Empty include lists mean "include everything".
+// consumer. Empty include lists match nothing; use "*" to include everything.
 type MessageFilter struct {
 	Include []string
 	Exclude []string
 }
 
 func (f MessageFilter) Allows(messageName string) bool {
-	normalized := NormalizeMessageName(messageName)
-	if normalized == "" {
+	if len(f.Include) == 0 {
 		return false
 	}
+	normalized := NormalizeMessageName(messageName)
 	if containsMessage(f.Exclude, normalized) {
 		return false
-	}
-	if len(f.Include) == 0 {
-		return true
 	}
 	return containsMessage(f.Include, normalized)
 }
@@ -28,6 +25,9 @@ func (f MessageFilter) Allows(messageName string) bool {
 func containsMessage(messages []string, messageName string) bool {
 	for _, item := range messages {
 		normalized := NormalizeMessageName(item)
+		if normalized == "" {
+			continue
+		}
 		if normalized == wildcardMessage || normalized == messageName {
 			return true
 		}

--- a/internal/outputs/filters.go
+++ b/internal/outputs/filters.go
@@ -11,8 +11,17 @@ type MessageFilter struct {
 	Exclude []string
 }
 
+func (f MessageFilter) hasIncludes() bool {
+	for _, message := range f.Include {
+		if NormalizeMessageName(message) != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func (f MessageFilter) Allows(messageName string) bool {
-	if len(f.Include) == 0 {
+	if !f.hasIncludes() {
 		return false
 	}
 	normalized := NormalizeMessageName(messageName)

--- a/internal/outputs/filters.go
+++ b/internal/outputs/filters.go
@@ -1,0 +1,56 @@
+package outputs
+
+import "strings"
+
+const wildcardMessage = "*"
+
+// MessageFilter controls which normalized MAVLink message names reach a
+// consumer. Empty include lists mean "include everything".
+type MessageFilter struct {
+	Include []string
+	Exclude []string
+}
+
+func (f MessageFilter) Allows(messageName string) bool {
+	normalized := NormalizeMessageName(messageName)
+	if normalized == "" {
+		return false
+	}
+	if containsMessage(f.Exclude, normalized) {
+		return false
+	}
+	if len(f.Include) == 0 {
+		return true
+	}
+	return containsMessage(f.Include, normalized)
+}
+
+func containsMessage(messages []string, messageName string) bool {
+	for _, item := range messages {
+		normalized := NormalizeMessageName(item)
+		if normalized == wildcardMessage || normalized == messageName {
+			return true
+		}
+	}
+	return false
+}
+
+// NormalizeMessageName collapses Go type strings, pointer prefixes, and package
+// paths to the stable MAVLink message name used by filters.
+func NormalizeMessageName(messageName string) string {
+	name := strings.TrimSpace(messageName)
+	if name == "" {
+		return ""
+	}
+	if name == wildcardMessage {
+		return wildcardMessage
+	}
+	for strings.HasPrefix(name, "*") {
+		name = strings.TrimPrefix(name, "*")
+	}
+	if idx := strings.LastIndex(name, "."); idx >= 0 {
+		name = name[idx+1:]
+	}
+	name = strings.TrimPrefix(name, "Message")
+	return name
+}

--- a/internal/outputs/filters_test.go
+++ b/internal/outputs/filters_test.go
@@ -1,0 +1,50 @@
+package outputs
+
+import "testing"
+
+func TestNormalizeMessageName(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "GlobalPositionInt", want: "GlobalPositionInt"},
+		{name: "*common.MessageGlobalPositionInt", want: "GlobalPositionInt"},
+		{name: "github.com/bluenviron/gomavlib/v2/pkg/dialects/common.MessageSysStatus", want: "SysStatus"},
+		{name: "VFR_HUD", want: "VFR_HUD"},
+		{name: "*", want: "*"},
+	}
+
+	for _, test := range tests {
+		if got := NormalizeMessageName(test.name); got != test.want {
+			t.Errorf("NormalizeMessageName(%q) = %q, want %q", test.name, got, test.want)
+		}
+	}
+}
+
+func TestMessageFilterAllows(t *testing.T) {
+	filter := MessageFilter{
+		Include: []string{"GlobalPositionInt", "VFR_HUD"},
+		Exclude: []string{"VFR_HUD"},
+	}
+
+	if !filter.Allows("*common.MessageGlobalPositionInt") {
+		t.Fatal("expected GlobalPositionInt to be allowed")
+	}
+	if filter.Allows("VFR_HUD") {
+		t.Fatal("expected excluded VFR_HUD to be blocked")
+	}
+	if filter.Allows("Heartbeat") {
+		t.Fatal("expected non-included Heartbeat to be blocked")
+	}
+}
+
+func TestMessageFilterWildcard(t *testing.T) {
+	filter := MessageFilter{Include: []string{"*"}}
+
+	if !filter.Allows("Heartbeat") {
+		t.Fatal("expected wildcard to allow Heartbeat")
+	}
+	if !filter.Allows("*common.MessageGlobalPositionInt") {
+		t.Fatal("expected wildcard to allow normalized Go type names")
+	}
+}

--- a/internal/outputs/filters_test.go
+++ b/internal/outputs/filters_test.go
@@ -47,4 +47,18 @@ func TestMessageFilterWildcard(t *testing.T) {
 	if !filter.Allows("*common.MessageGlobalPositionInt") {
 		t.Fatal("expected wildcard to allow normalized Go type names")
 	}
+	if !filter.Allows("") {
+		t.Fatal("expected wildcard to allow any message name")
+	}
+}
+
+func TestMessageFilterEmptyIncludeMatchesNothing(t *testing.T) {
+	filter := MessageFilter{}
+
+	if filter.Allows("Heartbeat") {
+		t.Fatal("expected an empty include list to reject named messages")
+	}
+	if filter.Allows("") {
+		t.Fatal("expected an empty include list to reject unnamed messages")
+	}
 }

--- a/internal/outputs/filters_test.go
+++ b/internal/outputs/filters_test.go
@@ -62,3 +62,11 @@ func TestMessageFilterEmptyIncludeMatchesNothing(t *testing.T) {
 		t.Fatal("expected an empty include list to reject unnamed messages")
 	}
 }
+
+func TestMessageFilterBlankIncludesMatchNothing(t *testing.T) {
+	filter := MessageFilter{Include: []string{"", "  "}}
+
+	if filter.Allows("Heartbeat") {
+		t.Fatal("expected blank include entries to reject messages")
+	}
+}

--- a/internal/outputs/router.go
+++ b/internal/outputs/router.go
@@ -1,0 +1,71 @@
+package outputs
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/makinje/aero-arc-relay/pkg/telemetry"
+)
+
+type route struct {
+	consumer EnvelopeConsumer
+	filter   MessageFilter
+}
+
+// Router fans telemetry envelopes out to internal Aero Arc paths and generic
+// sinks according to each consumer's message filter.
+type Router struct {
+	routes []route
+}
+
+func NewRouter() *Router {
+	return &Router{routes: make([]route, 0)}
+}
+
+func (r *Router) AddConsumer(consumer EnvelopeConsumer, filter MessageFilter) {
+	if consumer == nil {
+		return
+	}
+	r.routes = append(r.routes, route{consumer: consumer, filter: filter})
+}
+
+func (r *Router) Route(ctx context.Context, envelope telemetry.TelemetryEnvelope) error {
+	if r == nil {
+		return nil
+	}
+
+	var routeErr error
+	for _, route := range r.routes {
+		if !route.filter.Allows(envelope.MsgName) {
+			continue
+		}
+		if err := route.consumer.WriteEnvelope(ctx, envelope); err != nil {
+			slog.Warn("telemetry consumer write failed",
+				slog.String("consumer", route.consumer.Name()),
+				slog.String("message_name", envelope.MsgName),
+				slog.String("error", err.Error()),
+			)
+			routeErr = fmt.Errorf("%s: %w", route.consumer.Name(), err)
+		}
+	}
+	return routeErr
+}
+
+func (r *Router) Close(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+
+	var closeErr error
+	for _, route := range r.routes {
+		if err := route.consumer.Close(ctx); err != nil {
+			slog.Warn("telemetry consumer close failed",
+				slog.String("consumer", route.consumer.Name()),
+				slog.String("error", err.Error()),
+			)
+			closeErr = fmt.Errorf("%s: %w", route.consumer.Name(), err)
+		}
+	}
+	return closeErr
+}

--- a/internal/outputs/router.go
+++ b/internal/outputs/router.go
@@ -33,6 +33,10 @@ func (r *Router) AddConsumer(consumer EnvelopeConsumer, filter MessageFilter) {
 	r.routes = append(r.routes, route{consumer: consumer, filter: filter})
 }
 
+func (r *Router) HasConsumers() bool {
+	return r != nil && len(r.routes) > 0
+}
+
 func (r *Router) Route(ctx context.Context, envelope telemetry.TelemetryEnvelope, onError RouteErrorHandler) {
 	//TODO: Figure out what happens or how to get around blocked consumer
 	var wg sync.WaitGroup

--- a/internal/outputs/router.go
+++ b/internal/outputs/router.go
@@ -30,6 +30,12 @@ func (r *Router) AddConsumer(consumer EnvelopeConsumer, filter MessageFilter) {
 	if consumer == nil {
 		return
 	}
+	if !filter.hasIncludes() {
+		slog.Warn("output registered without included messages; it will receive no telemetry",
+			slog.String("consumer", consumer.Name()),
+			slog.String("configuration_hint", "set include_messages to [\"*\"] to receive all messages"),
+		)
+	}
 	r.routes = append(r.routes, route{consumer: consumer, filter: filter})
 }
 

--- a/internal/outputs/router.go
+++ b/internal/outputs/router.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 
 	"github.com/makinje/aero-arc-relay/pkg/telemetry"
 )
+
+type RouteErrorHandler func(consumer string, err error)
 
 type route struct {
 	consumer EnvelopeConsumer
@@ -30,26 +33,37 @@ func (r *Router) AddConsumer(consumer EnvelopeConsumer, filter MessageFilter) {
 	r.routes = append(r.routes, route{consumer: consumer, filter: filter})
 }
 
-func (r *Router) Route(ctx context.Context, envelope telemetry.TelemetryEnvelope) error {
+func (r *Router) Route(ctx context.Context, envelope telemetry.TelemetryEnvelope, onError RouteErrorHandler) {
+	//TODO: Figure out what happens or how to get around blocked consumer
+	var wg sync.WaitGroup
+
 	if r == nil {
-		return nil
+		return
 	}
 
-	var routeErr error
 	for _, route := range r.routes {
 		if !route.filter.Allows(envelope.MsgName) {
 			continue
 		}
-		if err := route.consumer.WriteEnvelope(ctx, envelope); err != nil {
-			slog.Warn("telemetry consumer write failed",
-				slog.String("consumer", route.consumer.Name()),
-				slog.String("message_name", envelope.MsgName),
-				slog.String("error", err.Error()),
-			)
-			routeErr = fmt.Errorf("%s: %w", route.consumer.Name(), err)
-		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := route.consumer.WriteEnvelope(ctx, envelope); err != nil {
+				consumer := route.consumer.Name()
+				slog.Warn("telemetry consumer write failed",
+					slog.String("consumer", route.consumer.Name()),
+					slog.String("message_name", envelope.MsgName),
+					slog.Any("error", err),
+				)
+
+				if onError != nil {
+					onError(consumer, err)
+				}
+			}
+		}()
 	}
-	return routeErr
+
+	wg.Wait()
 }
 
 func (r *Router) Close(ctx context.Context) error {

--- a/internal/outputs/router_test.go
+++ b/internal/outputs/router_test.go
@@ -2,6 +2,7 @@ package outputs
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/makinje/aero-arc-relay/pkg/telemetry"
@@ -10,6 +11,7 @@ import (
 type recordingConsumer struct {
 	name     string
 	messages []telemetry.TelemetryEnvelope
+	err      error
 }
 
 func (r *recordingConsumer) Name() string {
@@ -18,7 +20,7 @@ func (r *recordingConsumer) Name() string {
 
 func (r *recordingConsumer) WriteEnvelope(_ context.Context, envelope telemetry.TelemetryEnvelope) error {
 	r.messages = append(r.messages, envelope)
-	return nil
+	return r.err
 }
 
 func (r *recordingConsumer) Close(context.Context) error {
@@ -33,17 +35,33 @@ func TestRouterRoutesByMessageFilter(t *testing.T) {
 	router.AddConsumer(global, MessageFilter{Include: []string{"GlobalPositionInt"}})
 	router.AddConsumer(all, MessageFilter{Include: []string{"*"}})
 
-	if err := router.Route(context.Background(), telemetry.TelemetryEnvelope{MsgName: "*common.MessageGlobalPositionInt"}); err != nil {
-		t.Fatalf("route global position: %v", err)
-	}
-	if err := router.Route(context.Background(), telemetry.TelemetryEnvelope{MsgName: "Heartbeat"}); err != nil {
-		t.Fatalf("route heartbeat: %v", err)
-	}
+	router.Route(context.Background(), telemetry.TelemetryEnvelope{MsgName: "*common.MessageGlobalPositionInt"}, nil)
+	router.Route(context.Background(), telemetry.TelemetryEnvelope{MsgName: "Heartbeat"}, nil)
 
 	if got := len(global.messages); got != 1 {
 		t.Fatalf("global consumer got %d messages, want 1", got)
 	}
 	if got := len(all.messages); got != 2 {
 		t.Fatalf("all consumer got %d messages, want 2", got)
+	}
+}
+
+func TestRouterReportsConsumerWriteError(t *testing.T) {
+	router := NewRouter()
+	wantErr := errors.New("write failed")
+	router.AddConsumer(&recordingConsumer{name: "failing", err: wantErr}, MessageFilter{Include: []string{"*"}})
+
+	var gotConsumer string
+	var gotErr error
+	router.Route(context.Background(), telemetry.TelemetryEnvelope{MsgName: "Heartbeat"}, func(consumer string, err error) {
+		gotConsumer = consumer
+		gotErr = err
+	})
+
+	if gotConsumer != "failing" {
+		t.Fatalf("error consumer = %q, want %q", gotConsumer, "failing")
+	}
+	if !errors.Is(gotErr, wantErr) {
+		t.Fatalf("error = %v, want %v", gotErr, wantErr)
 	}
 }

--- a/internal/outputs/router_test.go
+++ b/internal/outputs/router_test.go
@@ -1,0 +1,49 @@
+package outputs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/makinje/aero-arc-relay/pkg/telemetry"
+)
+
+type recordingConsumer struct {
+	name     string
+	messages []telemetry.TelemetryEnvelope
+}
+
+func (r *recordingConsumer) Name() string {
+	return r.name
+}
+
+func (r *recordingConsumer) WriteEnvelope(_ context.Context, envelope telemetry.TelemetryEnvelope) error {
+	r.messages = append(r.messages, envelope)
+	return nil
+}
+
+func (r *recordingConsumer) Close(context.Context) error {
+	return nil
+}
+
+func TestRouterRoutesByMessageFilter(t *testing.T) {
+	router := NewRouter()
+	global := &recordingConsumer{name: "global"}
+	all := &recordingConsumer{name: "all"}
+
+	router.AddConsumer(global, MessageFilter{Include: []string{"GlobalPositionInt"}})
+	router.AddConsumer(all, MessageFilter{Include: []string{"*"}})
+
+	if err := router.Route(context.Background(), telemetry.TelemetryEnvelope{MsgName: "*common.MessageGlobalPositionInt"}); err != nil {
+		t.Fatalf("route global position: %v", err)
+	}
+	if err := router.Route(context.Background(), telemetry.TelemetryEnvelope{MsgName: "Heartbeat"}); err != nil {
+		t.Fatalf("route heartbeat: %v", err)
+	}
+
+	if got := len(global.messages); got != 1 {
+		t.Fatalf("global consumer got %d messages, want 1", got)
+	}
+	if got := len(all.messages); got != 2 {
+		t.Fatalf("all consumer got %d messages, want 2", got)
+	}
+}

--- a/internal/outputs/router_test.go
+++ b/internal/outputs/router_test.go
@@ -46,6 +46,22 @@ func TestRouterRoutesByMessageFilter(t *testing.T) {
 	}
 }
 
+func TestRouterHasConsumers(t *testing.T) {
+	var nilRouter *Router
+	if nilRouter.HasConsumers() {
+		t.Fatal("nil router reports consumers")
+	}
+
+	router := NewRouter()
+	if router.HasConsumers() {
+		t.Fatal("empty router reports consumers")
+	}
+	router.AddConsumer(&recordingConsumer{name: "consumer"}, MessageFilter{})
+	if !router.HasConsumers() {
+		t.Fatal("router with a consumer reports no consumers")
+	}
+}
+
 func TestRouterReportsConsumerWriteError(t *testing.T) {
 	router := NewRouter()
 	wantErr := errors.New("write failed")

--- a/internal/outputs/sink_adapter.go
+++ b/internal/outputs/sink_adapter.go
@@ -1,0 +1,29 @@
+package outputs
+
+import (
+	"context"
+
+	"github.com/makinje/aero-arc-relay/internal/sinks"
+	"github.com/makinje/aero-arc-relay/pkg/telemetry"
+)
+
+type SinkConsumer struct {
+	name string
+	sink sinks.Sink
+}
+
+func NewSinkConsumer(name string, sink sinks.Sink) *SinkConsumer {
+	return &SinkConsumer{name: name, sink: sink}
+}
+
+func (s *SinkConsumer) Name() string {
+	return s.name
+}
+
+func (s *SinkConsumer) WriteEnvelope(_ context.Context, envelope telemetry.TelemetryEnvelope) error {
+	return s.sink.WriteMessage(envelope)
+}
+
+func (s *SinkConsumer) Close(ctx context.Context) error {
+	return s.sink.Close(ctx)
+}

--- a/internal/registryreporter/noop.go
+++ b/internal/registryreporter/noop.go
@@ -1,0 +1,25 @@
+package registryreporter
+
+import (
+	"context"
+
+	"github.com/makinje/aero-arc-relay/pkg/telemetry"
+)
+
+type NoopReporter struct{}
+
+func NewNoopReporter() *NoopReporter {
+	return &NoopReporter{}
+}
+
+func (n *NoopReporter) Name() string {
+	return "registry"
+}
+
+func (n *NoopReporter) WriteEnvelope(context.Context, telemetry.TelemetryEnvelope) error {
+	return nil
+}
+
+func (n *NoopReporter) Close(context.Context) error {
+	return nil
+}

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"strings"
 	"time"
 
 	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
@@ -86,13 +87,16 @@ func (r *Relay) TelemetryStream(stream agentv1.AgentGateway_TelemetryStreamServe
 			return status.Errorf(codes.Unknown, "stream recv error: %v", err)
 		}
 
-		// Process the frame (e.g., forward to sinks)
-		r.handleTelemetryFrame(frame)
-
-		// Send ACK
 		ack := &agentv1.TelemetryAck{
 			Seq:    frame.Seq,
 			Status: agentv1.TelemetryAck_STATUS_OK,
+		}
+		if strings.TrimSpace(frame.MsgName) == "" {
+			ack.Status = agentv1.TelemetryAck_STATUS_PERMANENT_ERROR
+			ack.Error = "telemetry frame message name is required"
+		} else {
+			// Process the frame (e.g., forward to outputs).
+			r.handleTelemetryFrame(frame)
 		}
 
 		if err := stream.Send(ack); err != nil {

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -154,7 +154,25 @@ func TestTelemetryStream(t *testing.T) {
 		}
 	}
 
-	// Test Case 2: Clean Shutdown
+	// Test Case 2: Reject a frame without a message name and keep the stream open.
+	unnamedFrame := &agentv1.TelemetryFrame{AgentId: "frame-2", Seq: 2}
+	stream.recvChan <- unnamedFrame
+	select {
+	case ack := <-stream.sentAckChan:
+		if ack.Status != agentv1.TelemetryAck_STATUS_PERMANENT_ERROR {
+			t.Errorf("Expected permanent error status, got %v", ack.Status)
+		}
+		if ack.Error == "" {
+			t.Error("Expected validation error for unnamed frame")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Timeout waiting for unnamed frame ACK")
+	}
+	if mockSink.GetMessageCount() != 1 {
+		t.Errorf("Unnamed frame reached sink; message count = %d, want 1", mockSink.GetMessageCount())
+	}
+
+	// Test Case 3: Clean Shutdown
 	close(stream.recvChan) // Trigger io.EOF
 
 	select {

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -8,7 +8,6 @@ import (
 
 	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
 	"github.com/makinje/aero-arc-relay/internal/mock"
-	"github.com/makinje/aero-arc-relay/internal/sinks"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -89,10 +88,8 @@ func (m *mockTelemetryStream) Send(ack *agentv1.TelemetryAck) error {
 func TestTelemetryStream(t *testing.T) {
 	// Setup Relay with mock sink
 	mockSink := mock.NewMockSink()
-	relay := &Relay{
-		grpcSessions: make(map[string]*DroneSession),
-		sinks:        []sinks.Sink{mockSink},
-	}
+	relay := relayWithSinks(mockSink)
+	relay.grpcSessions = make(map[string]*DroneSession)
 
 	// Pre-register session (usually required but updated via stream)
 	agentID := "agent-stream-test"

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -237,14 +237,14 @@ func (r *Relay) initializeOutputs() error {
 	if r.config.Registry.Enabled {
 		r.router.AddConsumer(
 			registryreporter.NewNoopReporter(),
-			filterFromConfig(r.config.Registry.MessageFilterConfig),
+			registryMessageFilter(),
 		)
 	}
 
 	if r.config.Telemetry.Enabled {
 		r.router.AddConsumer(
 			telemetrywriter.NewNoopWriter(),
-			filterFromConfig(r.config.Telemetry.MessageFilterConfig),
+			telemetryMessageFilter(),
 		)
 	}
 
@@ -256,6 +256,23 @@ func (r *Relay) initializeOutputs() error {
 	}
 	r.outputsInitialized = true
 	return nil
+}
+
+// registryMessageFilter defines the telemetry required by Aero Arc registry reporting.
+func registryMessageFilter() outputs.MessageFilter {
+	return outputs.MessageFilter{Include: []string{
+		"Heartbeat",
+		"GlobalPositionInt",
+	}}
+}
+
+// telemetryMessageFilter defines the normalized hot telemetry maintained by Aero Arc.
+func telemetryMessageFilter() outputs.MessageFilter {
+	return outputs.MessageFilter{Include: []string{
+		"GlobalPositionInt",
+		"VFR_HUD",
+		"SystemStatus",
+	}}
 }
 
 // initializeSinks sets up all configured generic data sinks.

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -32,14 +32,14 @@ import (
 
 // Relay manages MAVLink connections and data forwarding to sinks
 type Relay struct {
-	config           *config.Config
-	sinks            []sinks.Sink
-	router           *outputs.Router
-	connections      sync.Map // map[string]*gomavlib.Node
-	sinksInitialized bool
-	grpcServer       *grpc.Server
-	grpcSessions     map[string]*DroneSession
-	sessionsMu       sync.RWMutex
+	config             *config.Config
+	sinks              []sinks.Sink
+	router             *outputs.Router
+	connections        sync.Map // map[string]*gomavlib.Node
+	outputsInitialized bool
+	grpcServer         *grpc.Server
+	grpcSessions       map[string]*DroneSession
+	sessionsMu         sync.RWMutex
 	relayv1.UnimplementedRelayControlServer
 	agentv1.UnimplementedAgentGatewayServer
 }
@@ -227,7 +227,7 @@ func (r *Relay) Start(ctx context.Context) error {
 }
 
 func (r *Relay) ready() bool {
-	return r.sinksInitialized
+	return r.outputsInitialized
 }
 
 // initializeOutputs sets up internal relay outputs and configured data sinks.
@@ -248,7 +248,14 @@ func (r *Relay) initializeOutputs() error {
 		)
 	}
 
-	return r.initializeSinks()
+	if err := r.initializeSinks(); err != nil {
+		return err
+	}
+	if !r.router.HasConsumers() {
+		return fmt.Errorf("no outputs configured")
+	}
+	r.outputsInitialized = true
+	return nil
 }
 
 // initializeSinks sets up all configured generic data sinks.
@@ -343,10 +350,6 @@ func (r *Relay) initializeSinks() error {
 		r.addSinkConsumer("file", fileSink, r.config.Sinks.File.MessageFilterConfig)
 	}
 
-	if len(r.sinks) == 0 {
-		return fmt.Errorf("no sinks configured")
-	}
-	r.sinksInitialized = true
 	return nil
 }
 

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -20,7 +20,10 @@ import (
 	relayv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
 	"github.com/bluenviron/gomavlib/v2/pkg/dialects/common"
 	"github.com/makinje/aero-arc-relay/internal/config"
+	"github.com/makinje/aero-arc-relay/internal/outputs"
+	"github.com/makinje/aero-arc-relay/internal/registryreporter"
 	"github.com/makinje/aero-arc-relay/internal/sinks"
+	"github.com/makinje/aero-arc-relay/internal/telemetrywriter"
 	"github.com/makinje/aero-arc-relay/pkg/telemetry"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -33,6 +36,7 @@ import (
 type Relay struct {
 	config           *config.Config
 	sinks            []sinks.Sink
+	router           *outputs.Router
 	connections      sync.Map // map[string]*gomavlib.Node
 	sinksInitialized bool
 	grpcServer       *grpc.Server
@@ -75,9 +79,8 @@ func New(cfg *config.Config) (*Relay, error) {
 		grpcSessions: make(map[string]*DroneSession),
 	}
 
-	// Initialize sinks
-	if err := relay.initializeSinks(); err != nil {
-		return nil, fmt.Errorf("failed to initialize sinks: %w", err)
+	if err := relay.initializeOutputs(); err != nil {
+		return nil, fmt.Errorf("failed to initialize outputs: %w", err)
 	}
 
 	return relay, nil
@@ -174,15 +177,24 @@ func (r *Relay) Start(ctx context.Context) error {
 			r.grpcServer.Stop()
 		}
 
-		// Shutdown sinks with timeout
+		// Shutdown outputs with timeout
 		baseCtx := context.Background()
-		for _, sink := range r.sinks {
+		if r.router != nil {
 			sinkCtx, cancel := context.WithTimeout(baseCtx, 30*time.Second)
-			if err := sink.Close(sinkCtx); err != nil {
+			if err := r.router.Close(sinkCtx); err != nil {
 				slog.LogAttrs(context.Background(), slog.LevelWarn,
-					"Error closing sink", slog.String("error", err.Error()))
+					"Error closing outputs", slog.String("error", err.Error()))
 			}
 			cancel() // Release resources
+		} else {
+			for _, sink := range r.sinks {
+				sinkCtx, cancel := context.WithTimeout(baseCtx, 30*time.Second)
+				if err := sink.Close(sinkCtx); err != nil {
+					slog.LogAttrs(context.Background(), slog.LevelWarn,
+						"Error closing sink", slog.String("error", err.Error()))
+				}
+				cancel() // Release resources
+			}
 		}
 
 		// Shutdown HTTP server
@@ -220,7 +232,28 @@ func (r *Relay) ready() bool {
 	return r.sinksInitialized
 }
 
-// initializeSinks sets up all configured data sinks
+// initializeOutputs sets up internal relay outputs and configured data sinks.
+func (r *Relay) initializeOutputs() error {
+	r.router = outputs.NewRouter()
+
+	if r.config.Registry.Enabled {
+		r.router.AddConsumer(
+			registryreporter.NewNoopReporter(),
+			filterFromConfig(r.config.Registry.MessageFilterConfig),
+		)
+	}
+
+	if r.config.Telemetry.Enabled {
+		r.router.AddConsumer(
+			telemetrywriter.NewNoopWriter(),
+			filterFromConfig(r.config.Telemetry.MessageFilterConfig),
+		)
+	}
+
+	return r.initializeSinks()
+}
+
+// initializeSinks sets up all configured generic data sinks.
 func (r *Relay) initializeSinks() error {
 	// Initialize S3 sink if configured
 	if r.config.Sinks.S3 != nil {
@@ -229,6 +262,7 @@ func (r *Relay) initializeSinks() error {
 			return fmt.Errorf("failed to create S3 sink: %w", err)
 		}
 		r.sinks = append(r.sinks, s3Sink)
+		r.addSinkConsumer("s3", s3Sink, r.config.Sinks.S3.MessageFilterConfig)
 	}
 
 	// Initialize GCS sink if configured
@@ -238,6 +272,7 @@ func (r *Relay) initializeSinks() error {
 			return fmt.Errorf("failed to create GCS sink: %w", err)
 		}
 		r.sinks = append(r.sinks, gcsSink)
+		r.addSinkConsumer("gcs", gcsSink, r.config.Sinks.GCS.MessageFilterConfig)
 	}
 
 	// Initialize BigQuery sink if configured
@@ -247,6 +282,7 @@ func (r *Relay) initializeSinks() error {
 			return fmt.Errorf("failed to create BigQuery sink: %w", err)
 		}
 		r.sinks = append(r.sinks, bigquerySink)
+		r.addSinkConsumer("bigquery", bigquerySink, r.config.Sinks.BigQuery.MessageFilterConfig)
 	}
 
 	// Initialize Timestream sink if configured
@@ -256,6 +292,7 @@ func (r *Relay) initializeSinks() error {
 			return fmt.Errorf("failed to create Timestream sink: %w", err)
 		}
 		r.sinks = append(r.sinks, timestreamSink)
+		r.addSinkConsumer("timestream", timestreamSink, r.config.Sinks.Timestream.MessageFilterConfig)
 	}
 
 	// Initialize InfluxDB sink if configured
@@ -265,6 +302,7 @@ func (r *Relay) initializeSinks() error {
 			return fmt.Errorf("failed to create InfluxDB sink: %w", err)
 		}
 		r.sinks = append(r.sinks, influxdbSink)
+		r.addSinkConsumer("influxdb", influxdbSink, r.config.Sinks.InfluxDB.MessageFilterConfig)
 	}
 
 	// Initialize Prometheus sink if configured
@@ -274,6 +312,7 @@ func (r *Relay) initializeSinks() error {
 			return fmt.Errorf("failed to create Prometheus sink: %w", err)
 		}
 		r.sinks = append(r.sinks, prometheusSink)
+		r.addSinkConsumer("prometheus", prometheusSink, r.config.Sinks.Prometheus.MessageFilterConfig)
 	}
 
 	// Initialize Elasticsearch sink if configured
@@ -283,6 +322,7 @@ func (r *Relay) initializeSinks() error {
 			return fmt.Errorf("failed to create Elasticsearch sink: %w", err)
 		}
 		r.sinks = append(r.sinks, elasticsearchSink)
+		r.addSinkConsumer("elasticsearch", elasticsearchSink, r.config.Sinks.Elasticsearch.MessageFilterConfig)
 	}
 
 	// Initialize Kafka sink if configured
@@ -292,6 +332,7 @@ func (r *Relay) initializeSinks() error {
 			return fmt.Errorf("failed to create Kafka sink: %w", err)
 		}
 		r.sinks = append(r.sinks, kafkaSink)
+		r.addSinkConsumer("kafka", kafkaSink, r.config.Sinks.Kafka.MessageFilterConfig)
 	}
 
 	// Initialize file sink if configured
@@ -301,6 +342,7 @@ func (r *Relay) initializeSinks() error {
 			return fmt.Errorf("failed to create file sink: %w", err)
 		}
 		r.sinks = append(r.sinks, fileSink)
+		r.addSinkConsumer("file", fileSink, r.config.Sinks.File.MessageFilterConfig)
 	}
 
 	if len(r.sinks) == 0 {
@@ -310,11 +352,30 @@ func (r *Relay) initializeSinks() error {
 	return nil
 }
 
+func (r *Relay) addSinkConsumer(name string, sink sinks.Sink, filter config.MessageFilterConfig) {
+	if r.router == nil {
+		return
+	}
+	r.router.AddConsumer(outputs.NewSinkConsumer(name, sink), filterFromConfig(filter))
+}
+
+func filterFromConfig(filter config.MessageFilterConfig) outputs.MessageFilter {
+	return outputs.MessageFilter{
+		Include: filter.IncludeMessages,
+		Exclude: filter.ExcludeMessages,
+	}
+}
+
 // handleTelemetryMessage processes incoming telemetry messages
 func (r *Relay) handleTelemetryMessage(msg telemetry.TelemetryEnvelope) {
 	relayMessagesTotal.WithLabelValues(msg.AgentID, msg.MsgName).Inc()
 
-	// Forward to all sinks
+	if r.router != nil {
+		_ = r.router.Route(context.Background(), msg)
+		return
+	}
+
+	// Backward-compatible path for tests that manually construct Relay{sinks: ...}.
 	for _, sink := range r.sinks {
 		if err := sink.WriteMessage(msg); err != nil {
 			relaySinkWriteErrorsTotal.WithLabelValues(sinkNameForMetrics(sink)).Inc()

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -5,13 +5,11 @@ package relay
 import (
 	"context"
 	"fmt"
-	"log"
 	"log/slog"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -369,25 +367,7 @@ func filterFromConfig(filter config.MessageFilterConfig) outputs.MessageFilter {
 // handleTelemetryMessage processes incoming telemetry messages
 func (r *Relay) handleTelemetryMessage(msg telemetry.TelemetryEnvelope) {
 	relayMessagesTotal.WithLabelValues(msg.AgentID, msg.MsgName).Inc()
-
-	if r.router != nil {
-		_ = r.router.Route(context.Background(), msg)
-		return
-	}
-
-	// Backward-compatible path for tests that manually construct Relay{sinks: ...}.
-	for _, sink := range r.sinks {
-		if err := sink.WriteMessage(msg); err != nil {
-			relaySinkWriteErrorsTotal.WithLabelValues(sinkNameForMetrics(sink)).Inc()
-			log.Printf("Failed to write message to sink: %v", err)
-		}
-	}
-}
-
-func sinkNameForMetrics(s sinks.Sink) string {
-	typeName := fmt.Sprintf("%T", s)
-	if idx := strings.LastIndex(typeName, "."); idx != -1 {
-		return typeName[idx+1:]
-	}
-	return typeName
+	r.router.Route(context.Background(), msg, func(consumer string, _ error) {
+		relaySinkWriteErrorsTotal.WithLabelValues(consumer).Inc()
+	})
 }

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -76,6 +76,41 @@ func TestRelayCreation(t *testing.T) {
 	}
 }
 
+func TestRelayCreationWithOnlyInternalOutput(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *config.Config
+	}{
+		{
+			name: "registry",
+			config: &config.Config{
+				Registry: config.RegistryConfig{Enabled: true},
+			},
+		},
+		{
+			name: "telemetry",
+			config: &config.Config{
+				Telemetry: config.TelemetryConfig{Enabled: true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			relay, err := New(tt.config)
+			if err != nil {
+				t.Fatalf("New() with only %s output: %v", tt.name, err)
+			}
+			if !relay.ready() {
+				t.Fatalf("relay with only %s output is not ready", tt.name)
+			}
+			if len(relay.sinks) != 0 {
+				t.Fatalf("relay with only %s output has %d generic sinks", tt.name, len(relay.sinks))
+			}
+		})
+	}
+}
+
 func TestHandleTelemetryMessage(t *testing.T) {
 	mockSink := mock.NewMockSink()
 	relay := relayWithSinks(mockSink)

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -111,6 +111,41 @@ func TestRelayCreationWithOnlyInternalOutput(t *testing.T) {
 	}
 }
 
+func TestInternalOutputMessageFilters(t *testing.T) {
+	tests := []struct {
+		name     string
+		filter   outputs.MessageFilter
+		included []string
+		excluded string
+	}{
+		{
+			name:     "registry",
+			filter:   registryMessageFilter(),
+			included: []string{"Heartbeat", "GlobalPositionInt"},
+			excluded: "Attitude",
+		},
+		{
+			name:     "telemetry",
+			filter:   telemetryMessageFilter(),
+			included: []string{"GlobalPositionInt", "VFR_HUD", "SystemStatus"},
+			excluded: "Heartbeat",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, message := range tt.included {
+				if !tt.filter.Allows(message) {
+					t.Errorf("internal %s filter rejects required message %q", tt.name, message)
+				}
+			}
+			if tt.filter.Allows(tt.excluded) {
+				t.Errorf("internal %s filter allows unrelated message %q", tt.name, tt.excluded)
+			}
+		})
+	}
+}
+
 func TestHandleTelemetryMessage(t *testing.T) {
 	mockSink := mock.NewMockSink()
 	relay := relayWithSinks(mockSink)

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -10,9 +10,43 @@ import (
 	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
 	"github.com/makinje/aero-arc-relay/internal/config"
 	"github.com/makinje/aero-arc-relay/internal/mock"
+	"github.com/makinje/aero-arc-relay/internal/outputs"
 	"github.com/makinje/aero-arc-relay/internal/sinks"
 	"github.com/makinje/aero-arc-relay/pkg/telemetry"
+	"github.com/prometheus/client_golang/prometheus"
 )
+
+func relayWithSinks(testSinks ...sinks.Sink) *Relay {
+	router := outputs.NewRouter()
+	for i, sink := range testSinks {
+		router.AddConsumer(
+			outputs.NewSinkConsumer(fmt.Sprintf("test-%d", i), sink),
+			outputs.MessageFilter{Include: []string{"*"}},
+		)
+	}
+	return &Relay{sinks: testSinks, router: router}
+}
+
+func sinkErrorMetricValue(t *testing.T, sink string) float64 {
+	t.Helper()
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	for _, family := range families {
+		if family.GetName() != "aero_relay_sink_errors_total" {
+			continue
+		}
+		for _, metric := range family.Metric {
+			for _, label := range metric.Label {
+				if label.GetName() == "sink" && label.GetValue() == sink {
+					return metric.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	return 0
+}
 
 func TestRelayCreation(t *testing.T) {
 	cfg := &config.Config{
@@ -44,9 +78,7 @@ func TestRelayCreation(t *testing.T) {
 
 func TestHandleTelemetryMessage(t *testing.T) {
 	mockSink := mock.NewMockSink()
-	relay := &Relay{
-		sinks: []sinks.Sink{mockSink},
-	}
+	relay := relayWithSinks(mockSink)
 
 	msg := telemetry.TelemetryEnvelope{
 		AgentID:        "test-agent",
@@ -74,9 +106,7 @@ func TestHandleTelemetryMessage(t *testing.T) {
 }
 
 func TestHandleTelemetryMessageMultipleSinks(t *testing.T) {
-	relay := &Relay{
-		sinks: []sinks.Sink{mock.NewMockSink(), mock.NewMockSink()},
-	}
+	relay := relayWithSinks(mock.NewMockSink(), mock.NewMockSink())
 
 	msg := telemetry.TelemetryEnvelope{
 		AgentID:        "test-agent",
@@ -133,9 +163,7 @@ func TestBuildTelemetryFrameEnvelope(t *testing.T) {
 
 func TestHandleTelemetryFrame(t *testing.T) {
 	mockSink := mock.NewMockSink()
-	relay := &Relay{
-		sinks: []sinks.Sink{mockSink},
-	}
+	relay := relayWithSinks(mockSink)
 
 	frame := &agentv1.TelemetryFrame{
 		AgentId: "agent-2",
@@ -162,9 +190,7 @@ func TestHandleTelemetryFrame(t *testing.T) {
 }
 
 func TestConcurrentTelemetryHandling(t *testing.T) {
-	relay := &Relay{
-		sinks: []sinks.Sink{mock.NewMockSink()},
-	}
+	relay := relayWithSinks(mock.NewMockSink())
 
 	numMessages := 100
 	var wg sync.WaitGroup
@@ -193,9 +219,8 @@ func TestConcurrentTelemetryHandling(t *testing.T) {
 
 func TestRelayErrorHandling(t *testing.T) {
 	failingSink := &failingSink{}
-	relay := &Relay{
-		sinks: []sinks.Sink{failingSink, mock.NewMockSink()},
-	}
+	relay := relayWithSinks(failingSink, mock.NewMockSink())
+	errorsBefore := sinkErrorMetricValue(t, "test-0")
 
 	msg := telemetry.TelemetryEnvelope{
 		AgentID:        "test-agent",
@@ -209,6 +234,9 @@ func TestRelayErrorHandling(t *testing.T) {
 	mockSink := relay.sinks[1].(*mock.MockSink)
 	if mockSink.GetMessageCount() != 1 {
 		t.Errorf("Expected 1 message in working sink, got %d", mockSink.GetMessageCount())
+	}
+	if got := sinkErrorMetricValue(t, "test-0"); got != errorsBefore+1 {
+		t.Errorf("Expected sink error metric to increase by 1, got %v before and %v after", errorsBefore, got)
 	}
 }
 

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -65,6 +65,9 @@ func TestRelayCreation(t *testing.T) {
 		Prefix:           "telemetry",
 		Format:           "json",
 		RotationInterval: time.Hour,
+		MessageFilterConfig: config.MessageFilterConfig{
+			IncludeMessages: []string{"*"},
+		},
 	}
 
 	relay, err := New(cfg)

--- a/internal/telemetrywriter/noop.go
+++ b/internal/telemetrywriter/noop.go
@@ -1,0 +1,25 @@
+package telemetrywriter
+
+import (
+	"context"
+
+	"github.com/makinje/aero-arc-relay/pkg/telemetry"
+)
+
+type NoopWriter struct{}
+
+func NewNoopWriter() *NoopWriter {
+	return &NoopWriter{}
+}
+
+func (n *NoopWriter) Name() string {
+	return "telemetry"
+}
+
+func (n *NoopWriter) WriteEnvelope(context.Context, telemetry.TelemetryEnvelope) error {
+	return nil
+}
+
+func (n *NoopWriter) Close(context.Context) error {
+	return nil
+}


### PR DESCRIPTION
## Summary

Refactor relay telemetry delivery around a configurable output router.

Previously, the relay forwarded every telemetry envelope directly to every
configured sink. This change introduces a common consumer boundary so generic
sinks, registry reporting, and normalized telemetry writers can independently
receive only the messages they need.

## Changes

- Add an `EnvelopeConsumer` interface for telemetry output implementations.
- Add an output router that filters and fans envelopes out to matching consumers.
- Route matching consumers concurrently.
- Add a sink adapter so existing sinks can participate without changing the
  existing `sinks.Sink` interface.
- Add per-output `include_messages` and `exclude_messages` configuration.
- Normalize MAVLink message names before applying filters.
- Add registry reporter and telemetry writer configuration boundaries with
  initial no-op implementations.
- Close registered outputs through the router during relay shutdown.
- Report consumer write failures through a generic router error callback.
- Preserve `aero_relay_sink_errors_total` for routed sink failures.
- Update relay tests to use the same router-based delivery path as production.

## Configuration

Outputs may select messages using `include_messages` and
`exclude_messages`:

```yaml
sinks:
  file:
    path: "/tmp/log/aero-arc-relay"
    prefix: "telemetry"
    format: "json"
    rotation_interval: "24h"
    include_messages:
      - "*"
    exclude_messages:
      - "HighLatencyMessage"
```
An empty include list allows all messages. Exclusions take precedence over
inclusions. Message names are normalized, so values such as Heartbeat,
MessageHeartbeat, and *common.MessageHeartbeat match consistently.

## Testing

- Added or updated coverage for:
- Message-name normalization.
- Include, exclude, and wildcard filtering.
- Routing only to matching consumers.
- Consumer error callbacks.
- Relay sink-error metric increments.
- Relay and telemetry-stream delivery through the production router path.
Focused test suites:
```
ok  ./internal/outputs
ok  ./internal/relay
```
