### PR TITLE
Carry canonical WAL cursor identity through Relay telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ The relay uses a unified `TelemetryEnvelope` format for all messages:
   "timestamp_device": 1705315800.123,
   "msg_id": 0,
   "msg_name": "Heartbeat",
+  "wal_id": "0195f6a8-86d1-7be7-a104-3a814dc19f9e",
+  "wal_sequence": 42,
   "system_id": 1,
   "component_id": 1,
   "sequence": 42,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -66,9 +66,9 @@ this additive contract in this order:
 3. After every Agent that may connect sends `wal_id`, deploy Relays that
    validate and persist it with normalized telemetry.
 
-An upgraded Relay validates the WAL UUID at gateway admission before message
-filtering or dispatch to normalized, no-op, or generic outputs. Missing or
-malformed identities receive a permanent-error ACK; only a valid cursor can
+An upgraded Relay validates the non-nil WAL UUID at gateway admission before
+message filtering or dispatch to normalized, no-op, or generic outputs. Missing
+or malformed identities receive a permanent-error ACK; only a valid cursor can
 receive `STATUS_OK` and be discarded from the Agent WAL.
 
 Schema version 1 deliberately retains its deployed capture-time-based

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -57,8 +57,10 @@ unknown field.
 
 ### WAL Generation Identity Rollout
 
-Telemetry frames now carry the Agent WAL database's generation UUID. Roll out
-this additive contract in this order:
+Telemetry frames now carry the Agent WAL append-generation UUID. A successful
+Agent WAL open rotates the generation for newly captured frames, while frames
+already persisted keep the generation they received before their first durable
+write. Roll out this additive contract in this order:
 
 1. Merge and publish the Protos revision containing `TelemetryFrame.wal_id`.
 2. Deploy Agents that persist and send the WAL generation UUID, while the Relay

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -66,6 +66,11 @@ this additive contract in this order:
 3. After every Agent that may connect sends `wal_id`, deploy Relays that
    validate and persist it with normalized telemetry.
 
+An upgraded Relay validates the WAL UUID at gateway admission before message
+filtering or dispatch to normalized, no-op, or generic outputs. Missing or
+malformed identities receive a permanent-error ACK; only a valid cursor can
+receive `STATUS_OK` and be discarded from the Agent WAL.
+
 Schema version 1 deliberately retains its deployed capture-time-based
 `frame_id` formula throughout this rollout. If an upgraded Agent loses an ACK
 from an old Relay and retries after connecting to an upgraded Relay, both

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -54,3 +54,28 @@ that omits the owner field. Roll back Registry owner enforcement first, or use a
 coordinated rollback, then roll back Relay. Rolling back Registry while Relays
 remain updated is wire-compatible because the older Registry ignores the
 unknown field.
+
+### WAL Generation Identity Rollout
+
+Telemetry frames now carry the Agent WAL database's generation UUID. Roll out
+this additive contract in this order:
+
+1. Merge and publish the Protos revision containing `TelemetryFrame.wal_id`.
+2. Deploy Agents that persist and send the WAL generation UUID, while the Relay
+   fleet still accepts the additive field without depending on it.
+3. After all connected Agents send `wal_id`, deploy Relays that validate and
+   persist it with normalized telemetry.
+
+Schema version 1 deliberately retains its deployed capture-time-based
+`frame_id` formula throughout this rollout. If an upgraded Agent loses an ACK
+from an old Relay and retries after connecting to an upgraded Relay, both
+Relays therefore select the same InfluxDB point identity. `wal_id` is stored as
+a field for cursor inspection and replay ordering; it does not alter the
+version 1 point identity.
+
+Do not change the version 1 `frame_id` formula to include `wal_id`. A future
+WAL-based formula requires a new normalized schema version and a coordinated
+drain: stop admission, allow every Agent WAL entry accepted by the old Relay
+fleet to receive its ACK, verify no in-flight version 1 retries remain, deploy
+the new Relay fleet, and then resume admission. Without that drain, a retry can
+be written once under each formula.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -69,7 +69,8 @@ this additive contract in this order:
 An upgraded Relay validates the non-nil WAL UUID at gateway admission before
 message filtering or dispatch to normalized, no-op, or generic outputs. Missing
 or malformed identities receive a permanent-error ACK; only a valid cursor can
-receive `STATUS_OK` and be discarded from the Agent WAL.
+receive `STATUS_OK` and be discarded from the Agent WAL. Accepted UUIDs are
+canonicalized to lowercase hyphenated text before routing and persistence.
 
 Schema version 1 deliberately retains its deployed capture-time-based
 `frame_id` formula throughout this rollout. If an upgraded Agent loses an ACK

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -63,15 +63,17 @@ this additive contract in this order:
 1. Merge and publish the Protos revision containing `TelemetryFrame.wal_id`.
 2. Deploy Agents that persist and send the WAL generation UUID, while the Relay
    fleet still accepts the additive field without depending on it.
-3. After all connected Agents send `wal_id`, deploy Relays that validate and
-   persist it with normalized telemetry.
+3. After every Agent that may connect sends `wal_id`, deploy Relays that
+   validate and persist it with normalized telemetry.
 
 Schema version 1 deliberately retains its deployed capture-time-based
 `frame_id` formula throughout this rollout. If an upgraded Agent loses an ACK
 from an old Relay and retries after connecting to an upgraded Relay, both
-Relays therefore select the same InfluxDB point identity. `wal_id` is stored as
-a field for cursor inspection and replay ordering; it does not alter the
-version 1 point identity.
+Relays therefore select the same InfluxDB point identity. Upgraded Relays store
+`wal_id` as a field for cursor inspection and replay ordering; it does not alter
+the version 1 point identity. Existing version 1 points and points written by
+old Relays do not contain this field and remain valid. Record consumers must
+treat a missing `wal_id` as legacy version 1 data, not as corruption.
 
 Do not change the version 1 `frame_id` formula to include `wal_id`. A future
 WAL-based formula requires a new normalized schema version and a coordinated

--- a/docs/images/telemetry-identity-authority.svg
+++ b/docs/images/telemetry-identity-authority.svg
@@ -134,7 +134,7 @@
   <text class="text authority" x="1060" y="758">Authority · Telemetry ingestion contract</text>
   <text class="muted small" x="1060" y="789">Created when a frame is written to the Agent WAL.</text>
   <text class="text body" x="1060" y="825">First-slice stable idempotency key:</text>
-  <text class="text authority" x="1060" y="854">agent_id + durable WAL sequence</text>
+  <text class="text authority" x="1060" y="854">agent_id + capture time + WAL sequence</text>
   <text class="text body" x="1060" y="884">Unchanged across resend and reconnect.</text>
   <text class="muted body" x="1060" y="915">Session and optional context attribute the record;</text>
   <text class="muted body" x="1060" y="935">frame identity remains retry-stable.</text>

--- a/docs/normalized-telemetry-record.md
+++ b/docs/normalized-telemetry-record.md
@@ -124,16 +124,21 @@ invented placeholders.
 unambiguous encoding of:
 
 ```text
-agent_id + WAL generation ID + durable agent WAL sequence
+agent_id + agent capture Unix nanoseconds + durable agent WAL sequence
 ```
 
 The concrete encoding must be stable, documented, and collision-safe. A
 length-delimited or escaped encoding is required; raw concatenation is not.
-Resending the same WAL entry produces the same `frame_id`. The WAL generation
-ID is a UUID stored in the Agent's WAL database: it survives process restarts
-and changes when the database is recreated. It therefore prevents a reset WAL
-sequence from reusing an idempotency key. A future explicit frame UUID may
-replace this derived encoding in a new transport contract.
+Resending the same WAL entry produces the same `frame_id`.
+
+The capture timestamp is persisted in the frame before WAL insertion and is
+stable across retry. Combining it with the WAL sequence prevents ordinary WAL
+recreation from reusing an idempotency key. This version 1 formula is retained
+while WAL generation identity rolls through the Agent and Relay fleet; changing
+it in place would let an entry persisted by an old Relay and retried through a
+new Relay create two InfluxDB points. A future schema version may use the WAL
+generation ID in the point identity only after a coordinated drain of in-flight
+version 1 entries.
 
 `wal_id` is the Agent WAL generation identity. It is required and must not be
 derived from a process, Relay session, SQLite row ID, or MAVLink packet.
@@ -319,7 +324,7 @@ For InfluxDB, measurement, tag set, and timestamp form the point identity. All
 records therefore use the stable `aircraft_telemetry` measurement, and only
 frame-invariant values (`frame_id`, `agent_id`, `message_name`, and
 `schema_version`) are tags. This keeps retries idempotent while ensuring frames
-with the same capture timestamp and different WAL cursors remain distinct.
+with the same capture timestamp and different WAL sequences remain distinct.
 Retry-variable relay, session, assignment, flight, and intent metadata remain
 queryable fields. `wal_id` and `wal_sequence` remain fields for replay ordering,
 inspection, and diagnostics.

--- a/docs/normalized-telemetry-record.md
+++ b/docs/normalized-telemetry-record.md
@@ -124,17 +124,19 @@ invented placeholders.
 unambiguous encoding of:
 
 ```text
-agent_id + agent capture Unix nanoseconds + durable agent WAL sequence
+agent_id + WAL generation ID + durable agent WAL sequence
 ```
 
 The concrete encoding must be stable, documented, and collision-safe. A
 length-delimited or escaped encoding is required; raw concatenation is not.
-Resending the same WAL entry produces the same `frame_id`.
-
-The capture timestamp is persisted in the frame before WAL insertion and is
-stable across retry. Combining it with the WAL sequence prevents ordinary WAL
-recreation from reusing an idempotency key. A future explicit frame UUID may
+Resending the same WAL entry produces the same `frame_id`. The WAL generation
+ID is a UUID stored in the Agent's WAL database: it survives process restarts
+and changes when the database is recreated. It therefore prevents a reset WAL
+sequence from reusing an idempotency key. A future explicit frame UUID may
 replace this derived encoding in a new transport contract.
