### PR TITLE
Route ARM and DISARM to active Agent sessions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/bigquery v1.71.0
 	cloud.google.com/go/storage v1.57.0
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.10.0
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260812020348-1f8a6730b3ee
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260817050509-7f9124ee65fd
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/bluenviron/gomavlib/v2 v2.2.0
 	github.com/elastic/go-elasticsearch/v8 v8.15.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/bigquery v1.71.0
 	cloud.google.com/go/storage v1.57.0
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.10.0
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260812020348-1f8a6730b3ee
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260817042625-1168c254a092
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/bluenviron/gomavlib/v2 v2.2.0
 	github.com/elastic/go-elasticsearch/v8 v8.15.0

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMz
 github.com/actgardner/gogen-avro/v10 v10.1.0/go.mod h1:o+ybmVjEa27AAr35FRqU98DJu1fXES56uXniYFv4yDA=
 github.com/actgardner/gogen-avro/v10 v10.2.1/go.mod h1:QUhjeHPchheYmMDni/Nx7VB0RsT/ee8YIgGY/xpEQgQ=
 github.com/actgardner/gogen-avro/v9 v9.1.0/go.mod h1:nyTj6wPqDJoxM3qdnjcLv+EnMDSDFqE0qDpva2QRmKc=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260812020348-1f8a6730b3ee h1:NX2tsjSjrrUVPvH43fbyq9TAxUdMiqDVykkc7UaKTlo=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260812020348-1f8a6730b3ee/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260817050509-7f9124ee65fd h1:39SaVLyvowCAJFmSLPXpnJ04uPLlGko7z4tUY0423e4=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260817050509-7f9124ee65fd/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMz
 github.com/actgardner/gogen-avro/v10 v10.1.0/go.mod h1:o+ybmVjEa27AAr35FRqU98DJu1fXES56uXniYFv4yDA=
 github.com/actgardner/gogen-avro/v10 v10.2.1/go.mod h1:QUhjeHPchheYmMDni/Nx7VB0RsT/ee8YIgGY/xpEQgQ=
 github.com/actgardner/gogen-avro/v9 v9.1.0/go.mod h1:nyTj6wPqDJoxM3qdnjcLv+EnMDSDFqE0qDpva2QRmKc=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260812020348-1f8a6730b3ee h1:NX2tsjSjrrUVPvH43fbyq9TAxUdMiqDVykkc7UaKTlo=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260812020348-1f8a6730b3ee/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260817042625-1168c254a092 h1:s39r5ktr4/mKXCBNdPfshs+V2UL6bDHOWkjlYMG90f4=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260817042625-1168c254a092/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/internal/relay/aircraft_command_test.go
