### PR TITLE
Document exported Relay APIs and lifecycle semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,3 +53,15 @@
 - Run `go test -race ./...` for concurrency changes.
 - Run `go test -tags=integration -timeout=10m ./internal/integration ./internal/registryreporter`
   when Docker and local sockets are available.
+
+## Go documentation
+
+- Every exported handwritten Go function or method must have a lint-valid Go
+  doc comment beginning with its exact identifier.
+- Editor hover text should explain observable behavior, each parameter, return
+  values, and meaningful errors. For session admission, Registry reporting,
+  routing, normalization, batching, and shutdown methods, call out ownership,
+  acknowledgment, ordering, and concurrency semantics where relevant.
+- Use `Parameters:` and `Returns:` sections for non-trivial APIs; concise
+  identifier-led comments are enough for simple getters.
+- Never hand-edit generated protobuf comments.

--- a/cmd/aero-arc-relay/main.go
+++ b/cmd/aero-arc-relay/main.go
@@ -65,14 +65,16 @@ var relayCommand = cli.Command{
 	},
 }
 
-// RunRelay runs the Relay process with the supplied arguments and returns its terminal startup or runtime error.
+// RunRelay loads configuration, constructs the Relay, and serves until orderly
+// shutdown. Configuration, construction, and Relay.Start failures are logged
+// and terminate the process with status 1 rather than being returned.
 //
 // Parameters:
 //   - ctx: controls cancellation and deadlines for the operation.
-//   - cmd: is the *cli.Command value supplied to RunRelay.
+//   - cmd: contains resolved configuration, listener, TLS, and debug flags.
 //
 // Returns:
-//   - error: reports validation, dependency, cancellation, or persistence failures.
+//   - error: is nil after orderly shutdown; fatal startup/runtime paths call os.Exit.
 func RunRelay(ctx context.Context, cmd *cli.Command) error {
 	// Load configuration
 	cfg, err := config.Load(cmd.String("config-path"))

--- a/cmd/aero-arc-relay/main.go
+++ b/cmd/aero-arc-relay/main.go
@@ -65,6 +65,14 @@ var relayCommand = cli.Command{
 	},
 }
 
+// RunRelay runs the Relay process with the supplied arguments and returns its terminal startup or runtime error.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - cmd: is the *cli.Command value supplied to RunRelay.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func RunRelay(ctx context.Context, cmd *cli.Command) error {
 	// Load configuration
 	cfg, err := config.Load(cmd.String("config-path"))

--- a/internal/outputs/filters.go
+++ b/internal/outputs/filters.go
@@ -34,6 +34,13 @@ func (f MessageFilter) hasIncludes() bool {
 	return false
 }
 