+
+`wal_id` is the Agent WAL generation identity. It is required and must not be
+derived from a process, Relay session, SQLite row ID, or MAVLink packet.
 
 `sequence` is the agent WAL sequence carried by the frame. It is required and
 must not be replaced with the MAVLink packet sequence.
@@ -188,9 +190,9 @@ The first slice normally selects `agent_capture`. A boot-relative timestamp is
 never interpreted directly as Unix time.
 
 The current agent transport requires a positive `sent_at_unix_ns` on every WAL
-frame because it is also part of the stable `frame_id`. Frames without it are
-rejected permanently before normalization; relay receive time is not substituted
-into the idempotency key.
+frame so event-time evaluation and replay retain the durable capture instant.
+Frames without it are rejected permanently before normalization; relay receive
+time is not substituted for missing capture evidence.
 
 `relay_time` is always required and records when the relay accepted the source
 frame.
@@ -285,7 +287,7 @@ Every normalized record must satisfy all of the following:
 1. It represents exactly one input telemetry frame and one canonical MAVLink
    message.
 2. `schema_version`, `agent_id`, `relay_id`, `session_id`, `frame_id`,
-   `sequence`, `message_id`, `message_name`, `dialect`, `event_time`,
+   `wal_id`, `sequence`, `message_id`, `message_name`, `dialect`, `event_time`,
    `relay_time`, and `timestamp_source` are present and valid.
 3. `frame_id` remains stable across retry and reconnect and does not collide
    after WAL recreation.
@@ -317,10 +319,10 @@ For InfluxDB, measurement, tag set, and timestamp form the point identity. All
 records therefore use the stable `aircraft_telemetry` measurement, and only
 frame-invariant values (`frame_id`, `agent_id`, `message_name`, and
 `schema_version`) are tags. This keeps retries idempotent while ensuring frames
-with the same capture timestamp and different WAL sequences remain distinct.
+with the same capture timestamp and different WAL cursors remain distinct.
 Retry-variable relay, session, assignment, flight, and intent metadata remain
-queryable fields. `wal_sequence` also remains a field for inspection and
-diagnostics.
+queryable fields. `wal_id` and `wal_sequence` remain fields for replay ordering,
+inspection, and diagnostics.
 
 ## API relationship
 