+++ b/internal/relay/aircraft_command_test.go
@@ -1,0 +1,114 @@
+package relay
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
+	relayv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestSendAircraftCommandDeliversToConnectedAgentAndCorrelatesResult(t *testing.T) {
+	stream := &mockTelemetryStream{
+		ctx:         context.Background(),
+		sentAckChan: make(chan *agentv1.RelayStreamMessage, 1),
+	}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream:          &telemetryStreamBinding{stream: stream},
+		pendingAircraft: make(map[string]chan *agentv1.AircraftCommandResult),
+	}
+	relay := &Relay{grpcSessions: map[string]*DroneSession{"agent-1": session}}
+	command := &agentv1.AircraftCommand{
+		CommandId: "command-1", AircraftId: "aircraft-1",
+		Type: agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_ARM,
+	}
+
+	type outcome struct {
+		response *relayv1.SendAircraftCommandResponse
+		err      error
+	}
+	completed := make(chan outcome, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	go func() {
+		response, err := relay.SendAircraftCommand(ctx, &relayv1.SendAircraftCommandRequest{
+			AgentId: "agent-1", Command: command,
+		})
+		completed <- outcome{response: response, err: err}
+	}()
+
+	select {
+	case message := <-stream.sentAckChan:
+		if got := message.GetAircraftCommand(); got.GetCommandId() != command.GetCommandId() || got.GetAircraftId() != command.GetAircraftId() {
+			t.Fatalf("delivered command = %+v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for command delivery")
+	}
+
+	wantResult := &agentv1.AircraftCommandResult{
+		CommandId: "command-1", AircraftId: "aircraft-1",
+		Status: agentv1.AircraftCommandResult_STATUS_ACCEPTED,
+	}
+	session.handleAircraftCommandResult(wantResult)
+	select {
+	case got := <-completed:
+		if got.err != nil {
+			t.Fatal(got.err)
+		}
+		if got.response.GetResult() != wantResult {
+			t.Fatalf("result = %+v", got.response.GetResult())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for correlated command result")
+	}
+}
+
+func TestSendAircraftCommandRejectsDisconnectedAgent(t *testing.T) {
+	relay := &Relay{grpcSessions: make(map[string]*DroneSession)}
+	_, err := relay.SendAircraftCommand(context.Background(), &relayv1.SendAircraftCommandRequest{
+		AgentId: "agent-1",
+		Command: &agentv1.AircraftCommand{
+			CommandId: "command-1", AircraftId: "aircraft-1",
+			Type: agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_ARM,
+		},
+	})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("error = %v, want NotFound", err)
+	}
+}
+
+func TestSendAircraftCommandDeadlineCleansPendingCorrelation(t *testing.T) {
+	stream := &mockTelemetryStream{
+		ctx:         context.Background(),
+		sentAckChan: make(chan *agentv1.RelayStreamMessage, 1),
+	}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream:          &telemetryStreamBinding{stream: stream},
+		pendingAircraft: make(map[string]chan *agentv1.AircraftCommandResult),
+	}
+	relay := &Relay{grpcSessions: map[string]*DroneSession{"agent-1": session}}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	_, err := relay.SendAircraftCommand(ctx, &relayv1.SendAircraftCommandRequest{
+		AgentId: "agent-1",
+		Command: &agentv1.AircraftCommand{
+			CommandId: "command-1", AircraftId: "aircraft-1",
+			Type: agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_DISARM,
+		},
+	})
+	if status.Code(err) != codes.DeadlineExceeded {
+		t.Fatalf("error = %v, want DeadlineExceeded", err)
+	}
+	session.pendingMu.Lock()
+	_, stillPending := session.pendingAircraft["command-1"]
+	session.pendingMu.Unlock()
+	if stillPending {
+		t.Fatal("expired command remained pending")
+	}
+}

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -13,7 +13,9 @@ package relay
 
 import (
 	"context"
+	"log/slog"
 	"strings"
+	"time"
 
 	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
 	pb "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
@@ -95,6 +97,118 @@ func (*Relay) SetOperationContext(context.Context, *pb.SetOperationContextReques
 //   - error: is a gRPC Unimplemented status explaining the security gate.
 func (*Relay) ClearOperationContext(context.Context, *pb.ClearOperationContextRequest) (*pb.ClearOperationContextResponse, error) {
 	return nil, status.Error(codes.Unimplemented, operationContextControlDisabled)
+}
+
+// SendAircraftCommand delivers an immediate ARM or DISARM command to the
+// Agent session active at RPC admission and waits for its correlated result.
+// The command is never queued for a later or replacement session.
+//
+// Parameters:
+//   - ctx: bounds delivery and the wait for the Agent/autopilot result.
+//   - req: identifies the Agent route and carries the aircraft command envelope.
+//
+// Returns:
+//   - response: contains the Agent's correlated autopilot-level result.
+//   - error: reports invalid input, an offline/replaced Agent session, stream
+//     delivery failure, deadline expiry, or a malformed Agent result.
+func (s *Relay) SendAircraftCommand(ctx context.Context, req *pb.SendAircraftCommandRequest) (*pb.SendAircraftCommandResponse, error) {
+	agentID := strings.TrimSpace(req.GetAgentId())
+	command := req.GetCommand()
+	if agentID == "" || command == nil || strings.TrimSpace(command.GetCommandId()) == "" || strings.TrimSpace(command.GetAircraftId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "agent_id, command_id, and aircraft_id are required")
+	}
+	if command.GetType() != agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_ARM &&
+		command.GetType() != agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_DISARM {
+		return nil, status.Error(codes.InvalidArgument, "aircraft command type must be ARM or DISARM")
+	}
+
+	s.sessionsMu.RLock()
+	session := s.grpcSessions[agentID]
+	s.sessionsMu.RUnlock()
+	if session == nil {
+		return nil, status.Error(codes.NotFound, "agent is not connected")
+	}
+
+	// Pin this exact session generation through result correlation. Registration
+	// replacement and stream cleanup require the write side of this lease, so an
+	// admitted command cannot migrate to a reconnecting Agent.
+	session.ownershipMu.RLock()
+	defer session.ownershipMu.RUnlock()
+	s.sessionsMu.RLock()
+	current := s.grpcSessions[agentID] == session && !session.retired
+	s.sessionsMu.RUnlock()
+	if !current {
+		return nil, status.Error(codes.NotFound, "agent session is no longer active")
+	}
+	session.sessionMu.RLock()
+	connected := session.stream != nil
+	sessionID := session.SessionID
+	session.sessionMu.RUnlock()
+	if !connected {
+		return nil, status.Error(codes.NotFound, "agent stream is not connected")
+	}
+
+	startedAt := time.Now()
+	slog.LogAttrs(ctx, slog.LevelInfo, "command_delivered_to_agent",
+		slog.String("command_id", command.GetCommandId()),
+		slog.String("aircraft_id", command.GetAircraftId()),
+		slog.String("agent_id", agentID),
+		slog.String("session_id", sessionID),
+		slog.String("command_type", command.GetType().String()),
+	)
+	result, err := deliverAircraftCommandToSession(ctx, session, command)
+	if err != nil {
+		relayAircraftCommandsTotal.WithLabelValues(command.GetType().String(), "delivery_failed").Inc()
+		return nil, err
+	}
+	if result.GetCommandId() != command.GetCommandId() || result.GetAircraftId() != command.GetAircraftId() {
+		return nil, status.Error(codes.Internal, "agent returned a mismatched aircraft command result")
+	}
+	duration := time.Since(startedAt)
+	relayAircraftCommandsTotal.WithLabelValues(command.GetType().String(), result.GetStatus().String()).Inc()
+	relayAircraftCommandDuration.WithLabelValues(command.GetType().String()).Observe(duration.Seconds())
+	slog.LogAttrs(ctx, slog.LevelInfo, "command_completed",
+		slog.String("command_id", command.GetCommandId()),
+		slog.String("aircraft_id", command.GetAircraftId()),
+		slog.String("agent_id", agentID),
+		slog.String("session_id", sessionID),
+		slog.String("command_type", command.GetType().String()),
+		slog.String("result", result.GetStatus().String()),
+		slog.Duration("duration", duration),
+	)
+	return &pb.SendAircraftCommandResponse{Result: result}, nil
+}
+
+func deliverAircraftCommandToSession(ctx context.Context, session *DroneSession, command *agentv1.AircraftCommand) (*agentv1.AircraftCommandResult, error) {
+	pending := make(chan *agentv1.AircraftCommandResult, 1)
+	session.pendingMu.Lock()
+	if session.pendingAircraft == nil {
+		session.pendingAircraft = make(map[string]chan *agentv1.AircraftCommandResult)
+	}
+	if _, exists := session.pendingAircraft[command.GetCommandId()]; exists {
+		session.pendingMu.Unlock()
+		return nil, status.Error(codes.AlreadyExists, "aircraft command is already pending")
+	}
+	session.pendingAircraft[command.GetCommandId()] = pending
+	session.pendingMu.Unlock()
+	cleanup := func() {
+		session.pendingMu.Lock()
+		delete(session.pendingAircraft, command.GetCommandId())
+		session.pendingMu.Unlock()
+	}
+	if err := sendToSession(ctx, session, &agentv1.RelayStreamMessage{
+		Payload: &agentv1.RelayStreamMessage_AircraftCommand{AircraftCommand: command},
+	}); err != nil {
+		cleanup()
+		return nil, err
+	}
+	select {
+	case result := <-pending:
+		return result, nil
+	case <-ctx.Done():
+		cleanup()
+		return nil, status.FromContextError(ctx.Err()).Err()
+	}
 }
 
 // deliverOperationCommandToSession is experimental command-delivery machinery.

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -49,15 +49,16 @@ func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*ag
 		return nil, status.Errorf(codes.Internal, "generate session ID: %v", err)
 	}
 	newSession := &DroneSession{
-		agentID:       agentID,
-		SessionID:     sessionID,
-		ConnectedAt:   time.Now(),
-		LastHeartbeat: time.Now(),
-		Position:      nil,
-		Attitude:      nil,
-		VfrHud:        nil,
-		SystemStatus:  nil,
-		pending:       make(map[string]chan *agentv1.OperationContextCommandAck),
+		agentID:         agentID,
+		SessionID:       sessionID,
+		ConnectedAt:     time.Now(),
+		LastHeartbeat:   time.Now(),
+		Position:        nil,
+		Attitude:        nil,
+		VfrHud:          nil,
+		SystemStatus:    nil,
+		pending:         make(map[string]chan *agentv1.OperationContextCommandAck),
+		pendingAircraft: make(map[string]chan *agentv1.AircraftCommandResult),
 	}
 
 	// Retire the previous session before publishing its replacement. Do not hold