+// Allows reports whether the filter permits the supplied telemetry envelope.
+//
+// Parameters:
+//   - messageName: is the string value supplied to Allows.
+//
+// Returns:
+//   - bool: reports whether the requested condition was satisfied.
 func (f MessageFilter) Allows(messageName string) bool {
 	if !f.hasIncludes() {
 		return false

--- a/internal/outputs/router.go
+++ b/internal/outputs/router.go
@@ -70,14 +70,17 @@ func (r *Router) HasConsumers() bool {
 	return r != nil && len(r.routes) > 0
 }
 
-// Route routes the supplied data to eligible Router consumers.
+// Route invokes every matching consumer concurrently and waits for all of them
+// to return. A consumer that ignores cancellation can therefore block Route;
+// failures are collected in completion order rather than route order.
 //
 // Parameters:
 //   - ctx: controls cancellation and deadlines for the operation.
 //   - envelope: is the telemetry.TelemetryEnvelope value supplied to Route.
 //
 // Returns:
-//   - result: is the []RouteError value produced by Route.
+//   - errors: contains consumer failures in nondeterministic completion order;
+//     nil means every matching consumer accepted the envelope.
 func (r *Router) Route(ctx context.Context, envelope telemetry.TelemetryEnvelope) []RouteError {
 	//TODO: Figure out what happens or how to get around blocked consumer
 	var wg sync.WaitGroup

--- a/internal/outputs/router.go
+++ b/internal/outputs/router.go
@@ -36,10 +36,19 @@ type Router struct {
 	routes []route
 }
 
+// NewRouter constructs outputs from the supplied configuration and dependencies.
+//
+// Returns:
+//   - result: is the *Router value produced by NewRouter.
 func NewRouter() *Router {
 	return &Router{routes: make([]route, 0)}
 }
 
+// AddConsumer adds the supplied value to Router.
+//
+// Parameters:
+//   - consumer: is the EnvelopeConsumer value supplied to AddConsumer.
+//   - filter: is the MessageFilter value supplied to AddConsumer.
 func (r *Router) AddConsumer(consumer EnvelopeConsumer, filter MessageFilter) {
 	if consumer == nil {
 		return
@@ -53,10 +62,22 @@ func (r *Router) AddConsumer(consumer EnvelopeConsumer, filter MessageFilter) {
 	r.routes = append(r.routes, route{consumer: consumer, filter: filter})
 }
 
+// HasConsumers reports whether Router has the requested state or capability.
+//
+// Returns:
+//   - bool: reports whether the requested condition was satisfied.
 func (r *Router) HasConsumers() bool {
 	return r != nil && len(r.routes) > 0
 }
 
+// Route routes the supplied data to eligible Router consumers.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - envelope: is the telemetry.TelemetryEnvelope value supplied to Route.
+//
+// Returns:
+//   - result: is the []RouteError value produced by Route.
 func (r *Router) Route(ctx context.Context, envelope telemetry.TelemetryEnvelope) []RouteError {
 	//TODO: Figure out what happens or how to get around blocked consumer
 	var wg sync.WaitGroup
@@ -93,6 +114,13 @@ func (r *Router) Route(ctx context.Context, envelope telemetry.TelemetryEnvelope
 	return routeErrors
 }
 
+// Close releases resources owned by Router and completes any required shutdown work.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (r *Router) Close(ctx context.Context) error {
 	if r == nil {
 		return nil

--- a/internal/outputs/sink_adapter.go
+++ b/internal/outputs/sink_adapter.go
@@ -23,14 +23,34 @@ type SinkConsumer struct {
 	sink sinks.Sink
 }
 
+// NewSinkConsumer constructs outputs from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - name: is the string value supplied to NewSinkConsumer.
+//   - sink: is the sinks.Sink value supplied to NewSinkConsumer.
+//
+// Returns:
+//   - result: is the *SinkConsumer value produced by NewSinkConsumer.
 func NewSinkConsumer(name string, sink sinks.Sink) *SinkConsumer {
 	return &SinkConsumer{name: name, sink: sink}
 }
 
+// Name returns the configured router-consumer name for this sink adapter.
+//
+// Returns:
+//   - result: is the string value produced by Name.
 func (s *SinkConsumer) Name() string {
 	return s.name
 }
 
+// WriteEnvelope writes the supplied data through SinkConsumer.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - envelope: is the telemetry.TelemetryEnvelope value supplied to WriteEnvelope.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *SinkConsumer) WriteEnvelope(ctx context.Context, envelope telemetry.TelemetryEnvelope) error {
 	if contextSink, ok := s.sink.(sinks.ContextSink); ok {
 		return contextSink.WriteMessageContext(ctx, envelope)
@@ -38,6 +58,13 @@ func (s *SinkConsumer) WriteEnvelope(ctx context.Context, envelope telemetry.Tel
 	return s.sink.WriteMessage(envelope)
 }
 
+// Close releases resources owned by SinkConsumer and completes any required shutdown work.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *SinkConsumer) Close(ctx context.Context) error {
 	return s.sink.Close(ctx)
 }

--- a/internal/registryreporter/reporter.go
+++ b/internal/registryreporter/reporter.go
@@ -83,6 +83,18 @@ type agentAdmission struct {
 	cancel context.CancelFunc
 }
 
+// New validates Registry reporting and establishes a ready gRPC connection.
+// It does not advertise the Relay or start heartbeat workers; callers invoke
+// Start only after the Relay listener and TLS configuration are ready.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - config: defines the Registry endpoint, Relay identity, TLS, heartbeat,
+//     and request-timeout policy.
+//
+// Returns:
+//   - reporter: owns the ready client connection and inactive worker context.
+//   - error: reports invalid configuration, TLS setup, dialing, or readiness failure.
 func New(ctx context.Context, config Config) (*Reporter, error) {
 	config = config.withDefaults()
 	if err := config.validate(); err != nil {
@@ -111,9 +123,16 @@ func New(ctx context.Context, config Config) (*Reporter, error) {
 	return reporter, nil
 }
 
-// Start publishes the relay and starts its liveness workers. Construction is
+// Start publishes the Relay and starts its liveness workers. Construction is
 // intentionally separate so callers can bind and validate their serving
-// listener before advertising the relay as available.
+// listener before advertising the Relay as available. Start is idempotent; a
+// failed first registration starts no workers and may be retried.
+//
+// Parameters:
+//   - ctx: bounds the initial Relay registration request.
+//
+// Returns:
+//   - error: reports publication failure or use after Close.
 func (r *Reporter) Start(ctx context.Context) error {
 	r.startMu.Lock()
 	defer r.startMu.Unlock()
@@ -218,7 +237,17 @@ func credentialsFor(config Config) (credentials.TransportCredentials, error) {
 	return credentials.NewTLS(tlsConfig), nil
 }
 
-// RegisterAgent makes an agent visible while its telemetry stream is active.
+// RegisterAgent publishes an Agent placement while its telemetry stream is
+// being admitted. Concurrent admissions are serialized by generation: only the
+// newest successful candidate becomes active, and the previous heartbeat
+// generation remains alive until replacement publication succeeds.
+//
+// Parameters:
+//   - ctx: controls cancellation of this admission attempt.
+//   - agentID: identifies the Agent being placed on this Relay.
+//
+// Returns:
+//   - error: reports invalid identity, Registry failure, or superseded admission.
 func (r *Reporter) RegisterAgent(ctx context.Context, agentID string) error {
 	agentID = strings.TrimSpace(agentID)
 	if agentID == "" {
@@ -272,8 +301,12 @@ func (r *Reporter) RegisterAgent(ctx context.Context, agentID string) error {
 	return nil
 }
 
-// StopAgent stops local heartbeats. Registry TTL expiry removes the remote
-// record even if the relay cannot reach the registry during disconnect.
+// StopAgent cancels pending admission and active heartbeat work for one Agent.
+// Registry TTL expiry removes the remote record even if the Relay cannot reach
+// Registry during disconnect. Repeated calls are safe.
+//
+// Parameters:
+//   - agentID: identifies the Agent session that ended.
 func (r *Reporter) StopAgent(agentID string) {
 	agentID = strings.TrimSpace(agentID)
 	r.mu.Lock()
@@ -435,6 +468,14 @@ func isCanceled(err error) bool {
 	return errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled
 }
 
+// Close stops every heartbeat generation, waits for workers, and closes the
+// owned gRPC connection once. It is safe before Start and across repeated calls.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//
+// Returns:
+//   - error: reports shutdown timeout or connection-close failure.
 func (r *Reporter) Close(ctx context.Context) error {
 	r.startMu.Lock()
 	r.closeOnce.Do(r.cancel)

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -44,7 +44,8 @@ func (s *Relay) ListActiveDrones(context.Context, *pb.ListActiveDronesRequest) (
 	return response, nil
 }
 
-// GetDroneStatus returns the current Relay-local session state for one Agent.
+// GetDroneStatus returns Relay-local state for one registered Agent. The
+// snapshot may represent a pending registration before telemetry-stream admission.
 //
 // Parameters:
 //   - ctx: is accepted for RPC lifecycle compatibility; this in-memory read
@@ -53,7 +54,7 @@ func (s *Relay) ListActiveDrones(context.Context, *pb.ListActiveDronesRequest) (
 //
 // Returns:
 //   - response: contains the matching session snapshot.
-//   - error: reports an empty ID or an Agent without an active session.
+//   - error: reports an empty ID or an Agent without a registered session.
 func (s *Relay) GetDroneStatus(_ context.Context, req *pb.GetDroneStatusRequest) (*pb.GetDroneStatusResponse, error) {
 	agentID := strings.TrimSpace(req.GetDroneId())
 	if agentID == "" {

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -23,6 +23,17 @@ import (
 
 const operationContextControlDisabled = "operation-context control is experimental and disabled until the relay control plane is authenticated and authorized"
 
+// ListActiveDrones snapshots the Relay's currently admitted Agent sessions as
+// drone-status records.
+//
+// Parameters:
+//   - ctx: is accepted for RPC lifecycle compatibility; this in-memory read
+//     completes synchronously.
+//   - request: carries no filters in the current Relay API.
+//
+// Returns:
+//   - response: contains one status record per currently admitted session.
+//   - error: is currently always nil.
 func (s *Relay) ListActiveDrones(context.Context, *pb.ListActiveDronesRequest) (*pb.ListActiveDronesResponse, error) {
 	s.sessionsMu.RLock()
 	defer s.sessionsMu.RUnlock()
@@ -33,6 +44,16 @@ func (s *Relay) ListActiveDrones(context.Context, *pb.ListActiveDronesRequest) (
 	return response, nil
 }
 
+// GetDroneStatus returns the current Relay-local session state for one Agent.
+//
+// Parameters:
+//   - ctx: is accepted for RPC lifecycle compatibility; this in-memory read
+//     completes synchronously.
+//   - req: identifies the Agent through its drone_id field.
+//
+// Returns:
+//   - response: contains the matching session snapshot.
+//   - error: reports an empty ID or an Agent without an active session.
 func (s *Relay) GetDroneStatus(_ context.Context, req *pb.GetDroneStatusRequest) (*pb.GetDroneStatusResponse, error) {
 	agentID := strings.TrimSpace(req.GetDroneId())
 	if agentID == "" {
@@ -47,10 +68,30 @@ func (s *Relay) GetDroneStatus(_ context.Context, req *pb.GetDroneStatusRequest)
 	return &pb.GetDroneStatusResponse{Drone: droneStatus(session)}, nil
 }
 
+// SetOperationContext rejects operation-context mutation while the Relay
+// control plane lacks its final authentication and authorization policy.
+//
+// Parameters:
+//   - ctx: is reserved for the future authenticated control-plane lifecycle.
+//   - request: is reserved for the future operation-context command.
+//
+// Returns:
+//   - response: is always nil while the RPC is disabled.
+//   - error: is a gRPC Unimplemented status explaining the security gate.
 func (*Relay) SetOperationContext(context.Context, *pb.SetOperationContextRequest) (*pb.SetOperationContextResponse, error) {
 	return nil, status.Error(codes.Unimplemented, operationContextControlDisabled)
 }
 
+// ClearOperationContext rejects operation-context mutation while the Relay
+// control plane lacks its final authentication and authorization policy.
+//
+// Parameters:
+//   - ctx: is reserved for the future authenticated control-plane lifecycle.
+//   - request: is reserved for the future operation-context command.
+//
+// Returns:
+//   - response: is always nil while the RPC is disabled.
+//   - error: is a gRPC Unimplemented status explaining the security gate.
 func (*Relay) ClearOperationContext(context.Context, *pb.ClearOperationContextRequest) (*pb.ClearOperationContextResponse, error) {
 	return nil, status.Error(codes.Unimplemented, operationContextControlDisabled)
 }

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -192,15 +192,16 @@ func New(cfg *config.Config) (*Relay, error) {
 }
 
 // Start binds the gRPC listener, validates server TLS, publishes Registry
-// liveness, and serves Agent sessions until cancellation or a terminal server
-// error. Startup failure performs bounded cleanup and never leaves a published
-// Relay without a listener.
+// liveness, and serves Agent sessions until cancellation or a termination
+// signal. A gRPC serving error after successful startup is logged but is not
+// propagated through Start. Startup failure performs bounded cleanup and never
+// leaves a published Relay without a listener.
 //
 // Parameters:
 //   - ctx: controls serving lifetime and startup cancellation.
 //
 // Returns:
-//   - error: reports listener, TLS, Registry publication, serving, or cleanup failure.
+//   - error: reports listener, TLS, Registry publication, or startup cleanup failure.
 func (r *Relay) Start(ctx context.Context) error {
 	slog.Info("Starting aero-arc-relay...")
 

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -115,6 +115,13 @@ type contextMutex struct {
 	token chan struct{}
 }
 
+// Lock acquires exclusive ownership of the session guard and records the owning goroutine token.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (m *contextMutex) Lock(ctx context.Context) error {
 	m.once.Do(func() {
 		m.token = make(chan struct{}, 1)
@@ -135,6 +142,7 @@ func (m *contextMutex) Lock(ctx context.Context) error {
 	}
 }
 
+// Unlock releases exclusive ownership of the session guard and clears its owner token.
 func (m *contextMutex) Unlock() {
 	m.token <- struct{}{}
 }
@@ -151,7 +159,16 @@ var (
 	}, []string{"sink"})
 )
 
-// New creates a new relay instance
+// New validates Agent authentication requirements and constructs a Relay with
+// its configured telemetry outputs. Network listeners and Registry publication
+// are deferred until Start.
+//
+// Parameters:
+//   - cfg: defines listener, TLS, authentication, output, and Registry settings.
+//
+// Returns:
+//   - relay: owns initialized outputs but is not yet serving.
+//   - error: reports authentication or output initialization failure.
 func New(cfg *config.Config) (*Relay, error) {
 	authenticator, err := newAgentTokenAuthenticator(cfg.AgentAuth.Tokens)
 	if err != nil {
@@ -174,7 +191,16 @@ func New(cfg *config.Config) (*Relay, error) {
 	return relay, nil
 }
 
-// Start begins the relay operation
+// Start binds the gRPC listener, validates server TLS, publishes Registry
+// liveness, and serves Agent sessions until cancellation or a terminal server
+// error. Startup failure performs bounded cleanup and never leaves a published
+// Relay without a listener.
+//
+// Parameters:
+//   - ctx: controls serving lifetime and startup cancellation.
+//
+// Returns:
+//   - error: reports listener, TLS, Registry publication, serving, or cleanup failure.
 func (r *Relay) Start(ctx context.Context) error {
 	slog.Info("Starting aero-arc-relay...")
 

--- a/internal/sinks/base.go
+++ b/internal/sinks/base.go
@@ -125,32 +125,35 @@ func NewBaseAsyncSink(buffer int, policy string, sinkName string, worker func(te
 	return b
 }
 
-// Enqueue queues the supplied item for asynchronous processing by BaseAsyncSink.
+// Enqueue admits a message to the asynchronous sink queue using a background
+// context. Nil acknowledges queue admission only, not downstream persistence.
 //
 // Parameters:
 //   - msg: is the telemetry.TelemetryEnvelope value supplied to Enqueue.
 //
 // Returns:
-//   - error: reports validation, dependency, cancellation, or persistence failures.
+//   - error: is ErrQueueFull under drop policy; block policy waits indefinitely.
 func (b *BaseAsyncSink) Enqueue(msg telemetry.TelemetryEnvelope) error {
 	return b.EnqueueContext(context.Background(), msg)
 }
 
 // WriteMessageContext allows the sink adapter to propagate stream
 // cancellation through an async sink's backpressure wait. Concrete sinks that
-// embed BaseAsyncSink inherit this implementation.
+// embed BaseAsyncSink inherit this implementation. Nil acknowledges queue
+// admission only; worker/persistence failures are logged asynchronously.
 func (b *BaseAsyncSink) WriteMessageContext(ctx context.Context, msg telemetry.TelemetryEnvelope) error {
 	return b.EnqueueContext(ctx, msg)
 }
 
-// EnqueueContext queues the supplied item for asynchronous processing by BaseAsyncSink.
+// EnqueueContext admits a message to the asynchronous sink queue according to
+// its block-or-drop backpressure policy. Nil acknowledges queue admission only.
 //
 // Parameters:
 //   - ctx: controls cancellation and deadlines for the operation.
 //   - msg: is the telemetry.TelemetryEnvelope value supplied to EnqueueContext.
 //
 // Returns:
-//   - error: reports validation, dependency, cancellation, or persistence failures.
+//   - error: is caller cancellation while blocking or ErrQueueFull under drop policy.
 func (b *BaseAsyncSink) EnqueueContext(ctx context.Context, msg telemetry.TelemetryEnvelope) error {
 	switch b.policy {
 	case BackpressurePolicyBlock:

--- a/internal/sinks/base.go
+++ b/internal/sinks/base.go
@@ -80,6 +80,16 @@ func normalizeBackpressurePolicy(policy string) BackpressurePolicy {
 	}
 }
 
+// NewBaseAsyncSink constructs sinks from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - buffer: is the int value supplied to NewBaseAsyncSink.
+//   - policy: is the string value supplied to NewBaseAsyncSink.
+//   - sinkName: is the string value supplied to NewBaseAsyncSink.
+//   - worker: provides the error value handled by the operation.
+//
+// Returns:
+//   - result: is the *BaseAsyncSink value produced by NewBaseAsyncSink.
 func NewBaseAsyncSink(buffer int, policy string, sinkName string, worker func(telemetry.TelemetryEnvelope) error) *BaseAsyncSink {
 	if buffer <= 0 {
 		buffer = defaultQueueSize
@@ -115,6 +125,13 @@ func NewBaseAsyncSink(buffer int, policy string, sinkName string, worker func(te
 	return b
 }
 
+// Enqueue queues the supplied item for asynchronous processing by BaseAsyncSink.
+//
+// Parameters:
+//   - msg: is the telemetry.TelemetryEnvelope value supplied to Enqueue.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (b *BaseAsyncSink) Enqueue(msg telemetry.TelemetryEnvelope) error {
 	return b.EnqueueContext(context.Background(), msg)
 }
@@ -126,6 +143,14 @@ func (b *BaseAsyncSink) WriteMessageContext(ctx context.Context, msg telemetry.T
 	return b.EnqueueContext(ctx, msg)
 }
 
+// EnqueueContext queues the supplied item for asynchronous processing by BaseAsyncSink.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - msg: is the telemetry.TelemetryEnvelope value supplied to EnqueueContext.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (b *BaseAsyncSink) EnqueueContext(ctx context.Context, msg telemetry.TelemetryEnvelope) error {
 	switch b.policy {
 	case BackpressurePolicyBlock:
@@ -152,6 +177,7 @@ func (b *BaseAsyncSink) EnqueueContext(ctx context.Context, msg telemetry.Teleme
 	}
 }
 
+// Close releases resources owned by BaseAsyncSink and completes any required shutdown work.
 func (b *BaseAsyncSink) Close() {
 	close(b.queue)
 	b.wg.Wait()

--- a/internal/sinks/s3.go
+++ b/internal/sinks/s3.go
@@ -125,7 +125,11 @@ func (s *S3Sink) handleMessage(msg telemetry.TelemetryEnvelope) error {
 	return nil
 }
 
-// RotateFile rotates the file
+// RotateAndUpload flushes the current file, uploads it to S3, and starts a new
+// local file while holding the sink rotation lock.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (s *S3Sink) RotateAndUpload() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/telemetrynormalize/registry.go
+++ b/internal/telemetrynormalize/registry.go
@@ -14,6 +14,14 @@ type Normalizer interface {
 
 type NormalizerFunc func(telemetry.TelemetryEnvelope) (Record, error)
 
+// Normalize normalizes the supplied telemetry through NormalizerFunc.
+//
+// Parameters:
+//   - envelope: is the telemetry.TelemetryEnvelope value supplied to Normalize.
+//
+// Returns:
+//   - result: is the Record value produced by Normalize.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (f NormalizerFunc) Normalize(envelope telemetry.TelemetryEnvelope) (Record, error) {
 	return f(envelope)
 }
@@ -22,6 +30,10 @@ type Registry struct {
 	normalizers map[string]Normalizer
 }
 
+// NewRegistry constructs telemetrynormalize from the supplied configuration and dependencies.
+//
+// Returns:
+//   - result: is the *Registry value produced by NewRegistry.
 func NewRegistry() *Registry {
 	registry := &Registry{normalizers: make(map[string]Normalizer)}
 	registry.Register("global_position_int", NormalizerFunc(normalizeGlobalPositionInt))
@@ -35,6 +47,11 @@ func NewRegistry() *Registry {
 	return registry
 }
 
+// Register registers the supplied Registry identity or handler.
+//
+// Parameters:
+//   - messageName: is the string value supplied to Register.
+//   - normalizer: is the Normalizer value supplied to Register.
 func (r *Registry) Register(messageName string, normalizer Normalizer) {
 	if r == nil || normalizer == nil {
 		return
@@ -45,6 +62,14 @@ func (r *Registry) Register(messageName string, normalizer Normalizer) {
 	}
 }
 
+// Lookup looks up Registry data using the supplied key.
+//
+// Parameters:
+//   - messageName: is the string value supplied to Lookup.
+//
+// Returns:
+//   - result: is the Normalizer value produced by Lookup.
+//   - bool: reports whether the requested condition was satisfied.
 func (r *Registry) Lookup(messageName string) (Normalizer, bool) {
 	if r == nil {
 		return nil, false

--- a/internal/telemetrynormalize/types.go
+++ b/internal/telemetrynormalize/types.go
@@ -67,6 +67,10 @@ type Record struct {
 	Fields        Fields
 }
 
+// Validate validates Record for required fields, supported values, and safety constraints.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (r Record) Validate() error {
 	if r.SchemaVersion == 0 {
 		return errors.New("schema version is required")

--- a/internal/telemetrywriter/influx/backend.go
+++ b/internal/telemetrywriter/influx/backend.go
@@ -26,6 +26,14 @@ type Backend struct {
 	client pointWriter
 }
 
+// New constructs influx from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - config: provides the configuration values used to initialize or execute the operation.
+//
+// Returns:
+//   - result: is the *Backend value produced by New.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func New(config Config) (*Backend, error) {
 	if config.Host == "" || config.Token == "" || config.Database == "" {
 		return nil, errors.New("InfluxDB 3 host, token, and database are required")
@@ -44,6 +52,14 @@ func New(config Config) (*Backend, error) {
 
 func newWithClient(client pointWriter) *Backend { return &Backend{client: client} }
 
+// WriteBatch writes the supplied data through Backend.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - records: is the []telemetrynormalize.Record value supplied to WriteBatch.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (b *Backend) WriteBatch(ctx context.Context, records []telemetrynormalize.Record) error {
 	if len(records) == 0 {
 		return nil
@@ -62,6 +78,13 @@ func (b *Backend) WriteBatch(ctx context.Context, records []telemetrynormalize.R
 	return nil
 }
 
+// Close releases resources owned by Backend and completes any required shutdown work.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to Close.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (b *Backend) Close(context.Context) error {
 	if err := b.client.Close(); err != nil {
 		return fmt.Errorf("close InfluxDB 3 client: %w", err)

--- a/internal/telemetrywriter/influx/backend.go
+++ b/internal/telemetrywriter/influx/backend.go
@@ -81,7 +81,7 @@ func (b *Backend) WriteBatch(ctx context.Context, records []telemetrynormalize.R
 // Close releases resources owned by Backend and completes any required shutdown work.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to Close.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //
 // Returns:
 //   - error: reports validation, dependency, cancellation, or persistence failures.

--- a/internal/telemetrywriter/noop.go
+++ b/internal/telemetrywriter/noop.go
@@ -19,10 +19,33 @@ import (
 
 type NoopWriter struct{}
 
+// NewNoopWriter constructs telemetrywriter from the supplied configuration and dependencies.
+//
+// Returns:
+//   - result: is the *NoopWriter value produced by NewNoopWriter.
 func NewNoopWriter() *NoopWriter { return &NoopWriter{} }
 
+// Name returns the no-op writer's stable output name.
+//
+// Returns:
+//   - result: is the string value produced by Name.
 func (n *NoopWriter) Name() string { return ConsumerName }
 
+// WriteEnvelope writes the supplied data through NoopWriter.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to WriteEnvelope.
+//   - value: is the telemetry.TelemetryEnvelope value supplied to WriteEnvelope.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (n *NoopWriter) WriteEnvelope(context.Context, telemetry.TelemetryEnvelope) error { return nil }
 
+// Close releases resources owned by NoopWriter and completes any required shutdown work.
+//
+// Parameters:
+//   - value: is the context.Context value supplied to Close.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (n *NoopWriter) Close(context.Context) error { return nil }

--- a/internal/telemetrywriter/noop.go
+++ b/internal/telemetrywriter/noop.go
@@ -34,8 +34,8 @@ func (n *NoopWriter) Name() string { return ConsumerName }
 // WriteEnvelope writes the supplied data through NoopWriter.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to WriteEnvelope.
-//   - value: is the telemetry.TelemetryEnvelope value supplied to WriteEnvelope.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
+//   - envelope: contains the telemetry value accepted by the writer.
 //
 // Returns:
 //   - error: reports validation, dependency, cancellation, or persistence failures.
@@ -44,7 +44,7 @@ func (n *NoopWriter) WriteEnvelope(context.Context, telemetry.TelemetryEnvelope)
 // Close releases resources owned by NoopWriter and completes any required shutdown work.
 //
 // Parameters:
-//   - value: is the context.Context value supplied to Close.
+//   - ctx: is accepted for interface compatibility; the in-memory operation completes synchronously.
 //
 // Returns:
 //   - error: reports validation, dependency, cancellation, or persistence failures.

--- a/internal/telemetrywriter/writer.go
+++ b/internal/telemetrywriter/writer.go
@@ -112,6 +112,16 @@ type Writer struct {
 	errMu      sync.Mutex
 }
 
+// NewWriter constructs telemetrywriter from the supplied configuration and dependencies.
+//
+// Parameters:
+//   - config: provides the configuration values used to initialize or execute the operation.
+//   - backend: is the Backend value supplied to NewWriter.
+//   - registry: is the *telemetrynormalize.Registry value supplied to NewWriter.
+//
+// Returns:
+//   - result: is the *Writer value produced by NewWriter.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func NewWriter(config Config, backend Backend, registry *telemetrynormalize.Registry) (*Writer, error) {
 	if backend == nil {
 		return nil, errors.New("normalized telemetry backend is required")
@@ -136,8 +146,20 @@ func NewWriter(config Config, backend Backend, registry *telemetrynormalize.Regi
 	return w, nil
 }
 
+// Name returns the telemetry writer's stable output name.
+//
+// Returns:
+//   - result: is the string value produced by Name.
 func (w *Writer) Name() string { return ConsumerName }
 
+// WriteEnvelope writes the supplied data through Writer.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - envelope: is the telemetry.TelemetryEnvelope value supplied to WriteEnvelope.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (w *Writer) WriteEnvelope(ctx context.Context, envelope telemetry.TelemetryEnvelope) error {
 	normalizer, supported := w.registry.Lookup(envelope.MsgName)
 	if !supported {
@@ -238,6 +260,13 @@ func (w *Writer) writeBatch(batch []telemetrynormalize.Record) error {
 	return nil
 }
 
+// Close releases resources owned by Writer and completes any required shutdown work.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (w *Writer) Close(ctx context.Context) error {
 	w.closeOnce.Do(func() {
 		w.stateMu.Lock()

--- a/internal/telemetrywriter/writer.go
+++ b/internal/telemetrywriter/writer.go
@@ -152,14 +152,18 @@ func NewWriter(config Config, backend Backend, registry *telemetrynormalize.Regi
 //   - result: is the string value produced by Name.
 func (w *Writer) Name() string { return ConsumerName }
 
-// WriteEnvelope writes the supplied data through Writer.
+// WriteEnvelope normalizes a supported envelope and admits it to the bounded
+// asynchronous backend queue. A nil result acknowledges queue admission only,
+// not durable InfluxDB persistence; backend failures are accumulated for Close.
+// Unsupported message names are intentionally ignored and also return nil.
 //
 // Parameters:
 //   - ctx: controls cancellation and deadlines for the operation.
-//   - envelope: is the telemetry.TelemetryEnvelope value supplied to WriteEnvelope.
+//   - envelope: contains one admitted Agent telemetry frame and its attribution.
 //
 // Returns:
-//   - error: reports validation, dependency, cancellation, or persistence failures.
+//   - error: reports normalization failure, a closed writer, caller cancellation,
+//     or expiration of the bounded enqueue timeout.
 func (w *Writer) WriteEnvelope(ctx context.Context, envelope telemetry.TelemetryEnvelope) error {
 	normalizer, supported := w.registry.Lookup(envelope.MsgName)
 	if !supported {

--- a/internal/testsupport/agent.go
+++ b/internal/testsupport/agent.go
@@ -17,6 +17,16 @@ type FakeAgent struct {
 	stream    agentv1.AgentGateway_TelemetryStreamClient
 }
 
+// RegisterFakeAgent registers the supplied testsupport identity or handler.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - conn: is the grpc.ClientConnInterface value supplied to RegisterFakeAgent.
+//   - agentID: identifies the target agent.
+//
+// Returns:
+//   - result: is the *FakeAgent value produced by RegisterFakeAgent.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func RegisterFakeAgent(ctx context.Context, conn grpc.ClientConnInterface, agentID string) (*FakeAgent, error) {
 	client := agentv1.NewAgentGatewayClient(conn)
 	registration, err := client.Register(ctx, &agentv1.RegisterRequest{AgentId: agentID})
@@ -39,6 +49,14 @@ func RegisterFakeAgent(ctx context.Context, conn grpc.ClientConnInterface, agent
 	}, nil
 }
 
+// Send sends the supplied data through FakeAgent.
+//
+// Parameters:
+//   - frame: is the *agentv1.TelemetryFrame value supplied to Send.
+//
+// Returns:
+//   - result: is the *agentv1.TelemetryAck value produced by Send.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (a *FakeAgent) Send(frame *agentv1.TelemetryFrame) (*agentv1.TelemetryAck, error) {
 	frame.AgentId = a.ID
 	frame.SessionId = a.SessionID
@@ -58,6 +76,10 @@ func (a *FakeAgent) Send(frame *agentv1.TelemetryFrame) (*agentv1.TelemetryAck, 
 	return ack, nil
 }
 
+// Close releases resources owned by FakeAgent and completes any required shutdown work.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (a *FakeAgent) Close() error {
 	if err := a.stream.CloseSend(); err != nil {
 		return fmt.Errorf("close fake agent telemetry stream: %w", err)

--- a/internal/testsupport/influxdb.go
+++ b/internal/testsupport/influxdb.go
@@ -26,6 +26,15 @@ type InfluxDB struct {
 	Client   *influxdb3.Client
 }
 
+// QueryRows queries InfluxDB with the supplied statement and parameters.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - query: is the string value supplied to QueryRows.
+//
+// Returns:
+//   - result: is the []map[string]any value produced by QueryRows.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (i *InfluxDB) QueryRows(ctx context.Context, query string) ([]map[string]any, error) {
 	iterator, err := i.Client.Query(ctx, query)
 	if err != nil {
@@ -41,6 +50,17 @@ func (i *InfluxDB) QueryRows(ctx context.Context, query string) ([]map[string]an
 	return rows, nil
 }
 
+// AwaitRow polls a real InfluxDB query until a matching row appears or the test times out.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//   - interval: defines the time bound applied by the operation.
+//   - query: is the string value supplied to AwaitRow.
+//   - identity: identifies the target identity.
+//
+// Returns:
+//   - result: is the map[string]any value produced by AwaitRow.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (i *InfluxDB) AwaitRow(ctx context.Context, interval time.Duration, query, identity string) (map[string]any, error) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -62,6 +82,13 @@ func (i *InfluxDB) AwaitRow(ctx context.Context, interval time.Duration, query, 
 	}
 }
 
+// StartInfluxDB starts and provisions the pinned InfluxDB Core Testcontainer.
+//
+// Parameters:
+//   - t: is the *testing.T value supplied to StartInfluxDB.
+//
+// Returns:
+//   - result: is the *InfluxDB value produced by StartInfluxDB.
 func StartInfluxDB(t *testing.T) *InfluxDB {
 	t.Helper()
 	testcontainers.SkipIfProviderIsNotHealthy(t)

--- a/internal/testsupport/relay.go
+++ b/internal/testsupport/relay.go
@@ -32,6 +32,18 @@ type Relay struct {
 	logf     func(string, ...any)
 }
 
+// StartRelay launches a production Relay against the supplied test InfluxDB and
+// returns its dynamically allocated endpoint and shutdown handle.
+//
+// Parameters:
+//   - t: is the *testing.T value supplied to StartRelay.
+//   - influx: is the *InfluxDB value supplied to StartRelay.
+//   - agentID: identifies the target agent.
+//   - aircraftID: identifies the target aircraft.
+//   - relayID: identifies the target relay.
+//
+// Returns:
+//   - result: is the *Relay value produced by StartRelay.
 func StartRelay(t *testing.T, influx *InfluxDB, agentID, aircraftID, relayID string) *Relay {
 	t.Helper()
 	t.Logf(
@@ -118,6 +130,13 @@ func StartRelay(t *testing.T, influx *InfluxDB, agentID, aircraftID, relayID str
 	return fixture
 }
 
+// Shutdown stops Relay and releases its owned resources.
+//
+// Parameters:
+//   - ctx: controls cancellation and deadlines for the operation.
+//
+// Returns:
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (r *Relay) Shutdown(ctx context.Context) error {
 	r.stopOnce.Do(func() {
 		r.logf("Stopping Relay in-process: endpoint=%s", r.Address)

--- a/pkg/telemetry/envelope.go
+++ b/pkg/telemetry/envelope.go
@@ -64,10 +64,13 @@ func (e TelemetryEnvelope) GetSource() string {
 	return e.Source
 }
 
-// GetTimestamp parses and returns the envelope's capture timestamp.
+// GetTimestamp returns Relay receipt time when present, otherwise converts the
+// device timestamp from fractional Unix seconds. It does not consult the Agent
+// timestamp field.
 //
 // Returns:
-//   - result: is the time.Time value produced by GetTimestamp.
+//   - timestamp: is UTC device time when Relay receipt time is absent, or zero
+//     when neither source is available.
 func (e TelemetryEnvelope) GetTimestamp() time.Time {
 	if !e.TimestampRelay.IsZero() {
 		return e.TimestampRelay
@@ -82,10 +85,11 @@ func (e TelemetryEnvelope) GetTimestamp() time.Time {
 	return time.Time{}
 }
 
-// GetMessageType returns the canonical telemetry message type name.
+// GetMessageType returns MsgName exactly as stored in the envelope. Callers that
+// require lower-snake-case grouping must normalize it separately.
 //
 // Returns:
-//   - result: is the string value produced by GetMessageType.
+//   - messageType: may contain a legacy mixed-case MAVLink name.
 func (e TelemetryEnvelope) GetMessageType() string {
 	return e.MsgName
 }

--- a/pkg/telemetry/envelope.go
+++ b/pkg/telemetry/envelope.go
@@ -56,10 +56,18 @@ type TelemetryMessage interface {
 	ToBinary() ([]byte, error)
 }
 
+// GetSource returns the Agent source identifier carried by the envelope.
+//
+// Returns:
+//   - result: is the string value produced by GetSource.
 func (e TelemetryEnvelope) GetSource() string {
 	return e.Source
 }
 
+// GetTimestamp parses and returns the envelope's capture timestamp.
+//
+// Returns:
+//   - result: is the time.Time value produced by GetTimestamp.
 func (e TelemetryEnvelope) GetTimestamp() time.Time {
 	if !e.TimestampRelay.IsZero() {
 		return e.TimestampRelay
@@ -74,22 +82,48 @@ func (e TelemetryEnvelope) GetTimestamp() time.Time {
 	return time.Time{}
 }
 
+// GetMessageType returns the canonical telemetry message type name.
+//
+// Returns:
+//   - result: is the string value produced by GetMessageType.
 func (e TelemetryEnvelope) GetMessageType() string {
 	return e.MsgName
 }
 
+// ToJSON converts TelemetryEnvelope to the requested representation.
+//
+// Returns:
+//   - result: is the []byte value produced by ToJSON.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (e TelemetryEnvelope) ToJSON() ([]byte, error) {
 	return json.Marshal(e)
 }
 
+// ToEnvelope converts TelemetryEnvelope to the requested representation.
+//
+// Returns:
+//   - result: is the TelemetryEnvelope value produced by ToEnvelope.
 func (e TelemetryEnvelope) ToEnvelope() TelemetryEnvelope {
 	return e
 }
 
+// ToBinary converts TelemetryEnvelope to the requested representation.
+//
+// Returns:
+//   - result: is the []byte value produced by ToBinary.
+//   - error: reports validation, dependency, cancellation, or persistence failures.
 func (e TelemetryEnvelope) ToBinary() ([]byte, error) {
 	return e.ToJSON()
 }
 
+// BuildHeartbeatEnvelope builds a telemetry value from the supplied inputs.
+//
+// Parameters:
+//   - source: is the string value supplied to BuildHeartbeatEnvelope.
+//   - msg: is the *common.MessageHeartbeat value supplied to BuildHeartbeatEnvelope.
+//
+// Returns:
+//   - result: is the TelemetryEnvelope value produced by BuildHeartbeatEnvelope.
 func BuildHeartbeatEnvelope(source string, msg *common.MessageHeartbeat) TelemetryEnvelope {
 	envelope := TelemetryEnvelope{
 		AgentID:         source,
@@ -109,6 +143,14 @@ func BuildHeartbeatEnvelope(source string, msg *common.MessageHeartbeat) Telemet
 	return envelope
 }
 
+// BuildGlobalPositionIntEnvelope builds a telemetry value from the supplied inputs.
+//
+// Parameters:
+//   - source: is the string value supplied to BuildGlobalPositionIntEnvelope.
+//   - msg: is the *common.MessageGlobalPositionInt value supplied to BuildGlobalPositionIntEnvelope.
+//
+// Returns:
+//   - result: is the TelemetryEnvelope value produced by BuildGlobalPositionIntEnvelope.
 func BuildGlobalPositionIntEnvelope(source string, msg *common.MessageGlobalPositionInt) TelemetryEnvelope {
 	envelope := TelemetryEnvelope{
 		AgentID:         source,
@@ -135,6 +177,14 @@ func BuildGlobalPositionIntEnvelope(source string, msg *common.MessageGlobalPosi
 	return envelope
 }
 
+// BuildAttitudeEnvelope builds a telemetry value from the supplied inputs.
+//
+// Parameters:
+//   - source: is the string value supplied to BuildAttitudeEnvelope.
+//   - msg: is the *common.MessageAttitude value supplied to BuildAttitudeEnvelope.
+//
+// Returns:
+//   - result: is the TelemetryEnvelope value produced by BuildAttitudeEnvelope.
 func BuildAttitudeEnvelope(source string, msg *common.MessageAttitude) TelemetryEnvelope {
 	envelope := TelemetryEnvelope{
 		AgentID:         source,
@@ -159,6 +209,14 @@ func BuildAttitudeEnvelope(source string, msg *common.MessageAttitude) Telemetry
 	return envelope
 }
 
+// BuildVfrHudEnvelope builds a telemetry value from the supplied inputs.
+//
+// Parameters:
+//   - source: is the string value supplied to BuildVfrHudEnvelope.
+//   - msg: is the *common.MessageVfrHud value supplied to BuildVfrHudEnvelope.
+//
+// Returns:
+//   - result: is the TelemetryEnvelope value produced by BuildVfrHudEnvelope.
 func BuildVfrHudEnvelope(source string, msg *common.MessageVfrHud) TelemetryEnvelope {
 	envelope := TelemetryEnvelope{
 		AgentID:         source,
@@ -182,6 +240,14 @@ func BuildVfrHudEnvelope(source string, msg *common.MessageVfrHud) TelemetryEnve
 	return envelope
 }
 
+// BuildSysStatusEnvelope builds a telemetry value from the supplied inputs.
+//
+// Parameters:
+//   - source: is the string value supplied to BuildSysStatusEnvelope.
+//   - msg: is the *common.MessageSysStatus value supplied to BuildSysStatusEnvelope.
+//
+// Returns:
+//   - result: is the TelemetryEnvelope value produced by BuildSysStatusEnvelope.
 func BuildSysStatusEnvelope(source string, msg *common.MessageSysStatus) TelemetryEnvelope {
 	envelope := TelemetryEnvelope{
 		AgentID:         source,


### PR DESCRIPTION
## Summary

- add hover-friendly documentation for every previously undocumented exported handwritten Go function and method
- clarify Registry reporter admission generations, Relay startup/publication ordering, session reads, telemetry routing, normalization, and writer shutdown
- record the exported API documentation standard in AGENTS.md

## Validation

- exported declaration documentation audit: pass
- gofmt and git diff --check: pass
- go test ./...: pass
- go vet ./...: pass