### PR TITLE
Add lint and coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -20,14 +21,37 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 2
           persist-credentials: false
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           cache: true
       - run: make build
-      - run: make test
+      - run: make test-coverage
       - run: go vet ./...
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: true
+          files: ./coverage/coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          only-new-issues: true
+          version: v2.12
 
   integration:
     name: Integration Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   test:
+    name: Unit Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,6 +30,7 @@ jobs:
       - run: go vet ./...
 
   integration:
+    name: Integration Test
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
 
   lint:
     name: Lint
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![Go Version](https://img.shields.io/github/go-mod/go-version/Aero-Arc/aero-arc-relay?filename=go.mod)](go.mod)
 [![License](https://img.shields.io/github/license/Aero-Arc/aero-arc-relay)](LICENSE)
 [![GitHub Release](https://img.shields.io/github/v/release/Aero-Arc/aero-arc-relay?include_prereleases)](https://github.com/Aero-Arc/aero-arc-relay/releases)
-[![Go Report Card](https://goreportcard.com/badge/github.com/Aero-Arc/aero-arc-relay)](https://goreportcard.com/report/github.com/Aero-Arc/aero-arc-relay)
-[![codecov](https://codecov.io/gh/Aero-Arc/aero-arc-relay/branch/main/graph/badge.svg)](https://codecov.io/gh/Aero-Arc/aero-arc-relay)
+[![CI](https://github.com/Aero-Arc/aero-arc-relay/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/Aero-Arc/aero-arc-relay/actions/workflows/ci.yml)
+[![Codecov](https://codecov.io/gh/Aero-Arc/aero-arc-relay/branch/main/graph/badge.svg)](https://codecov.io/gh/Aero-Arc/aero-arc-relay)
 
 
 Aero Arc Relay is a production-grade telemetry ingestion pipeline for MAVLink-enabled drones and autonomous systems.  


### PR DESCRIPTION
## Summary

This extends Relay's new CI workflow with a dedicated `Lint` job powered by golangci-lint v2.12. It evaluates only newly introduced findings so contributors cannot add lint debt while the repository's existing findings can be addressed separately.

The unit-test job now generates an atomic Go coverage profile and uploads it with the official Codecov action. Trusted branch runs use `CODECOV_TOKEN`; public fork pull requests remain compatible with Codecov's tokenless fork-upload support.

The retired Go Report Card badge is replaced with the GitHub Actions CI badge, and the Codecov badge remains backed by current uploads.

## Validation

- `make test-coverage`
- `go vet ./...`
- golangci-lint v2.12 with `--new-from-rev=origin/main`
- `git diff --check`

The current full lint baseline contains 36 pre-existing findings. This PR reports and blocks new findings without bundling an unrelated repository-wide cleanup.