@@ -166,6 +167,10 @@ func (r *Relay) TelemetryStream(stream agentv1.AgentGateway_TelemetryStreamServe
 
 		if commandAck := message.GetOperationContextCommandAck(); commandAck != nil {
 			streamSession.handleOperationContextCommandAck(commandAck)
+			continue
+		}
+		if commandResult := message.GetAircraftCommandResult(); commandResult != nil {
+			streamSession.handleAircraftCommandResult(commandResult)
 			continue
 		}
 		frame := message.GetTelemetryFrame()
@@ -325,6 +330,25 @@ func (session *DroneSession) handleOperationContextCommandAck(ack *agentv1.Opera
 	}
 	select {
 	case pending <- ack:
+	default:
+	}
+}
+
+func (session *DroneSession) handleAircraftCommandResult(result *agentv1.AircraftCommandResult) {
+	if session == nil || result == nil {
+		return
+	}
+	session.pendingMu.Lock()
+	pending := session.pendingAircraft[result.GetCommandId()]
+	if pending != nil {
+		delete(session.pendingAircraft, result.GetCommandId())
+	}
+	session.pendingMu.Unlock()
+	if pending == nil {
+		return
+	}
+	select {
+	case pending <- result:
 	default:
 	}
 }

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -96,6 +96,7 @@ type DroneSession struct {
 	sessionMu        sync.RWMutex
 	pendingMu        sync.Mutex
 	pending          map[string]chan *agentv1.OperationContextCommandAck
+	pendingAircraft  map[string]chan *agentv1.AircraftCommandResult
 	ownershipMu      sync.RWMutex
 	publicationMu    sync.Mutex
 	retired          bool
@@ -157,6 +158,16 @@ var (
 		Name: "aero_relay_sink_errors_total",
 		Help: "Errors returned while forwarding telemetry to sinks.",
 	}, []string{"sink"})