--- a/docs/normalized-telemetry-record.md
+++ b/docs/normalized-telemetry-record.md
@@ -53,6 +53,7 @@ type IdentityContext struct {
 
 type SourceContext struct {
 	FrameID     string
+	WALID       string
 	Sequence    uint64
 	MessageID   uint32
 	Dialect     string
@@ -140,8 +141,13 @@ new Relay create two InfluxDB points. A future schema version may use the WAL
 generation ID in the point identity only after a coordinated drain of in-flight
 version 1 entries.
 
-`wal_id` is the Agent WAL generation identity. It is required and must not be
-derived from a process, Relay session, SQLite row ID, or MAVLink packet.
+`wal_id` is the Agent WAL generation identity. It is optional in normalized
+schema version 1 so historical records and points written by old Relays during
+the staged rollout remain valid. When present, it must be a valid UUID persisted
+by the Agent's WAL database; it must not be derived from a process, Relay
+session, SQLite row ID, or MAVLink packet. Upgraded Relay transport admission
+requires it from upgraded Agents, but consumers of version 1 records must
+accept its absence.
 
 `sequence` is the agent WAL sequence carried by the frame. It is required and
 must not be replaced with the MAVLink packet sequence.
@@ -292,18 +298,19 @@ Every normalized record must satisfy all of the following:
 1. It represents exactly one input telemetry frame and one canonical MAVLink
    message.
 2. `schema_version`, `agent_id`, `relay_id`, `session_id`, `frame_id`,
-   `wal_id`, `sequence`, `message_id`, `message_name`, `dialect`, `event_time`,
+   `sequence`, `message_id`, `message_name`, `dialect`, `event_time`,
    `relay_time`, and `timestamp_source` are present and valid.
-3. `frame_id` remains stable across retry and reconnect and does not collide
+3. When `wal_id` is present, it is a valid Agent WAL generation UUID.
+4. `frame_id` remains stable across retry and reconnect and does not collide
    after WAL recreation.
-4. Operator, aircraft, flight, and intent identities are authoritative or
+5. Operator, aircraft, flight, and intent identities are authoritative or
    absent; they are never inferred from MAVLink fields.
-5. Fields are approved for the record's message and schema version.
-6. Field values use approved scalar types and documented units.
-7. Invalid sentinel values are not exposed as measurements.
-8. The record contains no generic raw payload and no storage-specific point,
+6. Fields are approved for the record's message and schema version.
+7. Field values use approved scalar types and documented units.
+8. Invalid sentinel values are not exposed as measurements.
+9. The record contains no generic raw payload and no storage-specific point,
    tag, bucket, measurement, or client type.
-9. The normalizer is deterministic for the same envelope and bound identity
+10. The normalizer is deterministic for the same envelope and bound identity
    and timing context.
 
 ## Backend responsibilities
@@ -326,8 +333,9 @@ frame-invariant values (`frame_id`, `agent_id`, `message_name`, and
 `schema_version`) are tags. This keeps retries idempotent while ensuring frames
 with the same capture timestamp and different WAL sequences remain distinct.
 Retry-variable relay, session, assignment, flight, and intent metadata remain
-queryable fields. `wal_id` and `wal_sequence` remain fields for replay ordering,
-inspection, and diagnostics.
+queryable fields. `wal_sequence` remains a field for inspection and diagnostics.
+When available, `wal_id` is also written as a field for replay ordering and
+cursor diagnostics; the backend omits it for legacy version 1 records.
 
 ## API relationship
 

--- a/docs/normalized-telemetry-record.md
+++ b/docs/normalized-telemetry-record.md
@@ -143,11 +143,11 @@ version 1 entries.
 
 `wal_id` is the Agent WAL generation identity. It is optional in normalized
 schema version 1 so historical records and points written by old Relays during
-the staged rollout remain valid. When present, it must be a valid UUID persisted
-by the Agent's WAL database; it must not be derived from a process, Relay
-session, SQLite row ID, or MAVLink packet. Upgraded Relay transport admission
-requires it from upgraded Agents, but consumers of version 1 records must
-accept its absence.
+the staged rollout remain valid. When present, it must be a valid, non-nil UUID
+persisted by the Agent's WAL database; it must not be derived from a process,
+Relay session, SQLite row ID, or MAVLink packet. Upgraded Relay transport
+admission requires it from upgraded Agents, but consumers of version 1 records
+must accept its absence.
 
 `sequence` is the agent WAL sequence carried by the frame. It is required and
 must not be replaced with the MAVLink packet sequence.
@@ -300,7 +300,7 @@ Every normalized record must satisfy all of the following:
 2. `schema_version`, `agent_id`, `relay_id`, `session_id`, `frame_id`,
    `sequence`, `message_id`, `message_name`, `dialect`, `event_time`,
    `relay_time`, and `timestamp_source` are present and valid.
-3. When `wal_id` is present, it is a valid Agent WAL generation UUID.
+3. When `wal_id` is present, it is a valid, non-nil Agent WAL generation UUID.
 4. `frame_id` remains stable across retry and reconnect and does not collide
    after WAL recreation.
 5. Operator, aircraft, flight, and intent identities are authoritative or

--- a/docs/normalized-telemetry-record.md
+++ b/docs/normalized-telemetry-record.md
@@ -141,15 +141,17 @@ new Relay create two InfluxDB points. A future schema version may use the WAL
 generation ID in the point identity only after a coordinated drain of in-flight
 version 1 entries.
 
-`wal_id` is the Agent WAL generation identity. It is optional in normalized
-schema version 1 so historical records and points written by old Relays during
-the staged rollout remain valid. When present, it must be a valid, non-nil UUID
-persisted by the Agent's WAL database; it must not be derived from a process,
-Relay session, SQLite row ID, or MAVLink packet. Upgraded Relay transport
-admission requires it from upgraded Agents, but consumers of version 1 records
-must accept its absence. Relays canonicalize accepted values to the lowercase,
-hyphenated UUID representation before routing or persistence so equivalent text
-representations cannot split cursor checkpoints.
+`wal_id` is the Agent WAL append-generation identity. It is optional in
+normalized schema version 1 so historical records and points written by old
+Relays during the staged rollout remain valid. When present, it must be a valid,
+non-nil UUID stamped into the frame before its first durable write. A successful
+WAL open rotates the generation for new capture, while persisted frames retain
+their original generation on retry; the value must not be derived from a
+process, Relay session, SQLite row ID, or MAVLink packet. Upgraded Relay
+transport admission requires it from upgraded Agents, but consumers of version
+1 records must accept its absence. Relays canonicalize accepted values to the
+lowercase, hyphenated UUID representation before routing or persistence so
+equivalent text representations cannot split cursor checkpoints.
 
 `sequence` is the agent WAL sequence carried by the frame. It is required and
 must not be replaced with the MAVLink packet sequence.

--- a/docs/normalized-telemetry-record.md
+++ b/docs/normalized-telemetry-record.md
@@ -147,7 +147,9 @@ the staged rollout remain valid. When present, it must be a valid, non-nil UUID
 persisted by the Agent's WAL database; it must not be derived from a process,
 Relay session, SQLite row ID, or MAVLink packet. Upgraded Relay transport
 admission requires it from upgraded Agents, but consumers of version 1 records
-must accept its absence.
+must accept its absence. Relays canonicalize accepted values to the lowercase,
+hyphenated UUID representation before routing or persistence so equivalent text
+representations cannot split cursor checkpoints.
 
 `sequence` is the agent WAL sequence carried by the frame. It is required and
 must not be replaced with the MAVLink packet sequence.

--- a/docs/telemetry-identity-authority.md
+++ b/docs/telemetry-identity-authority.md
@@ -84,6 +84,21 @@ identity must not override the server-resolved operator or aircraft identity.
 Flight and intent context may be added from an authoritative assignment, but
 must never be guessed from MAVLink fields.
 
+## Telemetry cursor and point identity
+
+The Agent owns the durable telemetry cursor. Its WAL rotates a fresh `wal_id`
+append generation on every successful open and stamps it into new frames before
+their first durable write. `seq` is monotonic only within that generation, so
+the transport cursor is `(wal_id, seq)`. Persisted frames retain the same pair
+through retry, reconnect, spool recovery, and process restart.
+
+The Relay separately owns the normalized point-identity contract. Schema
+version 1 keeps its deployed `frame_id` formula based on `agent_id`, the durable
+Agent capture timestamp, and the WAL sequence. `wal_id` is stored alongside it
+for cursor inspection but does not change version 1 point identity during a
+mixed rollout. Introducing a WAL-based `frame_id` requires a new schema version
+and a coordinated drain of in-flight version 1 retries.
+
 ## Unassigned agents
 
 A supported MAVLink message from an authenticated but unassigned agent is

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,11 @@ require (
 	cloud.google.com/go/bigquery v1.71.0
 	cloud.google.com/go/storage v1.57.0
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.10.0
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260812020348-1f8a6730b3ee
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260823010059-9c3641b684b5
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/bluenviron/gomavlib/v2 v2.2.0
 	github.com/elastic/go-elasticsearch/v8 v8.15.0
+	github.com/google/uuid v1.6.0
 	github.com/influxdata/influxdb-client-go/v2 v2.13.0
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/common v0.55.0
@@ -68,7 +69,6 @@ require (
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/google/flatbuffers v25.2.10+incompatible // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMz
 github.com/actgardner/gogen-avro/v10 v10.1.0/go.mod h1:o+ybmVjEa27AAr35FRqU98DJu1fXES56uXniYFv4yDA=
 github.com/actgardner/gogen-avro/v10 v10.2.1/go.mod h1:QUhjeHPchheYmMDni/Nx7VB0RsT/ee8YIgGY/xpEQgQ=
 github.com/actgardner/gogen-avro/v9 v9.1.0/go.mod h1:nyTj6wPqDJoxM3qdnjcLv+EnMDSDFqE0qDpva2QRmKc=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260812020348-1f8a6730b3ee h1:NX2tsjSjrrUVPvH43fbyq9TAxUdMiqDVykkc7UaKTlo=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260812020348-1f8a6730b3ee/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260823010059-9c3641b684b5 h1:+dfJoWW2FXDq8Pi1ydVKFS4mJEXv5LueEl02jFH/T8M=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260823010059-9c3641b684b5/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/internal/integration/relay_telemetry_integration_test.go
+++ b/internal/integration/relay_telemetry_integration_test.go
@@ -17,6 +17,7 @@ const (
 	testAgentID    = "agent-integration-gpi"
 	testAircraftID = "aircraft-integration-gpi"
 	testRelayID    = "relay-integration"
+	testWALID      = "0195f6a8-86d1-7be7-a104-3a814dc19f9e"
 	testWALSeq     = uint64(424242)
 	testBatchSize  = 8
 )
@@ -125,13 +126,14 @@ func TestRelayTelemetry_NormalizesPersistsQueriesAndFlushesInfluxDB(t *testing.T
 			len(rows), shutdownFrameID, rows,
 		)
 	}
+	assertString(t, rows[0], "wal_id", testWALID)
 	assertUint(t, rows[0], "wal_sequence", shutdownSequence)
 	assertInt(t, rows[0], "agent_capture_time_ns", shutdownCaptureTime.UnixNano())
 }
 
 func batteryStatusFrame(sequence uint64, captureTime time.Time) *agentv1.TelemetryFrame {
 	return &agentv1.TelemetryFrame{
-		Seq: sequence, SentAtUnixNs: captureTime.UnixNano(), Dialect: "common", MsgId: 147, MsgName: "BATTERY_STATUS",
+		WalId: testWALID, Seq: sequence, SentAtUnixNs: captureTime.UnixNano(), Dialect: "common", MsgId: 147, MsgName: "BATTERY_STATUS",
 		Fields: map[string]string{
 			"Id": "0", "BatteryFunction": "MAV_BATTERY_FUNCTION_ALL", "Type": "MAV_BATTERY_TYPE_LIPO",
 			"Temperature": "2534", "Voltages": "[4200,4190,65535,65535]", "VoltagesExt": "[0,0,0,0]",
@@ -144,6 +146,7 @@ func batteryStatusFrame(sequence uint64, captureTime time.Time) *agentv1.Telemet
 
 func globalPositionIntFrame(sequence uint64, captureTime time.Time) *agentv1.TelemetryFrame {
 	return &agentv1.TelemetryFrame{
+		WalId:        testWALID,
 		Seq:          sequence,
 		SentAtUnixNs: captureTime.UnixNano(),
 		Dialect:      "common",
@@ -182,8 +185,8 @@ func sendAndRequireOK(
 	return ack
 }
 
-func frameID(sequence uint64, captureTime time.Time) string {
-	return fmt.Sprintf("%d:%s:%d:%d", len(testAgentID), testAgentID, captureTime.UnixNano(), sequence)
+func frameID(sequence uint64, _ time.Time) string {
+	return fmt.Sprintf("%d:%s:%d:%s:%d", len(testAgentID), testAgentID, len(testWALID), testWALID, sequence)
 }
 
 func frameQuery(frameID, sessionID string) string {
@@ -210,6 +213,7 @@ func assertGlobalPositionIntRow(
 	assertString(t, row, "relay_id", testRelayID)
 	assertString(t, row, "session_id", sessionID)
 	assertString(t, row, "timestamp_source", "agent_capture")
+	assertString(t, row, "wal_id", testWALID)
 	assertString(t, row, "device_time_basis", "system_boot")
 	assertString(t, row, "device_time_unit", "milliseconds")
 
@@ -255,6 +259,7 @@ func assertBatteryStatusRow(
 	assertString(t, row, "aircraft_id", testAircraftID)
 	assertString(t, row, "relay_id", testRelayID)
 	assertString(t, row, "session_id", sessionID)
+	assertString(t, row, "wal_id", testWALID)
 	assertString(t, row, "battery_function", "mav_battery_function_all")
 	assertString(t, row, "battery_type", "mav_battery_type_lipo")
 	assertString(t, row, "battery_charge_state", "mav_battery_charge_state_ok")

--- a/internal/integration/relay_telemetry_integration_test.go
+++ b/internal/integration/relay_telemetry_integration_test.go
@@ -185,8 +185,8 @@ func sendAndRequireOK(
 	return ack
 }
 
-func frameID(sequence uint64, _ time.Time) string {
-	return fmt.Sprintf("%d:%s:%d:%s:%d", len(testAgentID), testAgentID, len(testWALID), testWALID, sequence)
+func frameID(sequence uint64, captureTime time.Time) string {
+	return fmt.Sprintf("%d:%s:%d:%d", len(testAgentID), testAgentID, captureTime.UnixNano(), sequence)
 }
 
 func frameQuery(frameID, sessionID string) string {

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -366,6 +366,7 @@ func (r *Relay) buildTelemetryFrameEnvelope(session *DroneSession, frame *agentv
 		Dialect:         frame.Dialect,
 		MsgID:           frame.MsgId,
 		MsgName:         frame.MsgName,
+		WALID:           frame.WalId,
 		WALSequence:     frame.Seq,
 		Fields:          fields,
 	}

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -176,6 +176,7 @@ func (r *Relay) TelemetryStream(stream agentv1.AgentGateway_TelemetryStreamServe
 		}
 		frameAgentID := strings.TrimSpace(frame.AgentId)
 		frameWALID := strings.TrimSpace(frame.WalId)
+		frameWALUUID, frameWALIDErr := uuid.Parse(frameWALID)
 
 		ack := &agentv1.TelemetryAck{
 			Seq:    frame.Seq,
@@ -206,7 +207,7 @@ func (r *Relay) TelemetryStream(stream agentv1.AgentGateway_TelemetryStreamServe
 		} else if frameWALID == "" {
 			ack.Status = agentv1.TelemetryAck_STATUS_PERMANENT_ERROR
 			ack.Error = "telemetry frame WAL generation ID is required"
-		} else if _, err := uuid.Parse(frameWALID); err != nil {
+		} else if frameWALIDErr != nil || frameWALUUID == uuid.Nil {
 			ack.Status = agentv1.TelemetryAck_STATUS_PERMANENT_ERROR
 			ack.Error = "telemetry frame WAL generation ID is invalid"
 		} else {

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -212,7 +212,7 @@ func (r *Relay) TelemetryStream(stream agentv1.AgentGateway_TelemetryStreamServe
 			ack.Error = "telemetry frame WAL generation ID is invalid"
 		} else {
 			// Process the frame (e.g., forward to outputs).
-			frame.WalId = frameWALID
+			frame.WalId = frameWALUUID.String()
 			streamSession.sessionMu.Lock()
 			streamSession.LastHeartbeat = time.Now().UTC()
 			streamSession.sessionMu.Unlock()

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
+	"github.com/google/uuid"
 	"github.com/makinje/aero-arc-relay/internal/telemetrywriter"
 	"github.com/makinje/aero-arc-relay/pkg/telemetry"
 	"google.golang.org/grpc/codes"
@@ -174,6 +175,7 @@ func (r *Relay) TelemetryStream(stream agentv1.AgentGateway_TelemetryStreamServe
 			continue
 		}
 		frameAgentID := strings.TrimSpace(frame.AgentId)
+		frameWALID := strings.TrimSpace(frame.WalId)
 
 		ack := &agentv1.TelemetryAck{
 			Seq:    frame.Seq,
@@ -201,8 +203,15 @@ func (r *Relay) TelemetryStream(stream agentv1.AgentGateway_TelemetryStreamServe
 		} else if frame.SentAtUnixNs <= 0 {
 			ack.Status = agentv1.TelemetryAck_STATUS_PERMANENT_ERROR
 			ack.Error = "telemetry frame capture timestamp is required"
+		} else if frameWALID == "" {
+			ack.Status = agentv1.TelemetryAck_STATUS_PERMANENT_ERROR
+			ack.Error = "telemetry frame WAL generation ID is required"
+		} else if _, err := uuid.Parse(frameWALID); err != nil {
+			ack.Status = agentv1.TelemetryAck_STATUS_PERMANENT_ERROR
+			ack.Error = "telemetry frame WAL generation ID is invalid"
 		} else {
 			// Process the frame (e.g., forward to outputs).
+			frame.WalId = frameWALID
 			streamSession.sessionMu.Lock()
 			streamSession.LastHeartbeat = time.Now().UTC()
 			streamSession.sessionMu.Unlock()

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -735,11 +735,13 @@ func TestTelemetryStreamValidatesWALGenerationIDBeforeRouting(t *testing.T) {
 		wantStatus    agentv1.TelemetryAck_Status
 		wantError     string
 		wantSinkCount int
+		wantWALID     string
 	}{
 		{name: "unsupported message missing ID", path: "unsupported", wantStatus: agentv1.TelemetryAck_STATUS_PERMANENT_ERROR, wantError: "required"},
 		{name: "unsupported message invalid ID", path: "unsupported", walID: "not-a-uuid", wantStatus: agentv1.TelemetryAck_STATUS_PERMANENT_ERROR, wantError: "invalid"},
 		{name: "unsupported message nil ID", path: "unsupported", walID: nilWALGenerationID, wantStatus: agentv1.TelemetryAck_STATUS_PERMANENT_ERROR, wantError: "invalid"},
-		{name: "unsupported message valid ID", path: "unsupported", walID: testWALGenerationID, wantStatus: agentv1.TelemetryAck_STATUS_OK, wantSinkCount: 1},
+		{name: "unsupported message valid ID", path: "unsupported", walID: testWALGenerationID, wantStatus: agentv1.TelemetryAck_STATUS_OK, wantSinkCount: 1, wantWALID: testWALGenerationID},
+		{name: "unsupported message uppercase ID", path: "unsupported", walID: strings.ToUpper(testWALGenerationID), wantStatus: agentv1.TelemetryAck_STATUS_OK, wantSinkCount: 1, wantWALID: testWALGenerationID},
 		{name: "noop missing ID", path: "noop", wantStatus: agentv1.TelemetryAck_STATUS_PERMANENT_ERROR, wantError: "required"},
 		{name: "noop invalid ID", path: "noop", walID: "not-a-uuid", wantStatus: agentv1.TelemetryAck_STATUS_PERMANENT_ERROR, wantError: "invalid"},
 		{name: "noop nil ID", path: "noop", walID: nilWALGenerationID, wantStatus: agentv1.TelemetryAck_STATUS_PERMANENT_ERROR, wantError: "invalid"},
@@ -794,6 +796,11 @@ func TestTelemetryStreamValidatesWALGenerationIDBeforeRouting(t *testing.T) {
 
 			if genericSink != nil && genericSink.GetMessageCount() != tt.wantSinkCount {
 				t.Fatalf("generic sink count = %d, want %d", genericSink.GetMessageCount(), tt.wantSinkCount)
+			}
+			if genericSink != nil && tt.wantWALID != "" {
+				if got := genericSink.GetMessages()[0].WALID; got != tt.wantWALID {
+					t.Fatalf("routed WAL generation ID = %q, want %q", got, tt.wantWALID)
+				}
 			}
 			close(stream.recvChan)
 			select {

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -68,6 +68,8 @@ func (r *replacementAgentRegistrar) counts() (int, int) {
 
 const testAgentToken = "test-agent-token"
 
+const testWALGenerationID = "0195f6a8-86d1-7be7-a104-3a814dc19f9e"
+
 func relayWithRegistryReporter(t *testing.T, reporter agentRegistryReporter) *Relay {
 	t.Helper()
 	authenticator, err := newAgentTokenAuthenticator(map[string]string{"agent-1": testAgentToken})
@@ -344,7 +346,7 @@ func TestTelemetryStreamFailedReplacementPreservesAcceptedStream(t *testing.T) {
 
 	original.recvChan <- telemetryStreamMessage(&agentv1.TelemetryFrame{
 		AgentId: agentID, SessionId: session.SessionID, Seq: 51,
-		MsgName: "Heartbeat", SentAtUnixNs: time.Now().UnixNano(),
+		MsgName: "Heartbeat", WalId: testWALGenerationID, SentAtUnixNs: time.Now().UnixNano(),
 	})
 	select {
 	case message := <-original.sentAckChan:
@@ -394,7 +396,7 @@ func TestPendingRegistryReplacementDoesNotBlockAcceptedStreamACK(t *testing.T) {
 
 	original.recvChan <- telemetryStreamMessage(&agentv1.TelemetryFrame{
 		AgentId: agentID, SessionId: session.SessionID, Seq: 52,
-		MsgName: "Heartbeat", SentAtUnixNs: time.Now().UnixNano(),
+		MsgName: "Heartbeat", WalId: testWALGenerationID, SentAtUnixNs: time.Now().UnixNano(),
 	})
 	select {
 	case message := <-original.sentAckChan:
@@ -691,7 +693,7 @@ func TestTelemetryStream_ACKReflectsTelemetryAdmissionFailure(t *testing.T) {
 			waitForStreamGeneration(t, session, 1)
 
 			stream.recvChan <- telemetryStreamMessage(&agentv1.TelemetryFrame{
-				AgentId: agentID, SessionId: session.SessionID, Seq: 44, MsgName: "Heartbeat", SentAtUnixNs: time.Now().UnixNano(),
+				AgentId: agentID, SessionId: session.SessionID, Seq: 44, MsgName: "Heartbeat", WalId: testWALGenerationID, SentAtUnixNs: time.Now().UnixNano(),
 			})
 			select {
 			case message := <-stream.sentAckChan:
@@ -713,6 +715,85 @@ func TestTelemetryStream_ACKReflectsTelemetryAdmissionFailure(t *testing.T) {
 			close(stream.recvChan)
 			select {
 			case err := <-errChannel:
+				if err != nil {
+					t.Fatalf("stream returned an error on EOF: %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timeout waiting for telemetry stream to close")
+			}
+		})
+	}
+}
+
+func TestTelemetryStreamValidatesWALGenerationIDBeforeRouting(t *testing.T) {
+	tests := []struct {
+		name          string
+		path          string
+		walID         string
+		wantStatus    agentv1.TelemetryAck_Status
+		wantError     string
+		wantSinkCount int
+	}{
+		{name: "unsupported message missing ID", path: "unsupported", wantStatus: agentv1.TelemetryAck_STATUS_PERMANENT_ERROR, wantError: "required"},
+		{name: "unsupported message invalid ID", path: "unsupported", walID: "not-a-uuid", wantStatus: agentv1.TelemetryAck_STATUS_PERMANENT_ERROR, wantError: "invalid"},
+		{name: "unsupported message valid ID", path: "unsupported", walID: testWALGenerationID, wantStatus: agentv1.TelemetryAck_STATUS_OK, wantSinkCount: 1},
+		{name: "noop missing ID", path: "noop", wantStatus: agentv1.TelemetryAck_STATUS_PERMANENT_ERROR, wantError: "required"},
+		{name: "noop invalid ID", path: "noop", walID: "not-a-uuid", wantStatus: agentv1.TelemetryAck_STATUS_PERMANENT_ERROR, wantError: "invalid"},
+		{name: "noop valid ID", path: "noop", walID: testWALGenerationID, wantStatus: agentv1.TelemetryAck_STATUS_OK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var genericSink *mock.MockSink
+			var relay *Relay
+			messageName := "Heartbeat"
+			if tt.path == "unsupported" {
+				genericSink = mock.NewMockSink()
+				relay = relayWithSinks(genericSink)
+				messageName = "Attitude"
+			} else {
+				relay = &Relay{router: outputs.NewRouter()}
+				relay.router.AddConsumer(telemetrywriter.NewNoopWriter(), telemetryMessageFilter())
+			}
+
+			const agentID = "wal-admission-agent"
+			session := &DroneSession{
+				agentID: agentID, SessionID: "wal-admission-session",
+				pending: make(map[string]chan *agentv1.OperationContextCommandAck),
+			}
+			relay.grpcSessions = map[string]*DroneSession{agentID: session}
+			stream, cancel := newAgentTelemetryStream(agentID, session.SessionID)
+			defer cancel()
+			streamErr := make(chan error, 1)
+			go func() { streamErr <- relay.TelemetryStream(stream) }()
+			waitForStreamGeneration(t, session, 1)
+
+			stream.recvChan <- telemetryStreamMessage(&agentv1.TelemetryFrame{
+				AgentId: agentID, SessionId: session.SessionID, Seq: 71,
+				MsgName: messageName, WalId: tt.walID, SentAtUnixNs: time.Now().UnixNano(),
+			})
+			select {
+			case message := <-stream.sentAckChan:
+				ack := message.GetTelemetryAck()
+				if ack == nil {
+					t.Fatal("stream response did not contain a telemetry ACK")
+				}
+				if ack.Status != tt.wantStatus {
+					t.Fatalf("ACK status = %v, want %v; error=%q", ack.Status, tt.wantStatus, ack.Error)
+				}
+				if tt.wantError != "" && !strings.Contains(ack.Error, tt.wantError) {
+					t.Fatalf("ACK error = %q, want substring %q", ack.Error, tt.wantError)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timeout waiting for telemetry ACK")
+			}
+
+			if genericSink != nil && genericSink.GetMessageCount() != tt.wantSinkCount {
+				t.Fatalf("generic sink count = %d, want %d", genericSink.GetMessageCount(), tt.wantSinkCount)
+			}
+			close(stream.recvChan)
+			select {
+			case err := <-streamErr:
 				if err != nil {
 					t.Fatalf("stream returned an error on EOF: %v", err)
 				}
@@ -767,6 +848,7 @@ func TestTelemetryStream(t *testing.T) {
 		AgentId:      paddedAgentID,
 		SessionId:    "session-stream-test",
 		MsgName:      "Heartbeat",
+		WalId:        testWALGenerationID,
 		SentAtUnixNs: time.Now().UnixNano(),
 		Fields: map[string]string{
 			"type": "1",
@@ -805,7 +887,7 @@ func TestTelemetryStream(t *testing.T) {
 
 	// Test Case 3: Reject a named frame without its durable capture timestamp.
 	missingTimestampFrame := &agentv1.TelemetryFrame{
-		AgentId: agentID, SessionId: "session-stream-test", Seq: 3, MsgName: "Heartbeat",
+		AgentId: agentID, SessionId: "session-stream-test", Seq: 3, MsgName: "Heartbeat", WalId: testWALGenerationID,
 	}
 	stream.recvChan <- telemetryStreamMessage(missingTimestampFrame)
 	select {
@@ -900,6 +982,7 @@ func TestTelemetryStream_OldStreamDoesNotDeleteReplacementSession(t *testing.T) 
 		AgentId:      agentID,
 		SessionId:    oldSession.SessionID,
 		MsgName:      "Heartbeat",
+		WalId:        testWALGenerationID,
 		SentAtUnixNs: time.Now().UnixNano(),
 	})
 	select {
@@ -967,6 +1050,7 @@ func TestTelemetryStream_ReplacementKeepsACKAndCleanupOnReceivingStream(t *testi
 		SessionId:    session.SessionID,
 		Seq:          42,
 		MsgName:      "Heartbeat",
+		WalId:        testWALGenerationID,
 		SentAtUnixNs: time.Now().UnixNano(),
 	})
 	select {
@@ -1035,7 +1119,7 @@ func TestTelemetryStream_ReplacementDoesNotWaitForBlockedOldSend(t *testing.T) {
 	waitForStreamGeneration(t, session, 1)
 
 	oldStream.recvChan <- telemetryStreamMessage(&agentv1.TelemetryFrame{
-		AgentId: agentID, SessionId: session.SessionID, Seq: 45, MsgName: "Heartbeat", SentAtUnixNs: time.Now().UnixNano(),
+		AgentId: agentID, SessionId: session.SessionID, Seq: 45, MsgName: "Heartbeat", WalId: testWALGenerationID, SentAtUnixNs: time.Now().UnixNano(),
 	})
 	select {
 	case <-oldStream.sendStarted:
@@ -1052,7 +1136,7 @@ func TestTelemetryStream_ReplacementDoesNotWaitForBlockedOldSend(t *testing.T) {
 	waitForStreamGeneration(t, session, 2)
 
 	replacementStream.recvChan <- telemetryStreamMessage(&agentv1.TelemetryFrame{
-		AgentId: agentID, SessionId: session.SessionID, Seq: 46, MsgName: "Heartbeat", SentAtUnixNs: time.Now().UnixNano(),
+		AgentId: agentID, SessionId: session.SessionID, Seq: 46, MsgName: "Heartbeat", WalId: testWALGenerationID, SentAtUnixNs: time.Now().UnixNano(),
 	})
 	select {
 	case message := <-replacementStream.sentAckChan:
@@ -1116,7 +1200,7 @@ func TestTelemetryStream_KeepsSessionOwnershipThroughAdmission(t *testing.T) {
 
 	stream.recvChan <- telemetryStreamMessage(&agentv1.TelemetryFrame{
 		AgentId: agentID, SessionId: session.SessionID, Seq: 47,
-		MsgName: "Heartbeat", SentAtUnixNs: time.Now().UnixNano(),
+		MsgName: "Heartbeat", WalId: testWALGenerationID, SentAtUnixNs: time.Now().UnixNano(),
 	})
 	select {
 	case <-consumer.started:

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -70,6 +70,8 @@ const testAgentToken = "test-agent-token"
 
 const testWALGenerationID = "0195f6a8-86d1-7be7-a104-3a814dc19f9e"
 
+const nilWALGenerationID = "00000000-0000-0000-0000-000000000000"
+
 func relayWithRegistryReporter(t *testing.T, reporter agentRegistryReporter) *Relay {
 	t.Helper()
 	authenticator, err := newAgentTokenAuthenticator(map[string]string{"agent-1": testAgentToken})
@@ -736,9 +738,11 @@ func TestTelemetryStreamValidatesWALGenerationIDBeforeRouting(t *testing.T) {
 	}{
 		{name: "unsupported message missing ID", path: "unsupported", wantStatus: agentv1.TelemetryAck_STATUS_PERMANENT_ERROR, wantError: "required"},
 		{name: "unsupported message invalid ID", path: "unsupported", walID: "not-a-uuid", wantStatus: agentv1.TelemetryAck_STATUS_PERMANENT_ERROR, wantError: "invalid"},
+		{name: "unsupported message nil ID", path: "unsupported", walID: nilWALGenerationID, wantStatus: agentv1.TelemetryAck_STATUS_PERMANENT_ERROR, wantError: "invalid"},
 		{name: "unsupported message valid ID", path: "unsupported", walID: testWALGenerationID, wantStatus: agentv1.TelemetryAck_STATUS_OK, wantSinkCount: 1},
 		{name: "noop missing ID", path: "noop", wantStatus: agentv1.TelemetryAck_STATUS_PERMANENT_ERROR, wantError: "required"},
 		{name: "noop invalid ID", path: "noop", walID: "not-a-uuid", wantStatus: agentv1.TelemetryAck_STATUS_PERMANENT_ERROR, wantError: "invalid"},
+		{name: "noop nil ID", path: "noop", walID: nilWALGenerationID, wantStatus: agentv1.TelemetryAck_STATUS_PERMANENT_ERROR, wantError: "invalid"},
 		{name: "noop valid ID", path: "noop", walID: testWALGenerationID, wantStatus: agentv1.TelemetryAck_STATUS_OK},
 	}
 

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -451,6 +451,7 @@ func TestBuildTelemetryFrameEnvelope(t *testing.T) {
 		FlightId:           "stale-frame-flight",
 		IntentId:           "stale-frame-intent",
 		IntentVersion:      1,
+		WalId:              "0195f6a8-86d1-7be7-a104-3a814dc19f9e",
 		Seq:                99,
 		SentAtUnixNs:       agentTime.UnixNano(),
 		DeviceTimestampSec: 42.5,
@@ -480,8 +481,8 @@ func TestBuildTelemetryFrameEnvelope(t *testing.T) {
 	if envelope.IntentID != "authoritative-intent" || envelope.IntentVersion != 4 {
 		t.Errorf("intent metadata = %q/%d", envelope.IntentID, envelope.IntentVersion)
 	}
-	if envelope.WALSequence != 99 || envelope.Dialect != "common" {
-		t.Errorf("sequence/dialect metadata = %d/%q", envelope.WALSequence, envelope.Dialect)
+	if envelope.WALID != "0195f6a8-86d1-7be7-a104-3a814dc19f9e" || envelope.WALSequence != 99 || envelope.Dialect != "common" {
+		t.Errorf("WAL ID/sequence/dialect metadata = %q/%d/%q", envelope.WALID, envelope.WALSequence, envelope.Dialect)
 	}
 	if !envelope.TimestampAgent.Equal(agentTime) || envelope.TimestampDevice != 42.5 {
 		t.Errorf("agent/device timestamps = %v/%v", envelope.TimestampAgent, envelope.TimestampDevice)

--- a/internal/telemetrynormalize/normalizers_test.go
+++ b/internal/telemetrynormalize/normalizers_test.go
@@ -341,6 +341,10 @@ func TestRecordValidationAcceptsLegacyV1WithoutWALGenerationID(t *testing.T) {
 	if err := record.Validate(); err == nil {
 		t.Fatal("schema-v1 record with invalid WAL generation ID passed validation")
 	}
+	record.Source.WALID = "00000000-0000-0000-0000-000000000000"
+	if err := record.Validate(); err == nil {
+		t.Fatal("schema-v1 record with nil WAL generation ID passed validation")
+	}
 }
 
 func testEnvelope(message string, messageID uint32, fields map[string]any) telemetry.TelemetryEnvelope {
@@ -374,7 +378,7 @@ func TestNormalizeRejectsMissingAgentCaptureTime(t *testing.T) {
 }
 
 func TestNormalizeRejectsInvalidWALGenerationID(t *testing.T) {
-	for _, walID := range []string{"", "not-a-uuid"} {
+	for _, walID := range []string{"", "not-a-uuid", "00000000-0000-0000-0000-000000000000"} {
 		envelope := testEnvelope("GlobalPositionInt", 33, map[string]any{
 			"Lat": "418781000", "Lon": "-876291000", "Alt": "123450",
 		})

--- a/internal/telemetrynormalize/normalizers_test.go
+++ b/internal/telemetrynormalize/normalizers_test.go
@@ -326,6 +326,23 @@ func TestRecordValidationRequiresRelayAndSessionIdentity(t *testing.T) {
 	}
 }
 
+func TestRecordValidationAcceptsLegacyV1WithoutWALGenerationID(t *testing.T) {
+	normalizer, _ := NewRegistry().Lookup("Heartbeat")
+	record, err := normalizer.Normalize(testEnvelope("Heartbeat", 0, nil))
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+
+	record.Source.WALID = ""
+	if err := record.Validate(); err != nil {
+		t.Fatalf("legacy schema-v1 record without WAL generation ID failed validation: %v", err)
+	}
+	record.Source.WALID = "not-a-uuid"
+	if err := record.Validate(); err == nil {
+		t.Fatal("schema-v1 record with invalid WAL generation ID passed validation")
+	}
+}
+
 func testEnvelope(message string, messageID uint32, fields map[string]any) telemetry.TelemetryEnvelope {
 	return telemetry.TelemetryEnvelope{
 		AgentID:        "agent-1",

--- a/internal/telemetrynormalize/normalizers_test.go
+++ b/internal/telemetrynormalize/normalizers_test.go
@@ -1,6 +1,7 @@
 package telemetrynormalize
 
 import (
+	"fmt"
 	"math"
 	"reflect"
 	"testing"
@@ -368,5 +369,44 @@ func TestNormalizeRejectsInvalidWALGenerationID(t *testing.T) {
 		if _, err := normalizer.Normalize(envelope); err == nil {
 			t.Fatalf("Normalize() accepted WAL generation ID %q", walID)
 		}
+	}
+}
+
+func TestNormalizePreservesV1FrameIDAcrossWALIdentityRollout(t *testing.T) {
+	normalizer, ok := NewRegistry().Lookup("GlobalPositionInt")
+	if !ok {
+		t.Fatal("GlobalPositionInt normalizer is not registered")
+	}
+	envelope := testEnvelope("GlobalPositionInt", 33, map[string]any{
+		"Lat": "418781000", "Lon": "-876291000", "Alt": "123450",
+	})
+	wantFrameID := fmt.Sprintf(
+		"%d:%s:%d:%d",
+		len(envelope.AgentID),
+		envelope.AgentID,
+		envelope.TimestampAgent.UnixNano(),
+		envelope.WALSequence,
+	)
+
+	first, err := normalizer.Normalize(envelope)
+	if err != nil {
+		t.Fatalf("Normalize(first WAL) error = %v", err)
+	}
+	envelope.WALID = "0195f6a8-86d1-7be7-a104-3a814dc19f9f"
+	second, err := normalizer.Normalize(envelope)
+	if err != nil {
+		t.Fatalf("Normalize(second WAL) error = %v", err)
+	}
+
+	if first.Source.FrameID != wantFrameID || second.Source.FrameID != wantFrameID {
+		t.Fatalf(
+			"schema-v1 frame IDs changed with WAL metadata: first=%q second=%q want=%q",
+			first.Source.FrameID,
+			second.Source.FrameID,
+			wantFrameID,
+		)
+	}
+	if first.Source.WALID == second.Source.WALID {
+		t.Fatalf("test WAL identities are equal: %q", first.Source.WALID)
 	}
 }

--- a/internal/telemetrynormalize/normalizers_test.go
+++ b/internal/telemetrynormalize/normalizers_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -345,6 +346,13 @@ func TestRecordValidationAcceptsLegacyV1WithoutWALGenerationID(t *testing.T) {
 	if err := record.Validate(); err == nil {
 		t.Fatal("schema-v1 record with nil WAL generation ID passed validation")
 	}
+	record.Source.WALID = strings.ToUpper("0195f6a8-86d1-7be7-a104-3a814dc19f9e")
+	if err := record.Validate(); err != nil {
+		t.Fatalf("schema-v1 record with uppercase WAL generation ID failed validation: %v", err)
+	}
+	if record.Source.WALID != "0195f6a8-86d1-7be7-a104-3a814dc19f9e" {
+		t.Fatalf("validated WAL generation ID = %q, want canonical lowercase UUID", record.Source.WALID)
+	}
 }
 
 func testEnvelope(message string, messageID uint32, fields map[string]any) telemetry.TelemetryEnvelope {
@@ -390,6 +398,20 @@ func TestNormalizeRejectsInvalidWALGenerationID(t *testing.T) {
 		if _, err := normalizer.Normalize(envelope); err == nil {
 			t.Fatalf("Normalize() accepted WAL generation ID %q", walID)
 		}
+	}
+}
+
+func TestNormalizeCanonicalizesWALGenerationID(t *testing.T) {
+	envelope := testEnvelope("Heartbeat", 0, nil)
+	envelope.WALID = strings.ToUpper(envelope.WALID)
+	normalizer, _ := NewRegistry().Lookup(envelope.MsgName)
+
+	record, err := normalizer.Normalize(envelope)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if record.Source.WALID != "0195f6a8-86d1-7be7-a104-3a814dc19f9e" {
+		t.Fatalf("normalized WAL generation ID = %q, want canonical lowercase UUID", record.Source.WALID)
 	}
 }
 

--- a/internal/telemetrynormalize/normalizers_test.go
+++ b/internal/telemetrynormalize/normalizers_test.go
@@ -335,6 +335,7 @@ func testEnvelope(message string, messageID uint32, fields map[string]any) telem
 		Dialect:        "common",
 		MsgID:          messageID,
 		MsgName:        message,
+		WALID:          "0195f6a8-86d1-7be7-a104-3a814dc19f9e",
 		WALSequence:    42,
 		Fields:         fields,
 	}
@@ -351,5 +352,21 @@ func TestNormalizeRejectsMissingAgentCaptureTime(t *testing.T) {
 	}
 	if _, err := normalizer.Normalize(envelope); err == nil {
 		t.Fatal("Normalize() accepted an envelope without agent capture time")
+	}
+}
+
+func TestNormalizeRejectsInvalidWALGenerationID(t *testing.T) {
+	for _, walID := range []string{"", "not-a-uuid"} {
+		envelope := testEnvelope("GlobalPositionInt", 33, map[string]any{
+			"Lat": "418781000", "Lon": "-876291000", "Alt": "123450",
+		})
+		envelope.WALID = walID
+		normalizer, ok := NewRegistry().Lookup(envelope.MsgName)
+		if !ok {
+			t.Fatal("GlobalPositionInt normalizer is not registered")
+		}
+		if _, err := normalizer.Normalize(envelope); err == nil {
+			t.Fatalf("Normalize() accepted WAL generation ID %q", walID)
+		}
 	}
 }

--- a/internal/telemetrynormalize/registry.go
+++ b/internal/telemetrynormalize/registry.go
@@ -3,6 +3,7 @@ package telemetrynormalize
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/makinje/aero-arc-relay/internal/outputs"
@@ -116,7 +117,7 @@ func baseRecord(envelope telemetry.TelemetryEnvelope, canonicalName string) (Rec
 			IntentVersion: envelope.IntentVersion,
 		},
 		Source: SourceContext{
-			FrameID:   fmt.Sprintf("%d:%s:%d:%s:%d", len(envelope.AgentID), envelope.AgentID, len(walID), walID, envelope.WALSequence),
+			FrameID:   frameIDV1(envelope.AgentID, agentTimeValue, envelope.WALSequence),
 			WALID:     walID,
 			Sequence:  envelope.WALSequence,
 			MessageID: envelope.MsgID,
@@ -131,4 +132,11 @@ func baseRecord(envelope telemetry.TelemetryEnvelope, canonicalName string) (Rec
 		MessageName: canonicalName,
 		Fields:      make(Fields),
 	}, nil
+}
+
+// frameIDV1 retains the deployed schema-version-1 identity across mixed Relay
+// versions. Changing this formula requires a new schema version and a
+// coordinated drain so one WAL entry cannot be persisted under two identities.
+func frameIDV1(agentID string, agentCaptureTime time.Time, walSequence uint64) string {
+	return fmt.Sprintf("%d:%s:%d:%d", len(agentID), agentID, agentCaptureTime.UnixNano(), walSequence)
 }

--- a/internal/telemetrynormalize/registry.go
+++ b/internal/telemetrynormalize/registry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/makinje/aero-arc-relay/internal/outputs"
 	"github.com/makinje/aero-arc-relay/pkg/telemetry"
 )
@@ -95,6 +96,13 @@ func baseRecord(envelope telemetry.TelemetryEnvelope, canonicalName string) (Rec
 	if strings.TrimSpace(envelope.AgentID) == "" {
 		return Record{}, fmt.Errorf("agent ID is required")
 	}
+	walID := strings.TrimSpace(envelope.WALID)
+	if walID == "" {
+		return Record{}, fmt.Errorf("WAL generation ID is required")
+	}
+	if _, err := uuid.Parse(walID); err != nil {
+		return Record{}, fmt.Errorf("WAL generation ID is invalid: %w", err)
+	}
 	return Record{
 		SchemaVersion: SchemaVersion,
 		Identity: IdentityContext{
@@ -108,7 +116,8 @@ func baseRecord(envelope telemetry.TelemetryEnvelope, canonicalName string) (Rec
 			IntentVersion: envelope.IntentVersion,
 		},
 		Source: SourceContext{
-			FrameID:   fmt.Sprintf("%d:%s:%d:%d", len(envelope.AgentID), envelope.AgentID, agentTime.UnixNano(), envelope.WALSequence),
+			FrameID:   fmt.Sprintf("%d:%s:%d:%s:%d", len(envelope.AgentID), envelope.AgentID, len(walID), walID, envelope.WALSequence),
+			WALID:     walID,
 			Sequence:  envelope.WALSequence,
 			MessageID: envelope.MsgID,
 			Dialect:   dialect,

--- a/internal/telemetrynormalize/registry.go
+++ b/internal/telemetrynormalize/registry.go
@@ -101,8 +101,12 @@ func baseRecord(envelope telemetry.TelemetryEnvelope, canonicalName string) (Rec
 	if walID == "" {
 		return Record{}, fmt.Errorf("WAL generation ID is required")
 	}
-	if _, err := uuid.Parse(walID); err != nil {
+	walUUID, err := uuid.Parse(walID)
+	if err != nil {
 		return Record{}, fmt.Errorf("WAL generation ID is invalid: %w", err)
+	}
+	if walUUID == uuid.Nil {
+		return Record{}, fmt.Errorf("WAL generation ID is invalid: nil UUID")
 	}
 	return Record{
 		SchemaVersion: SchemaVersion,

--- a/internal/telemetrynormalize/registry.go
+++ b/internal/telemetrynormalize/registry.go
@@ -108,6 +108,7 @@ func baseRecord(envelope telemetry.TelemetryEnvelope, canonicalName string) (Rec
 	if walUUID == uuid.Nil {
 		return Record{}, fmt.Errorf("WAL generation ID is invalid: nil UUID")
 	}
+	walID = walUUID.String()
 	return Record{
 		SchemaVersion: SchemaVersion,
 		Identity: IdentityContext{

--- a/internal/telemetrynormalize/types.go
+++ b/internal/telemetrynormalize/types.go
@@ -70,11 +70,14 @@ type Record struct {
 	Fields        Fields
 }
 
-// Validate validates Record for required fields, supported values, and safety constraints.
+// Validate validates Record for required fields, supported values, and safety
+// constraints. It canonicalizes a present WAL generation ID to the lowercase,
+// hyphenated UUID representation.
 //
 // Returns:
 //   - error: reports validation, dependency, cancellation, or persistence failures.
-func (r Record) Validate() error {
+func (r *Record) Validate() error {
+	canonicalWALID := r.Source.WALID
 	if r.SchemaVersion == 0 {
 		return errors.New("schema version is required")
 	}
@@ -98,6 +101,7 @@ func (r Record) Validate() error {
 		if walUUID == uuid.Nil {
 			return errors.New("WAL generation ID is invalid: nil UUID")
 		}
+		canonicalWALID = walUUID.String()
 	}
 	if r.MessageName == "" {
 		return errors.New("message name is required")
@@ -125,5 +129,6 @@ func (r Record) Validate() error {
 			return fmt.Errorf("field %s has unsupported type %T", name, value)
 		}
 	}
+	r.Source.WALID = canonicalWALID
 	return nil
 }

--- a/internal/telemetrynormalize/types.go
+++ b/internal/telemetrynormalize/types.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const SchemaVersion uint16 = 1
@@ -35,6 +37,7 @@ type IdentityContext struct {
 
 type SourceContext struct {
 	FrameID     string
+	WALID       string
 	Sequence    uint64
 	MessageID   uint32
 	Dialect     string
@@ -86,6 +89,12 @@ func (r Record) Validate() error {
 	}
 	if r.Source.FrameID == "" {
 		return errors.New("frame ID is required")
+	}
+	if r.Source.WALID == "" {
+		return errors.New("WAL generation ID is required")
+	}
+	if _, err := uuid.Parse(r.Source.WALID); err != nil {
+		return fmt.Errorf("WAL generation ID is invalid: %w", err)
 	}
 	if r.MessageName == "" {
 		return errors.New("message name is required")

--- a/internal/telemetrynormalize/types.go
+++ b/internal/telemetrynormalize/types.go
@@ -90,11 +90,10 @@ func (r Record) Validate() error {
 	if r.Source.FrameID == "" {
 		return errors.New("frame ID is required")
 	}
-	if r.Source.WALID == "" {
-		return errors.New("WAL generation ID is required")
-	}
-	if _, err := uuid.Parse(r.Source.WALID); err != nil {
-		return fmt.Errorf("WAL generation ID is invalid: %w", err)
+	if r.Source.WALID != "" {
+		if _, err := uuid.Parse(r.Source.WALID); err != nil {
+			return fmt.Errorf("WAL generation ID is invalid: %w", err)
+		}
 	}
 	if r.MessageName == "" {
 		return errors.New("message name is required")

--- a/internal/telemetrynormalize/types.go
+++ b/internal/telemetrynormalize/types.go
@@ -91,8 +91,12 @@ func (r Record) Validate() error {
 		return errors.New("frame ID is required")
 	}
 	if r.Source.WALID != "" {
-		if _, err := uuid.Parse(r.Source.WALID); err != nil {
+		walUUID, err := uuid.Parse(r.Source.WALID)
+		if err != nil {
 			return fmt.Errorf("WAL generation ID is invalid: %w", err)
+		}
+		if walUUID == uuid.Nil {
+			return errors.New("WAL generation ID is invalid: nil UUID")
 		}
 	}
 	if r.MessageName == "" {

--- a/internal/telemetrywriter/influx/point.go
+++ b/internal/telemetrywriter/influx/point.go
@@ -34,6 +34,7 @@ func recordToPoint(record telemetrynormalize.Record) (*influxdb3.Point, error) {
 		fields["intent_version"] = uint64(record.Identity.IntentVersion)
 	}
 	fields["wal_sequence"] = record.Source.Sequence
+	fields["wal_id"] = record.Source.WALID
 	fields["message_id"] = uint64(record.Source.MessageID)
 	fields["dialect"] = record.Source.Dialect
 	fields["timestamp_source"] = string(record.Timing.TimestampSource)

--- a/internal/telemetrywriter/influx/point.go
+++ b/internal/telemetrywriter/influx/point.go
@@ -34,7 +34,7 @@ func recordToPoint(record telemetrynormalize.Record) (*influxdb3.Point, error) {
 		fields["intent_version"] = uint64(record.Identity.IntentVersion)
 	}
 	fields["wal_sequence"] = record.Source.Sequence
-	fields["wal_id"] = record.Source.WALID
+	optionalField(fields, "wal_id", record.Source.WALID)
 	fields["message_id"] = uint64(record.Source.MessageID)
 	fields["dialect"] = record.Source.Dialect
 	fields["timestamp_source"] = string(record.Timing.TimestampSource)

--- a/internal/telemetrywriter/influx/point_test.go
+++ b/internal/telemetrywriter/influx/point_test.go
@@ -2,6 +2,7 @@ package influx
 
 import (
 	"maps"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,7 +18,7 @@ func TestRecordToPoint(t *testing.T) {
 			OperatorID: "operator-1", AircraftID: "aircraft-1", AgentID: "agent-1",
 			RelayID: "relay-1", SessionID: "session-1", FlightID: "flight-1", IntentID: "intent-1",
 		},
-		Source: telemetrynormalize.SourceContext{FrameID: "7:agent-1:1783857600000000000:42", WALID: "0195f6a8-86d1-7be7-a104-3a814dc19f9e", Sequence: 42, MessageID: 33, Dialect: "common"},
+		Source: telemetrynormalize.SourceContext{FrameID: "7:agent-1:1783857600000000000:42", WALID: "0195F6A8-86D1-7BE7-A104-3A814DC19F9E", Sequence: 42, MessageID: 33, Dialect: "common"},
 		Timing: telemetrynormalize.TimingContext{
 			EventTime: eventTime, RelayTime: eventTime.Add(time.Millisecond), AgentCaptureTime: &agentTime,
 			TimestampSource: telemetrynormalize.TimestampSourceAgent,
@@ -53,8 +54,8 @@ func TestRecordToPoint(t *testing.T) {
 	if _, ok := point.GetField("wal_sequence").(uint64); !ok {
 		t.Errorf("wal_sequence type = %T", point.GetField("wal_sequence"))
 	}
-	if got := point.GetField("wal_id"); got != record.Source.WALID {
-		t.Errorf("wal_id = %#v, want %q", got, record.Source.WALID)
+	if got := point.GetField("wal_id"); got != "0195f6a8-86d1-7be7-a104-3a814dc19f9e" {
+		t.Errorf("wal_id = %#v, want canonical lowercase UUID", got)
 	}
 	if !point.Values.Timestamp.Equal(eventTime) {
 		t.Errorf("timestamp = %v", point.Values.Timestamp)
@@ -85,6 +86,7 @@ func TestRecordToPointUsesFrameIDForPointIdentity(t *testing.T) {
 		t.Fatalf("recordToPoint(first) error = %v", err)
 	}
 	retryRecord := record
+	retryRecord.Source.WALID = strings.ToUpper(record.Source.WALID)
 	retryRecord.Identity = telemetrynormalize.IdentityContext{
 		OperatorID: "operator-2", AircraftID: "", AgentID: "agent-1",
 		RelayID: "relay-2", SessionID: "session-2", FlightID: "flight-2",
@@ -117,6 +119,9 @@ func TestRecordToPointUsesFrameIDForPointIdentity(t *testing.T) {
 	}
 	if got := retry.GetField("flight_id"); got != "flight-2" {
 		t.Fatalf("retry flight field = %#v", got)
+	}
+	if first.GetField("wal_id") != retry.GetField("wal_id") {
+		t.Fatalf("equivalent WAL UUID representations split cursor identity: first=%#v retry=%#v", first.GetField("wal_id"), retry.GetField("wal_id"))
 	}
 	if firstFrameID == secondFrameID {
 		t.Fatalf("distinct WAL frames share frame ID tag %q", firstFrameID)

--- a/internal/telemetrywriter/influx/point_test.go
+++ b/internal/telemetrywriter/influx/point_test.go
@@ -17,7 +17,7 @@ func TestRecordToPoint(t *testing.T) {
 			OperatorID: "operator-1", AircraftID: "aircraft-1", AgentID: "agent-1",
 			RelayID: "relay-1", SessionID: "session-1", FlightID: "flight-1", IntentID: "intent-1",
 		},
-		Source: telemetrynormalize.SourceContext{FrameID: "7:agent-1:36:0195f6a8-86d1-7be7-a104-3a814dc19f9e:42", WALID: "0195f6a8-86d1-7be7-a104-3a814dc19f9e", Sequence: 42, MessageID: 33, Dialect: "common"},
+		Source: telemetrynormalize.SourceContext{FrameID: "7:agent-1:1783857600000000000:42", WALID: "0195f6a8-86d1-7be7-a104-3a814dc19f9e", Sequence: 42, MessageID: 33, Dialect: "common"},
 		Timing: telemetrynormalize.TimingContext{
 			EventTime: eventTime, RelayTime: eventTime.Add(time.Millisecond), AgentCaptureTime: &agentTime,
 			TimestampSource: telemetrynormalize.TimestampSourceAgent,
@@ -70,7 +70,7 @@ func TestRecordToPointUsesFrameIDForPointIdentity(t *testing.T) {
 			AgentID: "agent-1", RelayID: "relay-1", SessionID: "session-1", AircraftID: "aircraft-1",
 		},
 		Source: telemetrynormalize.SourceContext{
-			FrameID: "7:agent-1:36:0195f6a8-86d1-7be7-a104-3a814dc19f9e:42", WALID: "0195f6a8-86d1-7be7-a104-3a814dc19f9e", Sequence: 42, MessageID: 33, Dialect: "common",
+			FrameID: "7:agent-1:1783857600000000000:42", WALID: "0195f6a8-86d1-7be7-a104-3a814dc19f9e", Sequence: 42, MessageID: 33, Dialect: "common",
 		},
 		Timing: telemetrynormalize.TimingContext{
 			EventTime: eventTime, RelayTime: eventTime, AgentCaptureTime: &agentTime,
@@ -96,7 +96,7 @@ func TestRecordToPointUsesFrameIDForPointIdentity(t *testing.T) {
 		t.Fatalf("recordToPoint(retry) error = %v", err)
 	}
 	secondRecord := record
-	secondRecord.Source.FrameID = "7:agent-1:36:0195f6a8-86d1-7be7-a104-3a814dc19f9e:43"
+	secondRecord.Source.FrameID = "7:agent-1:1783857600000000000:43"
 	secondRecord.Source.Sequence = 43
 	second, err := recordToPoint(secondRecord)
 	if err != nil {
@@ -132,7 +132,7 @@ func TestRecordToPointUsesStableMeasurementWithoutAssignment(t *testing.T) {
 		Identity: telemetrynormalize.IdentityContext{
 			AgentID: "agent-1", RelayID: "relay-1", SessionID: "session-1",
 		},
-		Source: telemetrynormalize.SourceContext{FrameID: "7:agent-1:36:0195f6a8-86d1-7be7-a104-3a814dc19f9e:1", WALID: "0195f6a8-86d1-7be7-a104-3a814dc19f9e", Sequence: 1, MessageID: 0, Dialect: "common"},
+		Source: telemetrynormalize.SourceContext{FrameID: "7:agent-1:1783857600000000000:1", WALID: "0195f6a8-86d1-7be7-a104-3a814dc19f9e", Sequence: 1, MessageID: 0, Dialect: "common"},
 		Timing: telemetrynormalize.TimingContext{
 			EventTime: time.Now().UTC(), RelayTime: time.Now().UTC(), TimestampSource: telemetrynormalize.TimestampSourceRelay,
 		},

--- a/internal/telemetrywriter/influx/point_test.go
+++ b/internal/telemetrywriter/influx/point_test.go
@@ -152,4 +152,8 @@ func TestRecordToPointUsesStableMeasurementWithoutAssignment(t *testing.T) {
 	if got := point.GetField("wal_id"); got != nil {
 		t.Errorf("legacy schema-v1 point contains wal_id = %#v", got)
 	}
+	record.Source.WALID = "00000000-0000-0000-0000-000000000000"
+	if _, err := recordToPoint(record); err == nil {
+		t.Fatal("recordToPoint() accepted a nil WAL generation UUID")
+	}
 }

--- a/internal/telemetrywriter/influx/point_test.go
+++ b/internal/telemetrywriter/influx/point_test.go
@@ -132,7 +132,7 @@ func TestRecordToPointUsesStableMeasurementWithoutAssignment(t *testing.T) {
 		Identity: telemetrynormalize.IdentityContext{
 			AgentID: "agent-1", RelayID: "relay-1", SessionID: "session-1",
 		},
-		Source: telemetrynormalize.SourceContext{FrameID: "7:agent-1:1783857600000000000:1", WALID: "0195f6a8-86d1-7be7-a104-3a814dc19f9e", Sequence: 1, MessageID: 0, Dialect: "common"},
+		Source: telemetrynormalize.SourceContext{FrameID: "7:agent-1:1783857600000000000:1", Sequence: 1, MessageID: 0, Dialect: "common"},
 		Timing: telemetrynormalize.TimingContext{
 			EventTime: time.Now().UTC(), RelayTime: time.Now().UTC(), TimestampSource: telemetrynormalize.TimestampSourceRelay,
 		},
@@ -148,5 +148,8 @@ func TestRecordToPointUsesStableMeasurementWithoutAssignment(t *testing.T) {
 	}
 	if _, ok := point.GetTag("aircraft_id"); ok {
 		t.Error("unassigned point unexpectedly has aircraft_id tag")
+	}
+	if got := point.GetField("wal_id"); got != nil {
+		t.Errorf("legacy schema-v1 point contains wal_id = %#v", got)
 	}
 }

--- a/internal/telemetrywriter/influx/point_test.go
+++ b/internal/telemetrywriter/influx/point_test.go
@@ -17,7 +17,7 @@ func TestRecordToPoint(t *testing.T) {
 			OperatorID: "operator-1", AircraftID: "aircraft-1", AgentID: "agent-1",
 			RelayID: "relay-1", SessionID: "session-1", FlightID: "flight-1", IntentID: "intent-1",
 		},
-		Source: telemetrynormalize.SourceContext{FrameID: "7:agent-1:42", Sequence: 42, MessageID: 33, Dialect: "common"},
+		Source: telemetrynormalize.SourceContext{FrameID: "7:agent-1:36:0195f6a8-86d1-7be7-a104-3a814dc19f9e:42", WALID: "0195f6a8-86d1-7be7-a104-3a814dc19f9e", Sequence: 42, MessageID: 33, Dialect: "common"},
 		Timing: telemetrynormalize.TimingContext{
 			EventTime: eventTime, RelayTime: eventTime.Add(time.Millisecond), AgentCaptureTime: &agentTime,
 			TimestampSource: telemetrynormalize.TimestampSourceAgent,
@@ -53,6 +53,9 @@ func TestRecordToPoint(t *testing.T) {
 	if _, ok := point.GetField("wal_sequence").(uint64); !ok {
 		t.Errorf("wal_sequence type = %T", point.GetField("wal_sequence"))
 	}
+	if got := point.GetField("wal_id"); got != record.Source.WALID {
+		t.Errorf("wal_id = %#v, want %q", got, record.Source.WALID)
+	}
 	if !point.Values.Timestamp.Equal(eventTime) {
 		t.Errorf("timestamp = %v", point.Values.Timestamp)
 	}
@@ -67,7 +70,7 @@ func TestRecordToPointUsesFrameIDForPointIdentity(t *testing.T) {
 			AgentID: "agent-1", RelayID: "relay-1", SessionID: "session-1", AircraftID: "aircraft-1",
 		},
 		Source: telemetrynormalize.SourceContext{
-			FrameID: "7:agent-1:1783857600000000000:42", Sequence: 42, MessageID: 33, Dialect: "common",
+			FrameID: "7:agent-1:36:0195f6a8-86d1-7be7-a104-3a814dc19f9e:42", WALID: "0195f6a8-86d1-7be7-a104-3a814dc19f9e", Sequence: 42, MessageID: 33, Dialect: "common",
 		},
 		Timing: telemetrynormalize.TimingContext{
 			EventTime: eventTime, RelayTime: eventTime, AgentCaptureTime: &agentTime,
@@ -93,7 +96,7 @@ func TestRecordToPointUsesFrameIDForPointIdentity(t *testing.T) {
 		t.Fatalf("recordToPoint(retry) error = %v", err)
 	}
 	secondRecord := record
-	secondRecord.Source.FrameID = "7:agent-1:1783857600000000000:43"
+	secondRecord.Source.FrameID = "7:agent-1:36:0195f6a8-86d1-7be7-a104-3a814dc19f9e:43"
 	secondRecord.Source.Sequence = 43
 	second, err := recordToPoint(secondRecord)
 	if err != nil {
@@ -129,7 +132,7 @@ func TestRecordToPointUsesStableMeasurementWithoutAssignment(t *testing.T) {
 		Identity: telemetrynormalize.IdentityContext{
 			AgentID: "agent-1", RelayID: "relay-1", SessionID: "session-1",
 		},
-		Source: telemetrynormalize.SourceContext{FrameID: "7:agent-1:1", Sequence: 1, MessageID: 0, Dialect: "common"},
+		Source: telemetrynormalize.SourceContext{FrameID: "7:agent-1:36:0195f6a8-86d1-7be7-a104-3a814dc19f9e:1", WALID: "0195f6a8-86d1-7be7-a104-3a814dc19f9e", Sequence: 1, MessageID: 0, Dialect: "common"},
 		Timing: telemetrynormalize.TimingContext{
 			EventTime: time.Now().UTC(), RelayTime: time.Now().UTC(), TimestampSource: telemetrynormalize.TimestampSourceRelay,
 		},

--- a/internal/telemetrywriter/writer_test.go
+++ b/internal/telemetrywriter/writer_test.go
@@ -224,6 +224,7 @@ func validPositionEnvelope() telemetry.TelemetryEnvelope {
 		Dialect:        "common",
 		MsgID:          33,
 		MsgName:        "GlobalPositionInt",
+		WALID:          "0195f6a8-86d1-7be7-a104-3a814dc19f9e",
 		WALSequence:    42,
 		Fields: map[string]any{
 			"Lat": "418781000", "Lon": "-876291000", "Alt": "123450",

--- a/pkg/telemetry/envelope.go
+++ b/pkg/telemetry/envelope.go
@@ -36,6 +36,7 @@ type TelemetryEnvelope struct {
 	Dialect         string         `json:"dialect,omitempty"`
 	MsgID           uint32         `json:"msg_id"`
 	MsgName         string         `json:"msg_name"`
+	WALID           string         `json:"wal_id,omitempty"`
 	WALSequence     uint64         `json:"wal_sequence,omitempty"`
 	SystemID        uint8          `json:"system_id"`
 	ComponentID     uint8          `json:"component_id"`


### PR DESCRIPTION
## Summary

- require a valid, non-nil UUID `wal_id` on authenticated Agent telemetry before any routing path
- canonicalize the UUID and carry the composite WAL cursor through the envelope, normalized source context, and Influx persistence
- preserve the existing schema-v1 capture-time `frame_id` semantics during the mixed-version rollout
- cover supported, filtered, no-op, and unsupported routing paths with the same validation boundary

## Why

An Agent WAL sequence is monotonic only within its append generation. Persisting the canonical generation UUID beside the sequence lets downstream consumers distinguish retries from a new WAL lifetime and prevents cursor collisions after recovery, cloning, or restoration.

Keeping the schema-v1 `frame_id` unchanged avoids silently changing point identity during a rolling deployment. A WAL-derived point identity can be introduced later as an explicit, coordinated schema-v2 contract.

## Compatibility and rollout

- depends on Aero-Arc/aero-arc-protos#11
- pairs with Aero-Arc/aero-arc-agent#27
- merge Protos first, deploy upgraded Agents next, then deploy the Relay requirement
- the live gateway rejects missing or invalid WAL identities
- normalized-record validation and Influx writing remain tolerant of historical schema-v1 records without `wal_id`

## Validation

- `go test ./...`
- `go test -race -count=1 ./...`
- `go test -count=1 -tags=integration -timeout=10m ./internal/integration ./internal/registryreporter`
- `go vet ./...`
- `git diff --check`
- GitHub Unit Test, Integration Test, Lint, and DCO checks are green