+
+	relayAircraftCommandsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "aero_relay_aircraft_commands_total",
+		Help: "Immediate aircraft commands handled by the relay.",
+	}, []string{"command_type", "result"})
+
+	relayAircraftCommandDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "aero_relay_aircraft_command_duration_seconds",
+		Help: "Time from Relay command receipt to Agent result.",
+	}, []string{"command_type"})
 )
 
 // New validates Agent authentication requirements and constructs a Relay with


### PR DESCRIPTION
## Summary

Adds the Relay transport/routing portion of the ARM/DISARM command vertical slice defined by [aero-arc-protos#10](https://github.com/Aero-Arc/aero-arc-protos/pull/10).

- implements `RelayControl.SendAircraftCommand`
- resolves the currently connected Agent session in the existing per-Agent session map
- writes the typed command onto the existing bidirectional Agent stream
- correlates `AircraftCommandResult` by `command_id`
- returns the Agent/autopilot terminal result to the API caller
- adds command counters, duration metrics, and structured lifecycle logs

## Session safety

- no active Agent stream returns gRPC `NotFound`
- the admitted session generation is pinned until the result or deadline
- a reconnect cannot receive a command admitted for an older session
- commands are never persisted, queued, broadcast, or redelivered after reconnect
- the Relay does not translate or interpret MAVLink

## Tests

- `go test -p 1 ./...`
- focused coverage for connected delivery, disconnected Agent, result correlation, and deadline cleanup

## Manual end-to-end SITL test

This was exercised with the real locally built ArduCopter SITL executable, not a mocked MAVLink server. Feature binaries for Registry, Relay, Agent, and API were run together with this topology:

```text
ArduCopter SERIAL0 ──UDP :14550──> Agent ──gRPC──> Relay :15052
                                             │
                                      Registry :15051
                                             │
                                          API :18080

Independent verifier ──TCP :5762──> ArduCopter SERIAL1
```

From the ArduPilot repository, SITL was started with:

```bash
build/sitl/bin/arducopter \
  --model quad \
  --wipe \
  --home 41.8781,-87.6298,180,0 \
  --serial0 udpclient:127.0.0.1:14550 \
  --defaults Tools/autotest/default_params/copter.parm
```

The Relay used the in-memory Registry at `127.0.0.1:15051`, listened at `127.0.0.1:15052`, advertised itself as `relay-sitl`, authenticated one temporary Agent identity, and had telemetry outputs disabled for this command-path test. Registry logs confirmed the Agent placement on `relay-sitl` before commands were issued.

After creating `aircraft-sitl` with its durable `agent_id` set to the registered Agent identity, ARM was issued through the API:

```bash
curl --fail-with-body --silent --show-error -X POST \
  http://127.0.0.1:18080/api/v1/aircraft/aircraft-sitl/commands/arm
```

The API returned `status: accepted`. Relay logs recorded `command_delivered_to_agent` and `command_completed` with the same command ID, aircraft ID, Agent ID, exact session ID, command type, `STATUS_ACCEPTED`, and duration.

Actual vehicle state was verified independently through SITL's `SERIAL1` port using `pymavlink`, checking `MAV_MODE_FLAG_SAFETY_ARMED` in autopilot heartbeats:

```python
from pymavlink import mavutil

m = mavutil.mavlink_connection("tcp:127.0.0.1:5762")
heartbeat = m.wait_heartbeat(timeout=10)
armed = bool(heartbeat.base_mode & mavutil.mavlink.MAV_MODE_FLAG_SAFETY_ARMED)
print(f"armed={armed}")
```

The observer transitioned from `armed=False` to `armed=True`. DISARM was then issued through `/commands/disarm`; the Relay correlated the result on the same active session, the API returned `accepted`, and the observer transitioned from `armed=True` to `armed=False`.

ArduCopter's default idle auto-disarm behavior means state verification must happen immediately after ARM; a delayed heartbeat check may correctly observe the later automatic disarm.

Failure paths were also exercised:

- SITL stopped while Agent remained connected: Relay delivered the command, and the Agent returned terminal `STATUS_TIMEOUT` after the five-second MAVLink ACK bound.
- Agent stopped: Relay returned gRPC `NotFound`, surfaced by the API as HTTP 409 `AIRCRAFT_NOT_CONNECTED`; no command was retained for reconnect.

## Dependency

- [aero-arc-protos#10](https://github.com/Aero-Arc/aero-arc-protos/pull/10) — merged; this branch pins its merged commit
