### PR TITLE
Authenticate operation context and aircraft commands

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -10,6 +10,16 @@ registry:
     ca_file: ""
     server_name: ""
 
+# Mutating RelayControl RPCs remain disabled unless this mTLS boundary is
+# enabled. Agents may still connect without a client certificate; only control
+# callers must present a certificate issued by this CA with an allow-listed CN,
+# DNS SAN, or URI SAN.
+control_auth:
+  enabled: false
+  client_ca_file: "${AERO_ARC_CONTROL_CLIENT_CA_FILE}"
+  allowed_identities:
+    - "spiffe://aero-arc/api"
+
 telemetry:
   enabled: false
   backend: "influxdb3"

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -26,6 +26,16 @@ before it creates or replaces any session. The relay then:
 Registration does not open the telemetry stream. It creates the session that a
 subsequent `TelemetryStream` call must attach to.
 
+When operation-context control is enabled, the first session for an agent
+observed by a Relay process starts with operation context unreconciled. The API
+must replay its durable authoritative state with either `SetOperationContext`
+for an active flight or `ClearOperationContext` for no active flight. Until the
+Agent acknowledges that command, telemetry receives `RETRY_WITH_BACKOFF` and
+remains in the Agent WAL instead of being admitted with an implicitly empty
+flight and intent. This is required after Relay restart; Registry discovery and
+stream admission provide the API-to-Relay replay path. Relays with context
+control disabled preserve their context-free telemetry behavior.
+
 Registering the same agent ID again replaces the map entry with a new
 `DroneSession` and a new session ID. The old stream handler can still be running,
 but it no longer owns the active registered session.
@@ -67,11 +77,17 @@ the relay builds an ACK using the frame sequence number and validates:
 - The frame session ID matches that captured session's ID.
 - The MAVLink message name is not empty.
 - The durable agent capture timestamp is present and positive.
+- The API-owned operation context has been reconciled for this Relay process.
 
 An invalid frame receives a permanent-error ACK and is not routed. A valid frame
 updates the session heartbeat and is converted into a telemetry envelope using
 the session's authoritative flight and intent context. Frame-provided operation
 context cannot override the session state.
+
+An otherwise valid frame received before operation-context reconciliation gets
+`RETRY_WITH_BACKOFF`, not a permanent error. Once the authoritative Set/Clear is
+acknowledged, the Agent can replay the same WAL records without losing them or
+allowing Relay restart to erase active-flight attribution.
 
 Validation and routing occur while holding a read lease on the captured
 session's ownership. Re-registration and active-stream cleanup retire a session
@@ -208,6 +224,8 @@ operation context into the replacement before publishing it, so reconnecting
 telemetry keeps its flight and intent attribution. Delayed operation-command
 ACKs received by the old handler remain bound to the old session and cannot
 update the replacement session's context or pending commands.
+If no prior in-process session exists, Relay does not infer an empty context:
+telemetry remains retryable until the API explicitly replays Set or Clear.
 
 ## 6. Disconnect and Cleanup
 

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -171,10 +171,14 @@ The delivery path:
 
 Waiting for the stream's send lock observes the control API context. If an
 already-started gRPC `Send` remains flow-controlled past the API deadline, the
-API request returns at its deadline while that send retains its binding's lock
-until gRPC completes. This preserves send serialization without allowing a
-wedged agent connection to accumulate blocked control handlers or prevent a
-replacement stream from attaching.
+Set/Clear API request and its session ownership lease remain held until that
+write returns, even after the deadline. Only then does the RPC observe context
+cancellation rather than waiting for the Agent ACK. This intentional
+through-write fence prevents registration from publishing a replacement while
+an operation-context mutation can still land on the old Agent stream. Aircraft
+commands use the same through-write session fence in their shared delivery task,
+but an individual caller may detach at its deadline and must treat that command
+outcome as uncertain while the started write finishes.
 
 Incoming operation-context ACKs are applied only when their command ID matches a
 pending request on the session captured by the receiving stream handler. The

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -114,21 +114,31 @@ a verified certificate whose common name, DNS SAN, or URI SAN is allow-listed.
 An unauthenticated caller is rejected before request validation, so it cannot
 probe Agent connectivity or command state.
 
+`SendAircraftCommand` uses the same authenticated control-mutation gate. ARM
+and DISARM target only the session active at admission, are not queued across a
+replacement, and are not automatically retried because they are immediate
+vehicle commands rather than durable operation-context mutations.
+
 Unlike a telemetry ACK, a control command is not a response to a message
 received on a particular stream. It targets the current admitted Agent session.
 If that session changes before the ACK is returned, the Relay reports `Aborted`;
-the caller can safely retry the durable command ID against the replacement.
+the caller can retry the same durable command ID and payload against the
+replacement. The Agent WAL is the cross-session and cross-process idempotency
+authority.
 
 The delivery path:
 
 1. Validates the agent ID and command ID.
 2. Resolves the current registered session.
-3. Adds a pending ACK channel keyed by command ID.
+3. Records a deterministic payload fingerprint and pending result keyed by
+   command ID.
 4. Sends through the captured session, which selects and locks that session's
    current stream binding.
 5. Waits for the matching command ACK or for the caller's context to end.
-6. Removes the pending entry when delivery fails, times out, is cancelled, or
-   receives an ACK.
+6. Retains the fingerprint and terminal outcome after delivery fails, times
+   out, is cancelled, or receives an ACK. Exact concurrent retries share the
+   pending outcome; exact retries of transient outcomes may redeliver, while a
+   conflicting payload is rejected.
 
 Waiting for the stream's send lock observes the control API context. If an
 already-started gRPC `Send` remains flow-controlled past the API deadline, the
@@ -140,16 +150,19 @@ replacement stream from attaching.
 Incoming operation-context ACKs are applied only when their command ID matches a
 pending request on the session captured by the receiving stream handler. The
 pending entry is consumed before an applied ACK may update active flight and
-intent state. Unsolicited and late ACKs are ignored. The relay does not look the
-session up again by agent ID because the same agent may have registered a
-replacement session while an old command ACK was in flight.
+intent state. For `APPLIED` and `ALREADY_APPLIED`, the ACK's active context must
+exactly match the authoritative result derived from the API command. Relay
+updates attribution from that expected result, never from unchecked Agent data.
+Unsolicited and late ACKs without a current matching attempt are ignored. The
+relay does not look the session up again by agent ID because the same agent may
+have registered a replacement session while an old command ACK was in flight.
 
-Before this machinery becomes supported, the protocol must also define command
-idempotency explicitly. Reusing an ID with the same payload should mean retrying
-one logical command; reusing it with a different payload must be rejected; and a
-new logical command must receive a new ID. Concurrent duplicates, completed-ID
-retention, payload fingerprints, session binding, retry limits, and delayed ACKs
-must be covered by integration tests.
+Relay retains outcomes per session for up to 24 hours, capped at 4096 entries,
+and evicts the oldest completed outcome when the bound is reached. This bounds memory; the
+Agent's durable WAL retains each command ID and payload fingerprint across
+session replacement and process restart. Reusing an ID with the same payload is
+one logical command. Reusing it with a different command kind or payload is a
+terminal conflict and cannot mutate operation context.
 
 This creates an intentional routing distinction:
 

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -214,6 +214,15 @@ After replacement:
 - The active-binding swap waits for any already-started control-command write;
   ordinary telemetry ACK sends remain isolated per binding and do not delay the
   replacement.
+- Pending operation-context and aircraft-command waits whose write completed on
+  the superseded binding finish with `Aborted` at the active-binding swap. This
+  releases the serialized operation-context gate instead of waiting forever for
+  evidence that is no longer authoritative. An aircraft-command caller must
+  treat this result as outcome-uncertain because the old Agent may have passed
+  the command to the autopilot before reconnecting.
+- Command admission is fenced with its stream write. A command waiting behind
+  the swap is admitted only after the replacement becomes active, so Relay
+  cannot abort it and then deliver it on the new binding.
 - Operation-context ACKs and aircraft-command results from the superseded
   binding are ignored, even though it shares the same session ID.
 - A frame already read, or subsequently read, by the old handler is ACKed on the
@@ -329,9 +338,13 @@ blocked ACK on an old stream does not prevent a replacement stream from attachin
 and sending.
 
 `TestSameSessionReplacementWaitsForControlWriteAndRejectsOldEvidence` verifies
-that the active-binding swap waits for a blocked control write and that both
-operation-context and aircraft-command evidence from the superseded binding are
-ignored.
+that the active-binding swap waits for a blocked control write, aborts pending
+waiters, releases the operation-context gate, and ignores both operation-context
+and aircraft-command evidence from the superseded binding.
+
+`TestRegistryBackedStreamReplacementAbortsPendingCommandsAtCommit` verifies the
+same abort rule applies only when a Registry-backed replacement is successfully
+published and committed, not while it is merely a pending candidate.
 
 `TestTelemetryStream_ACKReflectsTelemetryAdmissionFailure` verifies that queue
 admission failures are retryable and deterministic normalization failures are

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -282,6 +282,9 @@ The important ownership invariants are:
    telemetry consumer.
 10. `controlStreamMu` linearizes through-write control sends, active-binding
     swaps, and command evidence so one command cannot cross stream generations.
+11. Stream replacement captures and later revalidates its session under
+    `sessionsMu`; it never waits for a per-session fence while holding the
+    Relay-wide map lock, so one blocked Agent cannot stall unrelated Agents.
 
 These rules prevent a replacement connection from receiving an unrelated ACK and
 prevent stale handler cleanup from tearing down the current connection.

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -123,6 +123,13 @@ before waiting for the autopilot result, and aborts that pending wait if the
 session is retired. A disconnected Agent can therefore be replaced even when a
 control caller supplied no deadline.
 
+Within a session, Relay retains deterministic ARM/DISARM payload fingerprints
+and terminal correlation outcomes under the same bounded 24-hour/4096-entry
+policy used for operation-context commands. An exact retry observes the retained
+outcome without redelivery; reusing a command ID for another aircraft or command
+type is rejected. A new deliberate vehicle action therefore requires a new
+command ID.
+
 Unlike a telemetry ACK, an operation-context command is not a response to a
 message received on a particular stream. It targets the current admitted Agent
 session. If that session changes before the ACK is returned, the Relay reports

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -105,19 +105,19 @@ sending.
 
 ## 4. Delivering Control Commands
 
-`SetOperationContext` and `ClearOperationContext` currently return gRPC
-`Unimplemented`. The relay exposes the agent gateway and relay control service
-on one listener with server-authenticated TLS, so enabling mutation RPCs before
-the control plane has its own authenticated and authorized boundary would allow
-an arbitrary reachable client to target another agent.
+`SetOperationContext` and `ClearOperationContext` remain disabled by default.
+They are enabled only when `control_auth` supplies a client CA and an explicit
+workload-identity allow list. The shared TLS listener uses
+`VerifyClientCertIfGiven`: Agents continue to use their bearer credentials and
+do not need client certificates, while every mutating control caller must present
+a verified certificate whose common name, DNS SAN, or URI SAN is allow-listed.
+An unauthenticated caller is rejected before request validation, so it cannot
+probe Agent connectivity or command state.
 
-The internal command-delivery machinery remains implemented and tested as a
-highly experimental foundation. It is not yet a supported control interface.
-It may be enabled only after the control API is moved to a private listener
-protected by workload authentication and authorization and the operations panel
-has an intentional command workflow. Unlike a telemetry ACK, a control command
-is not a response to a message received on a particular stream. It should target
-whichever stream is currently active.
+Unlike a telemetry ACK, a control command is not a response to a message
+received on a particular stream. It targets the current admitted Agent session.
+If that session changes before the ACK is returned, the Relay reports `Aborted`;
+the caller can safely retry the durable command ID against the replacement.
 
 The delivery path:
 

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -203,9 +203,11 @@ If the agent registers again instead of only replacing its stream, the new map
 entry has a different `DroneSession` pointer and session ID. The old handler's
 cleanup is rejected by the session pointer check. Frames from the old registration
 also fail the active-session-identity validation and receive their error ACK on
-the old stream. Delayed operation-command ACKs received by the old handler remain
-bound to the old session and cannot update the replacement session's context or
-pending commands.
+the old stream. Relay atomically copies the last API-authoritative acknowledged
+operation context into the replacement before publishing it, so reconnecting
+telemetry keeps its flight and intent attribution. Delayed operation-command
+ACKs received by the old handler remain bound to the old session and cannot
+update the replacement session's context or pending commands.
 
 ## 6. Disconnect and Cleanup
 

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -117,14 +117,18 @@ probe Agent connectivity or command state.
 `SendAircraftCommand` uses the same authenticated control-mutation gate. ARM
 and DISARM target only the session active at admission, are not queued across a
 replacement, and are not automatically retried because they are immediate
-vehicle commands rather than durable operation-context mutations.
+vehicle commands rather than durable operation-context mutations. Relay holds
+the session ownership lease through validation and stream delivery, releases it
+before waiting for the autopilot result, and aborts that pending wait if the
+session is retired. A disconnected Agent can therefore be replaced even when a
+control caller supplied no deadline.
 
-Unlike a telemetry ACK, a control command is not a response to a message
-received on a particular stream. It targets the current admitted Agent session.
-If that session changes before the ACK is returned, the Relay reports `Aborted`;
-the caller can retry the same durable command ID and payload against the
-replacement. The Agent WAL is the cross-session and cross-process idempotency
-authority.
+Unlike a telemetry ACK, an operation-context command is not a response to a
+message received on a particular stream. It targets the current admitted Agent
+session. If that session changes before the ACK is returned, the Relay reports
+`Aborted`; the caller can retry the same durable command ID and payload against
+the replacement. The Agent WAL is the cross-session and cross-process
+idempotency authority.
 
 The delivery path:
 

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -180,9 +180,10 @@ commands use the same through-write session fence in their shared delivery task,
 but an individual caller may detach at its deadline and must treat that command
 outcome as uncertain while the started write finishes.
 
-Incoming operation-context ACKs are applied only when their command ID matches a
-pending request on the session captured by the receiving stream handler. The
-pending entry is consumed before an applied ACK may update active flight and
+Incoming operation-context ACKs and aircraft-command results are applied only
+when their command ID matches a pending request on the session captured by the
+receiving stream handler and that handler still owns the active stream binding.
+The pending entry is consumed before an applied ACK may update active flight and
 intent state. For `APPLIED` and `ALREADY_APPLIED`, the ACK's active context must
 exactly match the authoritative result derived from the API command. Relay
 updates attribution from that expected result, never from unchecked Agent data.
@@ -210,6 +211,11 @@ stream.
 After replacement:
 
 - New control commands target the replacement stream.
+- The active-binding swap waits for any already-started control-command write;
+  ordinary telemetry ACK sends remain isolated per binding and do not delay the
+  replacement.
+- Operation-context ACKs and aircraft-command results from the superseded
+  binding are ignored, even though it shares the same session ID.
 - A frame already read, or subsequently read, by the old handler is ACKed on the
   old stream while the shared session remains registered.
 - Sends remain serialized independently on each stream binding.
@@ -256,7 +262,7 @@ another telemetry stream.
 
 ## Synchronization and Ownership
 
-The stream lifecycle uses five locks with separate responsibilities:
+The stream lifecycle uses six locks with separate responsibilities:
 
 ![Ownership map of sessionsMu, sessionMu, ownershipMu, per-binding sendMu, and pendingMu with the state each lock protects](images/stream-synchronization-ownership.svg)
 
@@ -274,6 +280,8 @@ The important ownership invariants are:
 8. A command and its pending ACK are owned by the same captured session.
 9. A successful telemetry ACK requires admission by the official normalized
    telemetry consumer.
+10. `controlStreamMu` linearizes through-write control sends, active-binding
+    swaps, and command evidence so one command cannot cross stream generations.
 
 These rules prevent a replacement connection from receiving an unrelated ACK and
 prevent stale handler cleanup from tearing down the current connection.
@@ -286,6 +294,8 @@ and receive ACKs for its own frames while the shared session remains registered.
 It also means both handlers can temporarily submit valid telemetry for the same
 session. If the active replacement closes and removes the session, any surviving
 old handler returns permanent-error ACKs for later frames and does not route them.
+The drain allowance applies only to telemetry; command ACKs and results from a
+superseded binding never complete shared session command state.
 
 If the protocol later requires strict single-stream ingestion, replacement should
 also cancel the previous handler or cause stale generations to reject new frames.
@@ -314,6 +324,11 @@ ID.
 `TestTelemetryStream_ReplacementDoesNotWaitForBlockedOldSend` verifies that a
 blocked ACK on an old stream does not prevent a replacement stream from attaching
 and sending.
+
+`TestSameSessionReplacementWaitsForControlWriteAndRejectsOldEvidence` verifies
+that the active-binding swap waits for a blocked control write and that both
+operation-context and aircraft-command evidence from the superseded binding are
+ignored.
 
 `TestTelemetryStream_ACKReflectsTelemetryAdmissionFailure` verifies that queue
 admission failures are retryable and deterministic normalization failures are

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -29,7 +29,9 @@ subsequent `TelemetryStream` call must attach to.
 When operation-context control is enabled, the first session for an agent
 observed by a Relay process starts with operation context unreconciled. The API
 must replay its durable authoritative state with either `SetOperationContext`
-for an active flight or `ClearOperationContext` for no active flight. Until the
+for an active flight or `ClearOperationContext` with no flight ID for no active
+flight. Empty-flight Clear is accepted only for this initial reconciliation;
+ordinary clears remain scoped to a specific flight. Until the
 Agent acknowledges that command, telemetry receives `RETRY_WITH_BACKOFF` and
 remains in the Agent WAL instead of being admitted with an implicitly empty
 flight and intent. This is required after Relay restart; Registry discovery and

--- a/docs/images/agent-telemetry-lifecycle-sequence.svg
+++ b/docs/images/agent-telemetry-lifecycle-sequence.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1120" role="img" aria-labelledby="title desc">
   <title id="title">Agent telemetry stream lifecycle</title>
-  <desc id="desc">Sequence diagram across Agent, Relay, and Outputs or Control API. It covers authenticated registration, session creation, stream attachment, telemetry validation and routing, response-bound acknowledgements, active-stream control commands, command acknowledgements, stream replacement, and generation-safe cleanup.</desc>
+  <desc id="desc">Sequence diagram across Agent, Relay, and Outputs or Control API. It covers authenticated registration, session creation, stream attachment, telemetry validation and routing, response-bound acknowledgements, active-stream control commands, command acknowledgements, stream replacement with pending command aborts, and generation-safe cleanup.</desc>
   <style>
     :root { color-scheme: light dark; }
     .bg { fill: #f8fafc; }
@@ -88,7 +88,8 @@
   <text class="muted label" x="50" y="876">4 · REPLACE AND CLEAN UP SAFELY</text>
   <path class="cleanup" d="M180 910 H600"/>
   <text class="text label" x="390" y="901" text-anchor="middle">Replacement stream</text>
-  <text class="muted note" x="620" y="930">Attach generation N+1</text>
+  <text class="muted note" x="620" y="922">Attach generation N+1</text>
+  <text class="muted note" x="620" y="943">Abort pending old-binding command waits</text>
   <path class="cleanup" d="M180 962 H600"/>
   <text class="text label" x="390" y="953" text-anchor="middle">Old stream closes</text>
   <text class="muted note" x="620" y="975">Ignore stale cleanup</text>

--- a/docs/images/stream-synchronization-ownership.svg
+++ b/docs/images/stream-synchronization-ownership.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 850" role="img" aria-labelledby="title desc">
   <title id="title">Layered stream synchronization ownership</title>
-  <desc id="desc">Nested architecture diagram. The outer sessionsMu boundary protects the grpcSessions map and session identity replacement. Within a selected DroneSession, ownershipMu provides the retirement and frame-admission lease. sessionMu protects mutable state, active stream, and generation. Independent old and replacement bindings each have their own sendMu for that RPC stream. pendingMu separately protects the pending operation-command acknowledgement map.</desc>
+  <desc id="desc">Nested architecture diagram. The outer sessionsMu boundary protects the grpcSessions map and session identity replacement. Within a selected DroneSession, ownershipMu provides the retirement and frame-admission lease. sessionMu protects mutable state, active stream, and generation. controlStreamMu fences control writes and evidence across the active-binding swap. Independent old and replacement bindings each have their own sendMu for that RPC stream. pendingMu separately protects the pending operation-command acknowledgement map.</desc>
   <style>
     :root { color-scheme: light dark; }
     .bg { fill: #f8fafc; }
@@ -62,6 +62,8 @@
   <rect x="770" y="380" width="250" height="68" rx="18" fill="#64748b" opacity="0.15"/>
   <text class="text node" x="895" y="407" text-anchor="middle">streamGeneration</text>
   <text class="muted body" x="895" y="431" text-anchor="middle">N → N+1</text>
+  <text class="text node" x="400" y="495">controlStreamMu</text>
+  <text class="muted body" x="575" y="495">Fences control writes + evidence across active-binding swaps.</text>
 
   <path class="arrow" d="M635 460 V575 H485"/>
   <path class="arrow" d="M635 460 V575 H865"/>

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -47,15 +47,19 @@ networking commonly permits pod-to-pod traffic unless NetworkPolicy isolates a
 workload, and a NetworkPolicy can restrict ports but not individual gRPC methods
 on a shared port.
 
-The relay currently serves the external agent gateway and relay control API on
-the same gRPC listener. For that reason, the mutating `SetOperationContext` and
-`ClearOperationContext` RPCs remain disabled. Before enabling them:
+The relay serves the external Agent gateway and Relay control API on the same
+gRPC listener. Mutating `SetOperationContext` and `ClearOperationContext` calls
+remain disabled unless `control_auth` enables client-certificate verification
+and explicitly allow-lists the trusted API workload identity. Agents do not need
+client certificates; callers without a verified certificate are rejected from
+mutating methods before request validation.
 
-1. Serve the relay control API on a separate internal listener and `ClusterIP`.
-2. Apply default-deny ingress and allow only the trusted Aero Arc API workload.
-3. Require mutual TLS or equivalent workload authentication on that listener.
-4. Authorize the caller for the requested operator, aircraft, and agent before
-   forwarding a command.
+1. Apply default-deny ingress and allow only Agent networks and the trusted Aero
+   Arc API workload to reach the listener.
+2. Mount the control client CA and set `control_auth.client_ca_file`.
+3. Allow only the API certificate's CN, DNS SAN, or URI SAN through
+   `control_auth.allowed_identities`.
+4. Keep operator/aircraft/Agent authorization in the API before it forwards a
+   command, and rotate workload certificates through the cluster issuer.
 
-Do not expose the future control listener through `NodePort`, `LoadBalancer`, or
-an external Gateway.
+Do not expose RelayControl mutation access through an external Gateway.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/bigquery v1.71.0
 	cloud.google.com/go/storage v1.57.0
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.10.0
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260824205409-4a2f13cc719f
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260824210440-607329537377
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/bluenviron/gomavlib/v2 v2.2.0
 	github.com/elastic/go-elasticsearch/v8 v8.15.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/bigquery v1.71.0
 	cloud.google.com/go/storage v1.57.0
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.10.0
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260812020348-1f8a6730b3ee
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260817050509-7f9124ee65fd
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/bluenviron/gomavlib/v2 v2.2.0
 	github.com/elastic/go-elasticsearch/v8 v8.15.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/bigquery v1.71.0
 	cloud.google.com/go/storage v1.57.0
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.10.0
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260823010059-9c3641b684b5
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260824205409-4a2f13cc719f
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/bluenviron/gomavlib/v2 v2.2.0
 	github.com/elastic/go-elasticsearch/v8 v8.15.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/bigquery v1.71.0
 	cloud.google.com/go/storage v1.57.0
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.10.0
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260812020348-1f8a6730b3ee
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260817042625-1168c254a092
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/bluenviron/gomavlib/v2 v2.2.0
 	github.com/elastic/go-elasticsearch/v8 v8.15.0

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/actgardner/gogen-avro/v10 v10.2.1/go.mod h1:QUhjeHPchheYmMDni/Nx7VB0R
 github.com/actgardner/gogen-avro/v9 v9.1.0/go.mod h1:nyTj6wPqDJoxM3qdnjcLv+EnMDSDFqE0qDpva2QRmKc=
 github.com/aero-arc/aero-arc-protos v0.0.0-20260823010059-9c3641b684b5 h1:+dfJoWW2FXDq8Pi1ydVKFS4mJEXv5LueEl02jFH/T8M=
 github.com/aero-arc/aero-arc-protos v0.0.0-20260823010059-9c3641b684b5/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260824205409-4a2f13cc719f h1:FMaKzCx+K02+vOE8duBns1tZUT5RgS/Ow1/XA+ASbHM=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260824205409-4a2f13cc719f/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/aero-arc/aero-arc-protos v0.0.0-20260823010059-9c3641b684b5 h1:+dfJoW
 github.com/aero-arc/aero-arc-protos v0.0.0-20260823010059-9c3641b684b5/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/aero-arc/aero-arc-protos v0.0.0-20260824205409-4a2f13cc719f h1:FMaKzCx+K02+vOE8duBns1tZUT5RgS/Ow1/XA+ASbHM=
 github.com/aero-arc/aero-arc-protos v0.0.0-20260824205409-4a2f13cc719f/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260824210440-607329537377 h1:XT1wflfh4eHB+Km5VXilPVXm09RXj8I3GFq4czSBiqc=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260824210440-607329537377/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMz
 github.com/actgardner/gogen-avro/v10 v10.1.0/go.mod h1:o+ybmVjEa27AAr35FRqU98DJu1fXES56uXniYFv4yDA=
 github.com/actgardner/gogen-avro/v10 v10.2.1/go.mod h1:QUhjeHPchheYmMDni/Nx7VB0RsT/ee8YIgGY/xpEQgQ=
 github.com/actgardner/gogen-avro/v9 v9.1.0/go.mod h1:nyTj6wPqDJoxM3qdnjcLv+EnMDSDFqE0qDpva2QRmKc=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260812020348-1f8a6730b3ee h1:NX2tsjSjrrUVPvH43fbyq9TAxUdMiqDVykkc7UaKTlo=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260812020348-1f8a6730b3ee/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260817050509-7f9124ee65fd h1:39SaVLyvowCAJFmSLPXpnJ04uPLlGko7z4tUY0423e4=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260817050509-7f9124ee65fd/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMz
 github.com/actgardner/gogen-avro/v10 v10.1.0/go.mod h1:o+ybmVjEa27AAr35FRqU98DJu1fXES56uXniYFv4yDA=
 github.com/actgardner/gogen-avro/v10 v10.2.1/go.mod h1:QUhjeHPchheYmMDni/Nx7VB0RsT/ee8YIgGY/xpEQgQ=
 github.com/actgardner/gogen-avro/v9 v9.1.0/go.mod h1:nyTj6wPqDJoxM3qdnjcLv+EnMDSDFqE0qDpva2QRmKc=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260812020348-1f8a6730b3ee h1:NX2tsjSjrrUVPvH43fbyq9TAxUdMiqDVykkc7UaKTlo=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260812020348-1f8a6730b3ee/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260817042625-1168c254a092 h1:s39r5ktr4/mKXCBNdPfshs+V2UL6bDHOWkjlYMG90f4=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260817042625-1168c254a092/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,16 +24,26 @@ import (
 
 // Config represents the application configuration
 type Config struct {
-	Sinks       SinksConfig     `yaml:"sinks"`
-	Registry    RegistryConfig  `yaml:"registry"`
-	AgentAuth   AgentAuthConfig `yaml:"agent_auth"`
-	Telemetry   TelemetryConfig `yaml:"telemetry"`
-	Logging     LoggingConfig   `yaml:"logging"`
+	Sinks       SinksConfig       `yaml:"sinks"`
+	Registry    RegistryConfig    `yaml:"registry"`
+	AgentAuth   AgentAuthConfig   `yaml:"agent_auth"`
+	ControlAuth ControlAuthConfig `yaml:"control_auth"`
+	Telemetry   TelemetryConfig   `yaml:"telemetry"`
+	Logging     LoggingConfig     `yaml:"logging"`
 	Debug       bool
 	TLSCertPath string
 	TLSKeyPath  string
 	GrpcPort    int
 	BufferSize  int
+}
+
+// ControlAuthConfig protects the mutating Relay control RPCs with a client
+// certificate. The shared listener continues to accept Agent clients without a
+// certificate; only control mutations require a verified, allow-listed identity.
+type ControlAuthConfig struct {
+	Enabled           bool     `yaml:"enabled"`
+	ClientCAFile      string   `yaml:"client_ca_file"`
+	AllowedIdentities []string `yaml:"allowed_identities"`
 }
 
 // AgentAuthConfig contains bootstrap credentials for authenticating an agent
@@ -304,8 +314,34 @@ func Load(path string) (*Config, error) {
 	if err := config.validateRegistry(); err != nil {
 		return nil, err
 	}
+	if err := config.validateControlAuth(); err != nil {
+		return nil, err
+	}
 
 	return &config, nil
+}
+
+func (c *Config) validateControlAuth() error {
+	if !c.ControlAuth.Enabled {
+		return nil
+	}
+	if c.ControlAuth.ClientCAFile == "" || c.ControlAuth.ClientCAFile != strings.TrimSpace(c.ControlAuth.ClientCAFile) {
+		return fmt.Errorf("control_auth.client_ca_file is required without surrounding whitespace when control authentication is enabled")
+	}
+	if len(c.ControlAuth.AllowedIdentities) == 0 {
+		return fmt.Errorf("control_auth.allowed_identities is required when control authentication is enabled")
+	}
+	seen := make(map[string]struct{}, len(c.ControlAuth.AllowedIdentities))
+	for _, identity := range c.ControlAuth.AllowedIdentities {
+		if identity == "" || identity != strings.TrimSpace(identity) {
+			return fmt.Errorf("control_auth.allowed_identities contains an empty or untrimmed identity")
+		}
+		if _, duplicate := seen[identity]; duplicate {
+			return fmt.Errorf("control_auth.allowed_identities contains duplicate identity %q", identity)
+		}
+		seen[identity] = struct{}{}
+	}
+	return nil
 }
 
 func (c *Config) validateRegistry() error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,6 +37,12 @@ agent_auth:
   tokens:
     "agent-1": "test-agent-token"
 
+control_auth:
+  enabled: true
+  client_ca_file: "/run/secrets/control-ca.pem"
+  allowed_identities:
+    - "spiffe://aero-arc/api"
+
 telemetry:
   enabled: true
   backend: "influxdb3"
@@ -122,6 +128,9 @@ logging:
 	}
 	if cfg.AgentAuth.Tokens["agent-1"] != "test-agent-token" {
 		t.Errorf("unexpected agent authentication config: %#v", cfg.AgentAuth)
+	}
+	if !cfg.ControlAuth.Enabled || cfg.ControlAuth.ClientCAFile != "/run/secrets/control-ca.pem" || len(cfg.ControlAuth.AllowedIdentities) != 1 {
+		t.Errorf("unexpected control authentication config: %#v", cfg.ControlAuth)
 	}
 	if !cfg.Telemetry.Enabled {
 		t.Error("Telemetry should be enabled")
@@ -291,6 +300,31 @@ func TestRegistryConfigRequiresValidAgentCredentials(t *testing.T) {
 			config.AgentAuth.Tokens = tokens
 			if err := config.validateRegistry(); err == nil {
 				t.Fatal("expected invalid Agent credential configuration")
+			}
+		})
+	}
+}
+
+func TestControlAuthRequiresCAAndAllowedIdentity(t *testing.T) {
+	valid := Config{ControlAuth: ControlAuthConfig{
+		Enabled: true, ClientCAFile: "/run/secrets/control-ca.pem", AllowedIdentities: []string{"spiffe://aero-arc/api"},
+	}}
+	if err := valid.validateControlAuth(); err != nil {
+		t.Fatalf("valid control authentication rejected: %v", err)
+	}
+	for name, mutate := range map[string]func(*Config){
+		"missing CA":          func(c *Config) { c.ControlAuth.ClientCAFile = "" },
+		"missing identities":  func(c *Config) { c.ControlAuth.AllowedIdentities = nil },
+		"padded identity":     func(c *Config) { c.ControlAuth.AllowedIdentities = []string{" api "} },
+		"duplicate identity":  func(c *Config) { c.ControlAuth.AllowedIdentities = []string{"api", "api"} },
+		"padded CA file path": func(c *Config) { c.ControlAuth.ClientCAFile = " ca.pem " },
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidate := valid
+			candidate.ControlAuth.AllowedIdentities = append([]string(nil), valid.ControlAuth.AllowedIdentities...)
+			mutate(&candidate)
+			if err := candidate.validateControlAuth(); err == nil {
+				t.Fatal("expected invalid control authentication configuration")
 			}
 		})
 	}

--- a/internal/relay/aircraft_command_test.go
+++ b/internal/relay/aircraft_command_test.go
@@ -3,6 +3,7 @@ package relay
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -84,6 +85,43 @@ func TestSendAircraftCommandDeliversToConnectedAgentAndCorrelatesResult(t *testi
 	conflict.Type = agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_DISARM
 	if _, err := relay.SendAircraftCommand(context.Background(), &relayv1.SendAircraftCommandRequest{AgentId: "agent-1", Command: conflict}); status.Code(err) != codes.AlreadyExists {
 		t.Fatalf("conflicting command-ID reuse error = %v, want AlreadyExists", err)
+	}
+}
+
+func TestBeginAircraftCommandRetainsExactRetryAtCapacity(t *testing.T) {
+	command := &agentv1.AircraftCommand{
+		CommandId: "oldest-command", AircraftId: "aircraft-1",
+		Type: agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_ARM,
+	}
+	fingerprint := testMessageFingerprint(t, command)
+	completedAt := time.Now().Add(-operationCommandRetention / 2)
+	done := make(chan struct{})
+	close(done)
+	want := &aircraftCommandState{
+		fingerprint: fingerprint,
+		result: &agentv1.AircraftCommandResult{
+			CommandId: command.GetCommandId(), AircraftId: command.GetAircraftId(),
+			Status: agentv1.AircraftCommandResult_STATUS_ACCEPTED,
+		},
+		done: done, completed: true, completedAt: completedAt,
+	}
+	session := &DroneSession{aircraftCommands: map[string]*aircraftCommandState{command.GetCommandId(): want}}
+	for i := 1; i < maxOperationCommands; i++ {
+		id := fmt.Sprintf("retained-%04d", i)
+		session.aircraftCommands[id] = &aircraftCommandState{
+			fingerprint: id,
+			done:        done,
+			completed:   true,
+			completedAt: completedAt.Add(time.Duration(i)),
+		}
+	}
+
+	got, owner, err := beginAircraftCommandDelivery(session, command)
+	if err != nil || owner || got != want {
+		t.Fatalf("exact retry = (%p, %v, %v), want (%p, false, nil)", got, owner, err, want)
+	}
+	if len(session.aircraftCommands) != maxOperationCommands {
+		t.Fatalf("retained commands = %d, want %d", len(session.aircraftCommands), maxOperationCommands)
 	}
 }
 

--- a/internal/relay/aircraft_command_test.go
+++ b/internal/relay/aircraft_command_test.go
@@ -256,6 +256,65 @@ func TestAircraftCommandCallerCancellationDuringSendDoesNotFinalizeSharedCommand
 	}
 }
 
+func TestAircraftCommandDeliveryHoldsSessionLeaseUntilBlockedSendCompletes(t *testing.T) {
+	stream := &mockTelemetryStream{
+		ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 1),
+		sendStarted: make(chan struct{}, 1), sendBlock: make(chan struct{}),
+	}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream: &telemetryStreamBinding{stream: stream},
+	}
+	relay := &Relay{
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      map[string]*DroneSession{"agent-1": session},
+	}
+	commandCtx, cancelCommand := context.WithCancel(context.Background())
+	commandResult := make(chan error, 1)
+	go func() {
+		_, err := relay.SendAircraftCommand(commandCtx, &relayv1.SendAircraftCommandRequest{
+			AgentId: "agent-1",
+			Command: &agentv1.AircraftCommand{
+				CommandId: "command-replace", AircraftId: "aircraft-1",
+				Type: agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_ARM,
+			},
+		})
+		commandResult <- err
+	}()
+	<-stream.sendStarted
+
+	replaced := make(chan error, 1)
+	go func() {
+		_, err := relay.Register(context.Background(), &agentv1.RegisterRequest{AgentId: "agent-1"})
+		replaced <- err
+	}()
+	select {
+	case err := <-replaced:
+		t.Fatalf("session replaced while old command send was blocked: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	cancelCommand()
+	if err := <-commandResult; status.Code(err) != codes.Canceled {
+		t.Fatalf("command caller error = %v, want Canceled", err)
+	}
+	select {
+	case err := <-replaced:
+		t.Fatalf("caller cancellation released lease before old send completed: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(stream.sendBlock)
+	<-stream.sentAckChan
+	select {
+	case err := <-replaced:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("session replacement did not resume after old command send completed")
+	}
+}
+
 func TestSendAircraftCommandDoesNotBlockSessionRetirementWhileAwaitingResult(t *testing.T) {
 	stream := &mockTelemetryStream{
 		ctx:         context.Background(),

--- a/internal/relay/aircraft_command_test.go
+++ b/internal/relay/aircraft_command_test.go
@@ -137,6 +137,58 @@ func TestSendAircraftCommandDeadlineCleansPendingCorrelation(t *testing.T) {
 	}
 }
 
+func TestAircraftCommandCallerCancellationDoesNotFinalizeSharedCommand(t *testing.T) {
+	stream := &mockTelemetryStream{ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 2)}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream: &telemetryStreamBinding{stream: stream},
+	}
+	relay := &Relay{
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      map[string]*DroneSession{"agent-1": session},
+	}
+	request := &relayv1.SendAircraftCommandRequest{
+		AgentId: "agent-1",
+		Command: &agentv1.AircraftCommand{
+			CommandId: "command-shared", AircraftId: "aircraft-1",
+			Type: agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_ARM,
+		},
+	}
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	first := make(chan error, 1)
+	go func() {
+		_, err := relay.SendAircraftCommand(firstCtx, request)
+		first <- err
+	}()
+	<-stream.sentAckChan
+	second := make(chan error, 1)
+	go func() {
+		_, err := relay.SendAircraftCommand(context.Background(), request)
+		second <- err
+	}()
+	select {
+	case duplicate := <-stream.sentAckChan:
+		t.Fatalf("shared caller redelivered command: %#v", duplicate)
+	case <-time.After(20 * time.Millisecond):
+	}
+	cancelFirst()
+	if err := <-first; status.Code(err) != codes.Canceled {
+		t.Fatalf("first caller error = %v, want Canceled", err)
+	}
+	select {
+	case err := <-second:
+		t.Fatalf("first cancellation finalized shared command: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	session.handleAircraftCommandResult(&agentv1.AircraftCommandResult{
+		CommandId: "command-shared", AircraftId: "aircraft-1",
+		Status: agentv1.AircraftCommandResult_STATUS_ACCEPTED,
+	})
+	if err := <-second; err != nil {
+		t.Fatalf("second caller error = %v", err)
+	}
+}
+
 func TestSendAircraftCommandDoesNotBlockSessionRetirementWhileAwaitingResult(t *testing.T) {
 	stream := &mockTelemetryStream{
 		ctx:         context.Background(),

--- a/internal/relay/aircraft_command_test.go
+++ b/internal/relay/aircraft_command_test.go
@@ -154,7 +154,7 @@ func TestSendAircraftCommandDoesNotBlockSessionRetirementWhileAwaitingResult(t *
 	go func() {
 		session.ownershipMu.Lock()
 		session.retired = true
-		session.abortPendingAircraftCommands()
+		session.abortPendingCommands()
 		session.ownershipMu.Unlock()
 		close(retired)
 	}()

--- a/internal/relay/aircraft_command_test.go
+++ b/internal/relay/aircraft_command_test.go
@@ -1,0 +1,114 @@
+package relay
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
+	relayv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestSendAircraftCommandDeliversToConnectedAgentAndCorrelatesResult(t *testing.T) {
+	stream := &mockTelemetryStream{
+		ctx:         context.Background(),
+		sentAckChan: make(chan *agentv1.RelayStreamMessage, 1),
+	}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream:          &telemetryStreamBinding{stream: stream},
+		pendingAircraft: make(map[string]chan *agentv1.AircraftCommandResult),
+	}
+	relay := &Relay{grpcSessions: map[string]*DroneSession{"agent-1": session}}
+	command := &agentv1.AircraftCommand{
+		CommandId: "command-1", AircraftId: "aircraft-1",
+		Type: agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_ARM,
+	}
+
+	type outcome struct {
+		response *relayv1.SendAircraftCommandResponse
+		err      error
+	}
+	completed := make(chan outcome, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	go func() {
+		response, err := relay.SendAircraftCommand(ctx, &relayv1.SendAircraftCommandRequest{
+			AgentId: "agent-1", Command: command,
+		})
+		completed <- outcome{response: response, err: err}
+	}()
+
+	select {
+	case message := <-stream.sentAckChan:
+		if got := message.GetAircraftCommand(); got.GetCommandId() != command.GetCommandId() || got.GetAircraftId() != command.GetAircraftId() {
+			t.Fatalf("delivered command = %+v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for command delivery")
+	}
+
+	wantResult := &agentv1.AircraftCommandResult{
+		CommandId: "command-1", AircraftId: "aircraft-1",
+		Status: agentv1.AircraftCommandResult_STATUS_ACCEPTED,
+	}
+	session.handleAircraftCommandResult(wantResult)
+	select {
+	case got := <-completed:
+		if got.err != nil {
+			t.Fatal(got.err)
+		}
+		if got.response.GetResult() != wantResult {
+			t.Fatalf("result = %+v", got.response.GetResult())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for correlated command result")
+	}
+}
+
+func TestSendAircraftCommandRejectsDisconnectedAgent(t *testing.T) {
+	relay := &Relay{grpcSessions: make(map[string]*DroneSession)}
+	_, err := relay.SendAircraftCommand(context.Background(), &relayv1.SendAircraftCommandRequest{
+		AgentId: "agent-1",
+		Command: &agentv1.AircraftCommand{
+			CommandId: "command-1", AircraftId: "aircraft-1",
+			Type: agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_ARM,
+		},
+	})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("error = %v, want NotFound", err)
+	}
+}
+
+func TestSendAircraftCommandDeadlineCleansPendingCorrelation(t *testing.T) {
+	stream := &mockTelemetryStream{
+		ctx:         context.Background(),
+		sentAckChan: make(chan *agentv1.RelayStreamMessage, 1),
+	}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream:          &telemetryStreamBinding{stream: stream},
+		pendingAircraft: make(map[string]chan *agentv1.AircraftCommandResult),
+	}
+	relay := &Relay{grpcSessions: map[string]*DroneSession{"agent-1": session}}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	_, err := relay.SendAircraftCommand(ctx, &relayv1.SendAircraftCommandRequest{
+		AgentId: "agent-1",
+		Command: &agentv1.AircraftCommand{
+			CommandId: "command-1", AircraftId: "aircraft-1",
+			Type: agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_DISARM,
+		},
+	})
+	if status.Code(err) != codes.DeadlineExceeded {
+		t.Fatalf("error = %v, want DeadlineExceeded", err)
+	}
+	session.pendingMu.Lock()
+	_, stillPending := session.pendingAircraft["command-1"]
+	session.pendingMu.Unlock()
+	if stillPending {
+		t.Fatal("expired command remained pending")
+	}
+}

--- a/internal/relay/aircraft_command_test.go
+++ b/internal/relay/aircraft_command_test.go
@@ -189,6 +189,73 @@ func TestAircraftCommandCallerCancellationDoesNotFinalizeSharedCommand(t *testin
 	}
 }
 
+func TestAircraftCommandCallerCancellationDuringSendDoesNotFinalizeSharedCommand(t *testing.T) {
+	stream := &mockTelemetryStream{
+		ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 1),
+		sendStarted: make(chan struct{}, 1), sendBlock: make(chan struct{}),
+	}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream: &telemetryStreamBinding{stream: stream},
+	}
+	relay := &Relay{
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      map[string]*DroneSession{"agent-1": session},
+	}
+	request := &relayv1.SendAircraftCommandRequest{
+		AgentId: "agent-1",
+		Command: &agentv1.AircraftCommand{
+			CommandId: "command-shared-send", AircraftId: "aircraft-1",
+			Type: agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_ARM,
+		},
+	}
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	first := make(chan error, 1)
+	go func() {
+		_, err := relay.SendAircraftCommand(firstCtx, request)
+		first <- err
+	}()
+	<-stream.sendStarted
+	second := make(chan error, 1)
+	go func() {
+		_, err := relay.SendAircraftCommand(context.Background(), request)
+		second <- err
+	}()
+	deadline := time.Now().Add(time.Second)
+	for {
+		session.pendingMu.Lock()
+		state := session.aircraftCommands["command-shared-send"]
+		attached := state != nil && state.waiters == 2
+		session.pendingMu.Unlock()
+		if attached {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("second caller did not attach to blocked delivery")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	cancelFirst()
+	if err := <-first; status.Code(err) != codes.Canceled {
+		t.Fatalf("first caller error = %v, want Canceled", err)
+	}
+	select {
+	case err := <-second:
+		t.Fatalf("first cancellation finalized blocked shared delivery: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(stream.sendBlock)
+	<-stream.sentAckChan
+	session.handleAircraftCommandResult(&agentv1.AircraftCommandResult{
+		CommandId: "command-shared-send", AircraftId: "aircraft-1",
+		Status: agentv1.AircraftCommandResult_STATUS_ACCEPTED,
+	})
+	if err := <-second; err != nil {
+		t.Fatalf("second caller error = %v", err)
+	}
+}
+
 func TestSendAircraftCommandDoesNotBlockSessionRetirementWhileAwaitingResult(t *testing.T) {
 	stream := &mockTelemetryStream{
 		ctx:         context.Background(),

--- a/internal/relay/aircraft_command_test.go
+++ b/internal/relay/aircraft_command_test.go
@@ -10,6 +10,7 @@ import (
 	relayv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestSendAircraftCommandDeliversToConnectedAgentAndCorrelatesResult(t *testing.T) {
@@ -19,8 +20,7 @@ func TestSendAircraftCommandDeliversToConnectedAgentAndCorrelatesResult(t *testi
 	}
 	session := &DroneSession{
 		agentID: "agent-1", SessionID: "session-1",
-		stream:          &telemetryStreamBinding{stream: stream},
-		pendingAircraft: make(map[string]chan aircraftCommandOutcome),
+		stream: &telemetryStreamBinding{stream: stream},
 	}
 	relay := &Relay{
 		controlAuthorizer: func(context.Context) error { return nil },
@@ -64,11 +64,26 @@ func TestSendAircraftCommandDeliversToConnectedAgentAndCorrelatesResult(t *testi
 		if got.err != nil {
 			t.Fatal(got.err)
 		}
-		if got.response.GetResult() != wantResult {
+		if !proto.Equal(got.response.GetResult(), wantResult) {
 			t.Fatalf("result = %+v", got.response.GetResult())
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for correlated command result")
+	}
+
+	retry, err := relay.SendAircraftCommand(context.Background(), &relayv1.SendAircraftCommandRequest{AgentId: "agent-1", Command: command})
+	if err != nil || !proto.Equal(retry.GetResult(), wantResult) {
+		t.Fatalf("retained exact retry = %#v, %v", retry, err)
+	}
+	select {
+	case duplicate := <-stream.sentAckChan:
+		t.Fatalf("exact retry redelivered aircraft command: %#v", duplicate)
+	default:
+	}
+	conflict := proto.Clone(command).(*agentv1.AircraftCommand)
+	conflict.Type = agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_DISARM
+	if _, err := relay.SendAircraftCommand(context.Background(), &relayv1.SendAircraftCommandRequest{AgentId: "agent-1", Command: conflict}); status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("conflicting command-ID reuse error = %v, want AlreadyExists", err)
 	}
 }
 
@@ -96,8 +111,7 @@ func TestSendAircraftCommandDeadlineCleansPendingCorrelation(t *testing.T) {
 	}
 	session := &DroneSession{
 		agentID: "agent-1", SessionID: "session-1",
-		stream:          &telemetryStreamBinding{stream: stream},
-		pendingAircraft: make(map[string]chan aircraftCommandOutcome),
+		stream: &telemetryStreamBinding{stream: stream},
 	}
 	relay := &Relay{
 		controlAuthorizer: func(context.Context) error { return nil },
@@ -116,10 +130,10 @@ func TestSendAircraftCommandDeadlineCleansPendingCorrelation(t *testing.T) {
 		t.Fatalf("error = %v, want DeadlineExceeded", err)
 	}
 	session.pendingMu.Lock()
-	_, stillPending := session.pendingAircraft["command-1"]
+	state := session.aircraftCommands["command-1"]
 	session.pendingMu.Unlock()
-	if stillPending {
-		t.Fatal("expired command remained pending")
+	if state == nil || !state.completed || status.Code(state.err) != codes.DeadlineExceeded {
+		t.Fatalf("expired command state = %#v", state)
 	}
 }
 
@@ -130,8 +144,7 @@ func TestSendAircraftCommandDoesNotBlockSessionRetirementWhileAwaitingResult(t *
 	}
 	session := &DroneSession{
 		agentID: "agent-1", SessionID: "session-1",
-		stream:          &telemetryStreamBinding{stream: stream},
-		pendingAircraft: make(map[string]chan aircraftCommandOutcome),
+		stream: &telemetryStreamBinding{stream: stream},
 	}
 	relay := &Relay{
 		controlAuthorizer: func(context.Context) error { return nil },

--- a/internal/relay/aircraft_command_test.go
+++ b/internal/relay/aircraft_command_test.go
@@ -20,7 +20,7 @@ func TestSendAircraftCommandDeliversToConnectedAgentAndCorrelatesResult(t *testi
 	session := &DroneSession{
 		agentID: "agent-1", SessionID: "session-1",
 		stream:          &telemetryStreamBinding{stream: stream},
-		pendingAircraft: make(map[string]chan *agentv1.AircraftCommandResult),
+		pendingAircraft: make(map[string]chan aircraftCommandOutcome),
 	}
 	relay := &Relay{
 		controlAuthorizer: func(context.Context) error { return nil },
@@ -97,7 +97,7 @@ func TestSendAircraftCommandDeadlineCleansPendingCorrelation(t *testing.T) {
 	session := &DroneSession{
 		agentID: "agent-1", SessionID: "session-1",
 		stream:          &telemetryStreamBinding{stream: stream},
-		pendingAircraft: make(map[string]chan *agentv1.AircraftCommandResult),
+		pendingAircraft: make(map[string]chan aircraftCommandOutcome),
 	}
 	relay := &Relay{
 		controlAuthorizer: func(context.Context) error { return nil },
@@ -120,6 +120,56 @@ func TestSendAircraftCommandDeadlineCleansPendingCorrelation(t *testing.T) {
 	session.pendingMu.Unlock()
 	if stillPending {
 		t.Fatal("expired command remained pending")
+	}
+}
+
+func TestSendAircraftCommandDoesNotBlockSessionRetirementWhileAwaitingResult(t *testing.T) {
+	stream := &mockTelemetryStream{
+		ctx:         context.Background(),
+		sentAckChan: make(chan *agentv1.RelayStreamMessage, 1),
+	}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream:          &telemetryStreamBinding{stream: stream},
+		pendingAircraft: make(map[string]chan aircraftCommandOutcome),
+	}
+	relay := &Relay{
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      map[string]*DroneSession{"agent-1": session},
+	}
+	completed := make(chan error, 1)
+	go func() {
+		_, err := relay.SendAircraftCommand(context.Background(), &relayv1.SendAircraftCommandRequest{
+			AgentId: "agent-1",
+			Command: &agentv1.AircraftCommand{
+				CommandId: "command-retire", AircraftId: "aircraft-1",
+				Type: agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_ARM,
+			},
+		})
+		completed <- err
+	}()
+	<-stream.sentAckChan
+
+	retired := make(chan struct{})
+	go func() {
+		session.ownershipMu.Lock()
+		session.retired = true
+		session.abortPendingAircraftCommands()
+		session.ownershipMu.Unlock()
+		close(retired)
+	}()
+	select {
+	case <-retired:
+	case <-time.After(time.Second):
+		t.Fatal("session retirement blocked behind aircraft command result wait")
+	}
+	select {
+	case err := <-completed:
+		if status.Code(err) != codes.Aborted {
+			t.Fatalf("command error = %v, want Aborted", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("pending command did not wake when session retired")
 	}
 }
 

--- a/internal/relay/aircraft_command_test.go
+++ b/internal/relay/aircraft_command_test.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -21,7 +22,10 @@ func TestSendAircraftCommandDeliversToConnectedAgentAndCorrelatesResult(t *testi
 		stream:          &telemetryStreamBinding{stream: stream},
 		pendingAircraft: make(map[string]chan *agentv1.AircraftCommandResult),
 	}
-	relay := &Relay{grpcSessions: map[string]*DroneSession{"agent-1": session}}
+	relay := &Relay{
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      map[string]*DroneSession{"agent-1": session},
+	}
 	command := &agentv1.AircraftCommand{
 		CommandId: "command-1", AircraftId: "aircraft-1",
 		Type: agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_ARM,
@@ -69,7 +73,10 @@ func TestSendAircraftCommandDeliversToConnectedAgentAndCorrelatesResult(t *testi
 }
 
 func TestSendAircraftCommandRejectsDisconnectedAgent(t *testing.T) {
-	relay := &Relay{grpcSessions: make(map[string]*DroneSession)}
+	relay := &Relay{
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      make(map[string]*DroneSession),
+	}
 	_, err := relay.SendAircraftCommand(context.Background(), &relayv1.SendAircraftCommandRequest{
 		AgentId: "agent-1",
 		Command: &agentv1.AircraftCommand{
@@ -92,7 +99,10 @@ func TestSendAircraftCommandDeadlineCleansPendingCorrelation(t *testing.T) {
 		stream:          &telemetryStreamBinding{stream: stream},
 		pendingAircraft: make(map[string]chan *agentv1.AircraftCommandResult),
 	}
-	relay := &Relay{grpcSessions: map[string]*DroneSession{"agent-1": session}}
+	relay := &Relay{
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      map[string]*DroneSession{"agent-1": session},
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 	_, err := relay.SendAircraftCommand(ctx, &relayv1.SendAircraftCommandRequest{
@@ -110,5 +120,14 @@ func TestSendAircraftCommandDeadlineCleansPendingCorrelation(t *testing.T) {
 	session.pendingMu.Unlock()
 	if stillPending {
 		t.Fatal("expired command remained pending")
+	}
+}
+
+func TestSendAircraftCommandRequiresAuthorizedControlCaller(t *testing.T) {
+	want := status.Error(codes.PermissionDenied, "denied")
+	relay := &Relay{controlAuthorizer: func(context.Context) error { return want }}
+	_, err := relay.SendAircraftCommand(context.Background(), &relayv1.SendAircraftCommandRequest{})
+	if !errors.Is(err, want) {
+		t.Fatalf("SendAircraftCommand() error = %v, want %v", err, want)
 	}
 }

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -84,7 +84,9 @@ func (s *Relay) GetDroneStatus(_ context.Context, req *pb.GetDroneStatusRequest)
 // acknowledgement whose active context matches the requested value.
 //
 // Parameters:
-//   - ctx: bounds authorization, stream delivery, and acknowledgement waiting.
+//   - ctx: bounds authorization, waiting to start stream delivery, and
+//     acknowledgement waiting. Once a stream Send starts, the session lease is
+//     held through that write, so the RPC may return after ctx expires.
 //   - req: identifies the Agent and carries a durable command ID and context.
 //
 // Returns:
@@ -144,8 +146,12 @@ func (s *Relay) SetOperationContext(ctx context.Context, req *pb.SetOperationCon
 // correlated acknowledgement of the authoritative resulting context.
 //
 // Parameters:
-//   - ctx: bounds authorization, stream delivery, and acknowledgement waiting.
-//   - req: identifies the Agent and carries a durable command ID and flight ID.
+//   - ctx: bounds authorization, waiting to start stream delivery, and
+//     acknowledgement waiting. Once a stream Send starts, the session lease is
+//     held through that write, so the RPC may return after ctx expires.
+//   - req: identifies the Agent and carries a durable command ID. Flight ID is
+//     normally required; it may be empty only to reconcile a fresh Relay
+//     session to the API's authoritative empty context.
 //
 // Returns:
 //   - response: contains the correlated Agent acknowledgement.
@@ -161,8 +167,8 @@ func (s *Relay) ClearOperationContext(ctx context.Context, req *pb.ClearOperatio
 	if agentID == "" {
 		return nil, status.Error(codes.InvalidArgument, "agent ID is required")
 	}
-	if command == nil || strings.TrimSpace(command.GetCommandId()) == "" || strings.TrimSpace(command.GetFlightId()) == "" {
-		return nil, status.Error(codes.InvalidArgument, "operation-context command ID and flight ID are required")
+	if command == nil || strings.TrimSpace(command.GetCommandId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "operation-context command ID is required")
 	}
 	session, err := s.currentControlSession(agentID)
 	if err != nil {
@@ -173,6 +179,10 @@ func (s *Relay) ClearOperationContext(ctx context.Context, req *pb.ClearOperatio
 		return nil, err
 	}
 	defer release()
+	flightID := command.GetFlightId()
+	if strings.TrimSpace(flightID) == "" && (flightID != "" || !session.reserveEmptyContextReconciliation(command.GetCommandId())) {
+		return nil, status.Error(codes.InvalidArgument, "flight ID may be empty only while reconciling a fresh Relay session")
+	}
 	session.ownershipMu.RLock()
 	if !s.sessionIsCurrent(agentID, session) {
 		session.ownershipMu.RUnlock()

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -187,6 +187,13 @@ func (s *Relay) ClearOperationContext(ctx context.Context, req *pb.ClearOperatio
 	if emptyReconciliation && !session.reserveEmptyContextReconciliation(command.GetCommandId()) {
 		return nil, status.Error(codes.InvalidArgument, "flight ID may be empty only while reconciling a fresh Relay session")
 	}
+	if emptyReconciliation {
+		// Successful reconciliation opens admission before this runs, preserving
+		// the durable ID for exact retries. Every failure leaves the session
+		// unreconciled, so the reservation must be released even when the result
+		// was retained and no new delivery was owned by this caller.
+		defer session.releaseEmptyContextReconciliation(command.GetCommandId())
+	}
 	session.ownershipMu.RLock()
 	if !s.sessionIsCurrent(agentID, session) {
 		session.ownershipMu.RUnlock()
@@ -197,9 +204,6 @@ func (s *Relay) ClearOperationContext(ctx context.Context, req *pb.ClearOperatio
 	}, expectedContextAfterClear(session, command.GetFlightId()), true)
 	session.ownershipMu.RUnlock()
 	if err != nil {
-		if emptyReconciliation {
-			session.releaseEmptyContextReconciliation(command.GetCommandId())
-		}
 		return nil, err
 	}
 	ack, err := awaitOperationCommand(ctx, session, command.GetCommandId(), state, owner)

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -298,16 +298,14 @@ func (s *Relay) SendAircraftCommand(ctx context.Context, req *pb.SendAircraftCom
 	var result *agentv1.AircraftCommandResult
 	select {
 	case <-state.done:
-		result, err = aircraftCommandResult(session, state)
+		result, err = takeAircraftCommandResult(session, state)
 		if err != nil {
 			relayAircraftCommandsTotal.WithLabelValues(command.GetType().String(), "delivery_failed").Inc()
 			return nil, err
 		}
 	case <-ctx.Done():
 		requestErr := status.FromContextError(ctx.Err()).Err()
-		if owner {
-			finishAircraftCommand(session, command.GetCommandId(), state, nil, requestErr)
-		}
+		cancelAircraftCommandWaiter(session, command.GetCommandId(), state, requestErr)
 		relayAircraftCommandsTotal.WithLabelValues(command.GetType().String(), "delivery_failed").Inc()
 		return nil, requestErr
 	}
@@ -349,6 +347,7 @@ func beginAircraftCommandDelivery(ctx context.Context, session *DroneSession, co
 			session.pendingMu.Unlock()
 			return nil, false, status.Error(codes.AlreadyExists, "aircraft command ID was already used with a different payload")
 		}
+		existing.waiters++
 		session.pendingMu.Unlock()
 		return existing, false, nil
 	}
@@ -356,7 +355,7 @@ func beginAircraftCommandDelivery(ctx context.Context, session *DroneSession, co
 		session.pendingMu.Unlock()
 		return nil, false, status.Error(codes.ResourceExhausted, "aircraft command retention is full")
 	}
-	state := &aircraftCommandState{fingerprint: fingerprint, done: make(chan struct{})}
+	state := &aircraftCommandState{fingerprint: fingerprint, done: make(chan struct{}), waiters: 1}
 	session.aircraftCommands[command.GetCommandId()] = state
 	session.pendingMu.Unlock()
 	if err := sendToSession(ctx, session, &agentv1.RelayStreamMessage{
@@ -407,13 +406,34 @@ func finishAircraftCommand(session *DroneSession, commandID string, state *aircr
 	close(state.done)
 }
 
-func aircraftCommandResult(session *DroneSession, state *aircraftCommandState) (*agentv1.AircraftCommandResult, error) {
+func takeAircraftCommandResult(session *DroneSession, state *aircraftCommandState) (*agentv1.AircraftCommandResult, error) {
 	session.pendingMu.Lock()
 	defer session.pendingMu.Unlock()
+	if state.waiters > 0 {
+		state.waiters--
+	}
 	if state.result == nil {
 		return nil, state.err
 	}
 	return proto.Clone(state.result).(*agentv1.AircraftCommandResult), state.err
+}
+
+func cancelAircraftCommandWaiter(session *DroneSession, commandID string, state *aircraftCommandState, err error) {
+	session.pendingMu.Lock()
+	defer session.pendingMu.Unlock()
+	if session.aircraftCommands[commandID] != state {
+		return
+	}
+	if state.waiters > 0 {
+		state.waiters--
+	}
+	if state.waiters != 0 || state.completed {
+		return
+	}
+	state.err = err
+	state.completed = true
+	state.completedAt = time.Now()
+	close(state.done)
 }
 
 // deliverOperationCommandToSession retains command fingerprints and terminal

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -410,7 +410,7 @@ func beginAircraftCommandDelivery(session *DroneSession, command *agentv1.Aircra
 	go func() {
 		defer session.ownershipMu.RUnlock()
 		defer session.controlStreamMu.RUnlock()
-		if err := sendToSessionWithWritePolicy(deliveryCtx, session, &agentv1.RelayStreamMessage{
+		if _, err := sendToSessionWithWritePolicy(deliveryCtx, session, &agentv1.RelayStreamMessage{
 			Payload: &agentv1.RelayStreamMessage_AircraftCommand{AircraftCommand: command},
 		}, true); err != nil {
 			finishAircraftCommand(session, command.GetCommandId(), state, nil, err)
@@ -524,16 +524,15 @@ func beginOperationCommandDelivery(
 		return nil, false, err
 	}
 	if owner {
-		send := sendToSession
-		if waitThroughWrite {
-			send = func(ctx context.Context, session *DroneSession, message *agentv1.RelayStreamMessage) error {
-				return sendToSessionWithWritePolicy(ctx, session, message, true)
-			}
-		}
-		if err := send(ctx, session, message); err != nil {
-			finishOperationCommand(session, commandID, state, nil, err, false)
-		} else {
+		sendAttempted, sendErr := sendToSessionWithWritePolicy(ctx, session, message, waitThroughWrite)
+		if sendAttempted {
+			// Both successful Send and Send errors are outcome-uncertain until the
+			// Agent ACK is correlated: the peer may have durably applied the
+			// mutation before Relay observed either result.
 			markOperationCommandDelivered(session, commandID, state)
+		}
+		if sendErr != nil {
+			finishOperationCommand(session, commandID, state, nil, sendErr, sendAttempted)
 		}
 	}
 	return state, owner, nil

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -13,7 +13,9 @@ package relay
 
 import (
 	"context"
+	"log/slog"
 	"strings"
+	"time"
 
 	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
 	pb "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
@@ -95,6 +97,118 @@ func (*Relay) SetOperationContext(context.Context, *pb.SetOperationContextReques
 //   - error: is a gRPC Unimplemented status explaining the security gate.
 func (*Relay) ClearOperationContext(context.Context, *pb.ClearOperationContextRequest) (*pb.ClearOperationContextResponse, error) {
 	return nil, status.Error(codes.Unimplemented, operationContextControlDisabled)
+}
+
+// SendAircraftCommand delivers an immediate ARM or DISARM command to the
+// Agent session active at RPC admission and waits for its correlated result.
+// The command is never queued for a later or replacement session.
+//
+// Parameters:
+//   - ctx: bounds delivery and the wait for the Agent/autopilot result.
+//   - req: identifies the Agent route and carries the aircraft command envelope.
+//
+// Returns:
+//   - response: contains the Agent's correlated autopilot-level result.
+//   - error: reports invalid input, an offline/replaced Agent session, stream
+//     delivery failure, deadline expiry, or a malformed Agent result.
+func (s *Relay) SendAircraftCommand(ctx context.Context, req *pb.SendAircraftCommandRequest) (*pb.SendAircraftCommandResponse, error) {
+	agentID := strings.TrimSpace(req.GetAgentId())
+	command := req.GetCommand()
+	if agentID == "" || command == nil || strings.TrimSpace(command.GetCommandId()) == "" || strings.TrimSpace(command.GetAircraftId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "agent_id, command_id, and aircraft_id are required")
+	}
+	if command.GetType() != agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_ARM &&
+		command.GetType() != agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_DISARM {
+		return nil, status.Error(codes.InvalidArgument, "aircraft command type must be ARM or DISARM")
+	}
+
+	s.sessionsMu.RLock()
+	session := s.grpcSessions[agentID]
+	s.sessionsMu.RUnlock()
+	if session == nil {
+		return nil, status.Error(codes.NotFound, "agent is not connected")
+	}
+
+	// Pin this exact session generation through result correlation. Registration
+	// replacement and stream cleanup require the write side of this lease, so an
+	// admitted command cannot migrate to a reconnecting Agent.
+	session.ownershipMu.RLock()
+	defer session.ownershipMu.RUnlock()
+	s.sessionsMu.RLock()
+	current := s.grpcSessions[agentID] == session && !session.retired
+	s.sessionsMu.RUnlock()
+	if !current {
+		return nil, status.Error(codes.NotFound, "agent session is no longer active")
+	}
+	session.sessionMu.RLock()
+	connected := session.stream != nil
+	sessionID := session.SessionID
+	session.sessionMu.RUnlock()
+	if !connected {
+		return nil, status.Error(codes.NotFound, "agent stream is not connected")
+	}
+
+	startedAt := time.Now()
+	slog.LogAttrs(ctx, slog.LevelInfo, "command_delivered_to_agent",
+		slog.String("command_id", command.GetCommandId()),
+		slog.String("aircraft_id", command.GetAircraftId()),
+		slog.String("agent_id", agentID),
+		slog.String("session_id", sessionID),
+		slog.String("command_type", command.GetType().String()),
+	)
+	result, err := deliverAircraftCommandToSession(ctx, session, command)
+	if err != nil {
+		relayAircraftCommandsTotal.WithLabelValues(command.GetType().String(), "delivery_failed").Inc()
+		return nil, err
+	}
+	if result.GetCommandId() != command.GetCommandId() || result.GetAircraftId() != command.GetAircraftId() {
+		return nil, status.Error(codes.Internal, "agent returned a mismatched aircraft command result")
+	}
+	duration := time.Since(startedAt)
+	relayAircraftCommandsTotal.WithLabelValues(command.GetType().String(), result.GetStatus().String()).Inc()
+	relayAircraftCommandDuration.WithLabelValues(command.GetType().String()).Observe(duration.Seconds())
+	slog.LogAttrs(ctx, slog.LevelInfo, "command_completed",
+		slog.String("command_id", command.GetCommandId()),
+		slog.String("aircraft_id", command.GetAircraftId()),
+		slog.String("agent_id", agentID),
+		slog.String("session_id", sessionID),
+		slog.String("command_type", command.GetType().String()),
+		slog.String("result", result.GetStatus().String()),
+		slog.Duration("duration", duration),
+	)
+	return &pb.SendAircraftCommandResponse{Result: result}, nil
+}
+
+func deliverAircraftCommandToSession(ctx context.Context, session *DroneSession, command *agentv1.AircraftCommand) (*agentv1.AircraftCommandResult, error) {
+	pending := make(chan *agentv1.AircraftCommandResult, 1)
+	session.pendingMu.Lock()
+	if session.pendingAircraft == nil {
+		session.pendingAircraft = make(map[string]chan *agentv1.AircraftCommandResult)
+	}
+	if _, exists := session.pendingAircraft[command.GetCommandId()]; exists {
+		session.pendingMu.Unlock()
+		return nil, status.Error(codes.AlreadyExists, "aircraft command is already pending")
+	}
+	session.pendingAircraft[command.GetCommandId()] = pending
+	session.pendingMu.Unlock()
+	cleanup := func() {
+		session.pendingMu.Lock()
+		delete(session.pendingAircraft, command.GetCommandId())
+		session.pendingMu.Unlock()
+	}
+	if err := sendToSession(ctx, session, &agentv1.RelayStreamMessage{
+		Payload: &agentv1.RelayStreamMessage_AircraftCommand{AircraftCommand: command},
+	}); err != nil {
+		cleanup()
+		return nil, err
+	}
+	select {
+	case result := <-pending:
+		return result, nil
+	case <-ctx.Done():
+		cleanup()
+		return nil, status.FromContextError(ctx.Err()).Err()
+	}
 }
 
 // deliverOperationCommandToSession is experimental command-delivery machinery.

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -527,7 +527,9 @@ func beginOperationCommandDelivery(
 			}
 		}
 		if err := send(ctx, session, message); err != nil {
-			finishOperationCommand(session, commandID, state, nil, err)
+			finishOperationCommand(session, commandID, state, nil, err, false)
+		} else {
+			markOperationCommandDelivered(session, commandID, state)
 		}
 	}
 	return state, owner, nil
@@ -540,7 +542,7 @@ func awaitOperationCommand(ctx context.Context, session *DroneSession, commandID
 	case <-ctx.Done():
 		requestErr := status.FromContextError(ctx.Err()).Err()
 		if owner {
-			finishOperationCommand(session, commandID, state, nil, requestErr)
+			finishOperationCommand(session, commandID, state, nil, requestErr, true)
 		}
 		return nil, requestErr
 	}
@@ -648,11 +650,20 @@ func finishOperationCommand(
 	state *operationCommandState,
 	ack *agentv1.OperationContextCommandAck,
 	err error,
+	fenceIfDelivered bool,
 ) {
 	session.pendingMu.Lock()
 	defer session.pendingMu.Unlock()
 	if session.operationCommands[commandID] != state || state.completed {
 		return
+	}
+	if fenceIfDelivered && state.delivered {
+		// The Agent may have durably applied this mutation before the caller's
+		// deadline elapsed. Its now-uncorrelated ACK cannot safely update Relay's
+		// attribution, so telemetry must wait for API reconciliation.
+		session.sessionMu.Lock()
+		session.operationContextUnreconciled = true
+		session.sessionMu.Unlock()
 	}
 	delete(session.pending, commandID)
 	state.ack = cloneOperationAck(ack)
@@ -660,6 +671,14 @@ func finishOperationCommand(
 	state.completed = true
 	state.completedAt = time.Now()
 	close(state.done)
+}
+
+func markOperationCommandDelivered(session *DroneSession, commandID string, state *operationCommandState) {
+	session.pendingMu.Lock()
+	defer session.pendingMu.Unlock()
+	if session.operationCommands[commandID] == state && !state.completed {
+		state.delivered = true
+	}
 }
 
 func operationCommandResult(session *DroneSession, state *operationCommandState) (*agentv1.OperationContextCommandAck, error) {

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -150,8 +150,9 @@ func (s *Relay) SetOperationContext(ctx context.Context, req *pb.SetOperationCon
 //     acknowledgement waiting. Once a stream Send starts, the session lease is
 //     held through that write, so the RPC may return after ctx expires.
 //   - req: identifies the Agent and carries a durable command ID. Flight ID is
-//     normally required; it may be empty only to reconcile a fresh Relay
-//     session to the API's authoritative empty context.
+//     required for a conditional clear. The authoritative discriminator may be
+//     true with an empty flight ID only to reconcile a gated Relay session to
+//     the API's authoritative empty context.
 //
 // Returns:
 //   - response: contains the correlated Agent acknowledgement.
@@ -180,10 +181,15 @@ func (s *Relay) ClearOperationContext(ctx context.Context, req *pb.ClearOperatio
 	}
 	defer release()
 	flightID := command.GetFlightId()
-	if strings.TrimSpace(flightID) == "" && flightID != "" {
-		return nil, status.Error(codes.InvalidArgument, "flight ID may be empty only while reconciling a fresh Relay session")
+	authoritative := command.GetAuthoritative()
+	if authoritative {
+		if flightID != "" {
+			return nil, status.Error(codes.InvalidArgument, "authoritative clear requires an empty flight ID")
+		}
+	} else if strings.TrimSpace(flightID) == "" {
+		return nil, status.Error(codes.InvalidArgument, "conditional clear requires a flight ID")
 	}
-	emptyReconciliation := flightID == ""
+	emptyReconciliation := authoritative
 	if emptyReconciliation && !session.reserveEmptyContextReconciliation(command.GetCommandId()) {
 		return nil, status.Error(codes.InvalidArgument, "flight ID may be empty only while reconciling a fresh Relay session")
 	}
@@ -201,7 +207,7 @@ func (s *Relay) ClearOperationContext(ctx context.Context, req *pb.ClearOperatio
 	}
 	state, owner, err := beginOperationCommandDelivery(ctx, session, command.GetCommandId(), &agentv1.RelayStreamMessage{
 		Payload: &agentv1.RelayStreamMessage_ClearOperationContext{ClearOperationContext: command},
-	}, expectedContextAfterClear(session, command.GetFlightId()), true)
+	}, expectedContextAfterClear(session, command.GetFlightId(), authoritative), true)
 	session.ownershipMu.RUnlock()
 	if err != nil {
 		return nil, err
@@ -676,10 +682,10 @@ func cloneOperationAck(value *agentv1.OperationContextCommandAck) *agentv1.Opera
 	return proto.Clone(value).(*agentv1.OperationContextCommandAck)
 }
 
-func expectedContextAfterClear(session *DroneSession, flightID string) *agentv1.OperationContext {
+func expectedContextAfterClear(session *DroneSession, flightID string, authoritative bool) *agentv1.OperationContext {
 	session.sessionMu.RLock()
 	defer session.sessionMu.RUnlock()
-	if session.FlightID == "" || session.FlightID == flightID {
+	if authoritative || session.FlightID == "" || session.FlightID == flightID {
 		return nil
 	}
 	return &agentv1.OperationContext{

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const operationContextControlDisabled = "operation-context control is experimental and disabled until the relay control plane is authenticated and authorized"
+const operationContextControlDisabled = "operation-context control is disabled until mTLS control authentication is configured"
 
 // ListActiveDrones snapshots the Relay's currently admitted Agent sessions as
 // drone-status records.
@@ -79,8 +79,36 @@ func (s *Relay) GetDroneStatus(_ context.Context, req *pb.GetDroneStatusRequest)
 // Returns:
 //   - response: is always nil while the RPC is disabled.
 //   - error: is a gRPC Unimplemented status explaining the security gate.
-func (*Relay) SetOperationContext(context.Context, *pb.SetOperationContextRequest) (*pb.SetOperationContextResponse, error) {
-	return nil, status.Error(codes.Unimplemented, operationContextControlDisabled)
+func (s *Relay) SetOperationContext(ctx context.Context, req *pb.SetOperationContextRequest) (*pb.SetOperationContextResponse, error) {
+	if err := s.authorizeControlMutation(ctx); err != nil {
+		return nil, err
+	}
+	agentID := strings.TrimSpace(req.GetAgentId())
+	command := req.GetCommand()
+	if agentID == "" {
+		return nil, status.Error(codes.InvalidArgument, "agent ID is required")
+	}
+	if command == nil || strings.TrimSpace(command.GetCommandId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "operation-context command ID is required")
+	}
+	operation := command.GetContext()
+	if operation == nil || strings.TrimSpace(operation.GetFlightId()) == "" || strings.TrimSpace(operation.GetIntentId()) == "" || operation.GetIntentVersion() == 0 {
+		return nil, status.Error(codes.InvalidArgument, "flight ID, intent ID, and positive intent version are required")
+	}
+	session, err := s.currentControlSession(agentID)
+	if err != nil {
+		return nil, err
+	}
+	ack, err := deliverOperationCommandToSession(ctx, session, command.GetCommandId(), &agentv1.RelayStreamMessage{
+		Payload: &agentv1.RelayStreamMessage_SetOperationContext{SetOperationContext: command},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !s.sessionIsCurrent(agentID, session) {
+		return nil, status.Error(codes.Aborted, "agent session changed while applying operation context")
+	}
+	return &pb.SetOperationContextResponse{Result: ack}, nil
 }
 
 // ClearOperationContext rejects operation-context mutation while the Relay
@@ -93,8 +121,61 @@ func (*Relay) SetOperationContext(context.Context, *pb.SetOperationContextReques
 // Returns:
 //   - response: is always nil while the RPC is disabled.
 //   - error: is a gRPC Unimplemented status explaining the security gate.
-func (*Relay) ClearOperationContext(context.Context, *pb.ClearOperationContextRequest) (*pb.ClearOperationContextResponse, error) {
-	return nil, status.Error(codes.Unimplemented, operationContextControlDisabled)
+func (s *Relay) ClearOperationContext(ctx context.Context, req *pb.ClearOperationContextRequest) (*pb.ClearOperationContextResponse, error) {
+	if err := s.authorizeControlMutation(ctx); err != nil {
+		return nil, err
+	}
+	agentID := strings.TrimSpace(req.GetAgentId())
+	command := req.GetCommand()
+	if agentID == "" {
+		return nil, status.Error(codes.InvalidArgument, "agent ID is required")
+	}
+	if command == nil || strings.TrimSpace(command.GetCommandId()) == "" || strings.TrimSpace(command.GetFlightId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "operation-context command ID and flight ID are required")
+	}
+	session, err := s.currentControlSession(agentID)
+	if err != nil {
+		return nil, err
+	}
+	ack, err := deliverOperationCommandToSession(ctx, session, command.GetCommandId(), &agentv1.RelayStreamMessage{
+		Payload: &agentv1.RelayStreamMessage_ClearOperationContext{ClearOperationContext: command},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !s.sessionIsCurrent(agentID, session) {
+		return nil, status.Error(codes.Aborted, "agent session changed while clearing operation context")
+	}
+	return &pb.ClearOperationContextResponse{Result: ack}, nil
+}
+
+func (s *Relay) authorizeControlMutation(ctx context.Context) error {
+	if s.controlAuthorizer == nil {
+		return status.Error(codes.Unimplemented, operationContextControlDisabled)
+	}
+	return s.controlAuthorizer(ctx)
+}
+
+func (s *Relay) currentControlSession(agentID string) (*DroneSession, error) {
+	s.sessionsMu.RLock()
+	session := s.grpcSessions[agentID]
+	s.sessionsMu.RUnlock()
+	if session == nil {
+		return nil, status.Error(codes.NotFound, "agent is not registered")
+	}
+	session.ownershipMu.RLock()
+	defer session.ownershipMu.RUnlock()
+	if !s.sessionIsCurrent(agentID, session) || session.retired {
+		return nil, status.Error(codes.Aborted, "agent session changed before operation-context delivery")
+	}
+	return session, nil
+}
+
+func (s *Relay) sessionIsCurrent(agentID string, expected *DroneSession) bool {
+	s.sessionsMu.RLock()
+	current := s.grpcSessions[agentID]
+	s.sessionsMu.RUnlock()
+	return current == expected
 }
 
 // deliverOperationCommandToSession is experimental command-delivery machinery.

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -180,7 +180,11 @@ func (s *Relay) ClearOperationContext(ctx context.Context, req *pb.ClearOperatio
 	}
 	defer release()
 	flightID := command.GetFlightId()
-	if strings.TrimSpace(flightID) == "" && (flightID != "" || !session.reserveEmptyContextReconciliation(command.GetCommandId())) {
+	if strings.TrimSpace(flightID) == "" && flightID != "" {
+		return nil, status.Error(codes.InvalidArgument, "flight ID may be empty only while reconciling a fresh Relay session")
+	}
+	emptyReconciliation := flightID == ""
+	if emptyReconciliation && !session.reserveEmptyContextReconciliation(command.GetCommandId()) {
 		return nil, status.Error(codes.InvalidArgument, "flight ID may be empty only while reconciling a fresh Relay session")
 	}
 	session.ownershipMu.RLock()
@@ -193,6 +197,9 @@ func (s *Relay) ClearOperationContext(ctx context.Context, req *pb.ClearOperatio
 	}, expectedContextAfterClear(session, command.GetFlightId()), true)
 	session.ownershipMu.RUnlock()
 	if err != nil {
+		if emptyReconciliation {
+			session.releaseEmptyContextReconciliation(command.GetCommandId())
+		}
 		return nil, err
 	}
 	ack, err := awaitOperationCommand(ctx, session, command.GetCommandId(), state, owner)
@@ -240,7 +247,10 @@ func (s *Relay) sessionIsCurrent(agentID string, expected *DroneSession) bool {
 // or replacement session.
 //
 // Parameters:
-//   - ctx: bounds delivery and the wait for the Agent/autopilot result.
+//   - ctx: bounds waiting to start delivery and waiting for the
+//     Agent/autopilot result. Once stream Send starts, shared command/session
+//     ownership continues through that write, so delivery may complete after
+//     ctx expires and the caller must treat the outcome as uncertain.
 //   - req: identifies the Agent route and carries the aircraft command envelope.
 //
 // Returns:

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -281,10 +281,13 @@ func (s *Relay) SendAircraftCommand(ctx context.Context, req *pb.SendAircraftCom
 
 	startedAt := time.Now()
 	state, owner, err := beginAircraftCommandDelivery(session, command)
-	session.ownershipMu.RUnlock()
 	if err != nil {
+		session.ownershipMu.RUnlock()
 		relayAircraftCommandsTotal.WithLabelValues(command.GetType().String(), "delivery_failed").Inc()
 		return nil, err
+	}
+	if !owner {
+		session.ownershipMu.RUnlock()
 	}
 	if owner {
 		slog.LogAttrs(ctx, slog.LevelInfo, "command_delivery_started",
@@ -330,6 +333,9 @@ func (s *Relay) SendAircraftCommand(ctx context.Context, req *pb.SendAircraftCom
 	return &pb.SendAircraftCommandResponse{Result: result}, nil
 }
 
+// beginAircraftCommandDelivery requires the caller to hold the session
+// ownership read lease. A new delivery transfers that lease to its send task;
+// an attached duplicate or an error leaves release with the caller.
 func beginAircraftCommandDelivery(session *DroneSession, command *agentv1.AircraftCommand) (*aircraftCommandState, bool, error) {
 	encoded, err := proto.MarshalOptions{Deterministic: true}.Marshal(command)
 	if err != nil {
@@ -364,7 +370,8 @@ func beginAircraftCommandDelivery(session *DroneSession, command *agentv1.Aircra
 	session.pendingMu.Unlock()
 	command = proto.Clone(command).(*agentv1.AircraftCommand)
 	go func() {
-		if err := sendToSession(deliveryCtx, session, &agentv1.RelayStreamMessage{
+		defer session.ownershipMu.RUnlock()
+		if err := sendToSessionThroughWrite(deliveryCtx, session, &agentv1.RelayStreamMessage{
 			Payload: &agentv1.RelayStreamMessage_AircraftCommand{AircraftCommand: command},
 		}); err != nil {
 			finishAircraftCommand(session, command.GetCommandId(), state, nil, err)

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -280,14 +280,14 @@ func (s *Relay) SendAircraftCommand(ctx context.Context, req *pb.SendAircraftCom
 	}
 
 	startedAt := time.Now()
-	state, owner, err := beginAircraftCommandDelivery(ctx, session, command)
+	state, owner, err := beginAircraftCommandDelivery(session, command)
 	session.ownershipMu.RUnlock()
 	if err != nil {
 		relayAircraftCommandsTotal.WithLabelValues(command.GetType().String(), "delivery_failed").Inc()
 		return nil, err
 	}
 	if owner {
-		slog.LogAttrs(ctx, slog.LevelInfo, "command_delivered_to_agent",
+		slog.LogAttrs(ctx, slog.LevelInfo, "command_delivery_started",
 			slog.String("command_id", command.GetCommandId()),
 			slog.String("aircraft_id", command.GetAircraftId()),
 			slog.String("agent_id", agentID),
@@ -330,7 +330,7 @@ func (s *Relay) SendAircraftCommand(ctx context.Context, req *pb.SendAircraftCom
 	return &pb.SendAircraftCommandResponse{Result: result}, nil
 }
 
-func beginAircraftCommandDelivery(ctx context.Context, session *DroneSession, command *agentv1.AircraftCommand) (*aircraftCommandState, bool, error) {
+func beginAircraftCommandDelivery(session *DroneSession, command *agentv1.AircraftCommand) (*aircraftCommandState, bool, error) {
 	encoded, err := proto.MarshalOptions{Deterministic: true}.Marshal(command)
 	if err != nil {
 		return nil, false, status.Errorf(codes.Internal, "fingerprint aircraft command: %v", err)
@@ -355,14 +355,21 @@ func beginAircraftCommandDelivery(ctx context.Context, session *DroneSession, co
 		session.pendingMu.Unlock()
 		return nil, false, status.Error(codes.ResourceExhausted, "aircraft command retention is full")
 	}
-	state := &aircraftCommandState{fingerprint: fingerprint, done: make(chan struct{}), waiters: 1}
+	deliveryCtx, deliveryCancel := context.WithCancel(context.Background())
+	state := &aircraftCommandState{
+		fingerprint: fingerprint, done: make(chan struct{}),
+		deliveryCancel: deliveryCancel, waiters: 1,
+	}
 	session.aircraftCommands[command.GetCommandId()] = state
 	session.pendingMu.Unlock()
-	if err := sendToSession(ctx, session, &agentv1.RelayStreamMessage{
-		Payload: &agentv1.RelayStreamMessage_AircraftCommand{AircraftCommand: command},
-	}); err != nil {
-		finishAircraftCommand(session, command.GetCommandId(), state, nil, err)
-	}
+	command = proto.Clone(command).(*agentv1.AircraftCommand)
+	go func() {
+		if err := sendToSession(deliveryCtx, session, &agentv1.RelayStreamMessage{
+			Payload: &agentv1.RelayStreamMessage_AircraftCommand{AircraftCommand: command},
+		}); err != nil {
+			finishAircraftCommand(session, command.GetCommandId(), state, nil, err)
+		}
+	}()
 	return state, true, nil
 }
 
@@ -403,6 +410,7 @@ func finishAircraftCommand(session *DroneSession, commandID string, state *aircr
 	state.err = err
 	state.completed = true
 	state.completedAt = time.Now()
+	state.deliveryCancel()
 	close(state.done)
 }
 
@@ -433,6 +441,7 @@ func cancelAircraftCommandWaiter(session *DroneSession, commandID string, state 
 	state.err = err
 	state.completed = true
 	state.completedAt = time.Now()
+	state.deliveryCancel()
 	close(state.done)
 }
 

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -245,15 +245,15 @@ func (s *Relay) SendAircraftCommand(ctx context.Context, req *pb.SendAircraftCom
 		return nil, status.Error(codes.NotFound, "agent is not connected")
 	}
 
-	// Pin this exact session generation through result correlation. Registration
-	// replacement and stream cleanup require the write side of this lease, so an
-	// admitted command cannot migrate to a reconnecting Agent.
+	// Pin this exact session generation only through admission and stream send.
+	// Waiting while holding the lease would prevent a disconnected Agent from
+	// being retired or replaced. Retirement explicitly aborts the pending wait.
 	session.ownershipMu.RLock()
-	defer session.ownershipMu.RUnlock()
 	s.sessionsMu.RLock()
 	current := s.grpcSessions[agentID] == session && !session.retired
 	s.sessionsMu.RUnlock()
 	if !current {
+		session.ownershipMu.RUnlock()
 		return nil, status.Error(codes.NotFound, "agent session is no longer active")
 	}
 	session.sessionMu.RLock()
@@ -261,6 +261,7 @@ func (s *Relay) SendAircraftCommand(ctx context.Context, req *pb.SendAircraftCom
 	sessionID := session.SessionID
 	session.sessionMu.RUnlock()
 	if !connected {
+		session.ownershipMu.RUnlock()
 		return nil, status.Error(codes.NotFound, "agent stream is not connected")
 	}
 
@@ -272,10 +273,27 @@ func (s *Relay) SendAircraftCommand(ctx context.Context, req *pb.SendAircraftCom
 		slog.String("session_id", sessionID),
 		slog.String("command_type", command.GetType().String()),
 	)
-	result, err := deliverAircraftCommandToSession(ctx, session, command)
+	pending, cleanup, err := beginAircraftCommandDelivery(ctx, session, command)
+	session.ownershipMu.RUnlock()
 	if err != nil {
 		relayAircraftCommandsTotal.WithLabelValues(command.GetType().String(), "delivery_failed").Inc()
 		return nil, err
+	}
+	defer cleanup()
+	var result *agentv1.AircraftCommandResult
+	select {
+	case outcome := <-pending:
+		if outcome.err != nil {
+			relayAircraftCommandsTotal.WithLabelValues(command.GetType().String(), "delivery_failed").Inc()
+			return nil, outcome.err
+		}
+		result = outcome.result
+	case <-ctx.Done():
+		relayAircraftCommandsTotal.WithLabelValues(command.GetType().String(), "delivery_failed").Inc()
+		return nil, status.FromContextError(ctx.Err()).Err()
+	}
+	if result == nil {
+		return nil, status.Error(codes.Internal, "agent returned an empty aircraft command result")
 	}
 	if result.GetCommandId() != command.GetCommandId() || result.GetAircraftId() != command.GetAircraftId() {
 		return nil, status.Error(codes.Internal, "agent returned a mismatched aircraft command result")
@@ -295,15 +313,15 @@ func (s *Relay) SendAircraftCommand(ctx context.Context, req *pb.SendAircraftCom
 	return &pb.SendAircraftCommandResponse{Result: result}, nil
 }
 
-func deliverAircraftCommandToSession(ctx context.Context, session *DroneSession, command *agentv1.AircraftCommand) (*agentv1.AircraftCommandResult, error) {
-	pending := make(chan *agentv1.AircraftCommandResult, 1)
+func beginAircraftCommandDelivery(ctx context.Context, session *DroneSession, command *agentv1.AircraftCommand) (<-chan aircraftCommandOutcome, func(), error) {
+	pending := make(chan aircraftCommandOutcome, 1)
 	session.pendingMu.Lock()
 	if session.pendingAircraft == nil {
-		session.pendingAircraft = make(map[string]chan *agentv1.AircraftCommandResult)
+		session.pendingAircraft = make(map[string]chan aircraftCommandOutcome)
 	}
 	if _, exists := session.pendingAircraft[command.GetCommandId()]; exists {
 		session.pendingMu.Unlock()
-		return nil, status.Error(codes.AlreadyExists, "aircraft command is already pending")
+		return nil, nil, status.Error(codes.AlreadyExists, "aircraft command is already pending")
 	}
 	session.pendingAircraft[command.GetCommandId()] = pending
 	session.pendingMu.Unlock()
@@ -316,15 +334,9 @@ func deliverAircraftCommandToSession(ctx context.Context, session *DroneSession,
 		Payload: &agentv1.RelayStreamMessage_AircraftCommand{AircraftCommand: command},
 	}); err != nil {
 		cleanup()
-		return nil, err
+		return nil, nil, err
 	}
-	select {
-	case result := <-pending:
-		return result, nil
-	case <-ctx.Done():
-		cleanup()
-		return nil, status.FromContextError(ctx.Err()).Err()
-	}
+	return pending, cleanup, nil
 }
 
 // deliverOperationCommandToSession retains command fingerprints and terminal

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -117,12 +117,19 @@ func (s *Relay) SetOperationContext(ctx context.Context, req *pb.SetOperationCon
 		return nil, err
 	}
 	defer release()
+	session.ownershipMu.RLock()
 	if !s.sessionIsCurrent(agentID, session) {
+		session.ownershipMu.RUnlock()
 		return nil, status.Error(codes.Aborted, "agent session changed before operation-context delivery")
 	}
-	ack, err := deliverOperationCommandToSession(ctx, session, command.GetCommandId(), &agentv1.RelayStreamMessage{
+	state, owner, err := beginOperationCommandDelivery(ctx, session, command.GetCommandId(), &agentv1.RelayStreamMessage{
 		Payload: &agentv1.RelayStreamMessage_SetOperationContext{SetOperationContext: command},
 	}, operation)
+	session.ownershipMu.RUnlock()
+	if err != nil {
+		return nil, err
+	}
+	ack, err := awaitOperationCommand(ctx, session, command.GetCommandId(), state, owner)
 	if err != nil {
 		return nil, err
 	}
@@ -166,12 +173,19 @@ func (s *Relay) ClearOperationContext(ctx context.Context, req *pb.ClearOperatio
 		return nil, err
 	}
 	defer release()
+	session.ownershipMu.RLock()
 	if !s.sessionIsCurrent(agentID, session) {
+		session.ownershipMu.RUnlock()
 		return nil, status.Error(codes.Aborted, "agent session changed before operation-context delivery")
 	}
-	ack, err := deliverOperationCommandToSession(ctx, session, command.GetCommandId(), &agentv1.RelayStreamMessage{
+	state, owner, err := beginOperationCommandDelivery(ctx, session, command.GetCommandId(), &agentv1.RelayStreamMessage{
 		Payload: &agentv1.RelayStreamMessage_ClearOperationContext{ClearOperationContext: command},
 	}, expectedContextAfterClear(session, command.GetFlightId()))
+	session.ownershipMu.RUnlock()
+	if err != nil {
+		return nil, err
+	}
+	ack, err := awaitOperationCommand(ctx, session, command.GetCommandId(), state, owner)
 	if err != nil {
 		return nil, err
 	}
@@ -266,31 +280,36 @@ func (s *Relay) SendAircraftCommand(ctx context.Context, req *pb.SendAircraftCom
 	}
 
 	startedAt := time.Now()
-	slog.LogAttrs(ctx, slog.LevelInfo, "command_delivered_to_agent",
-		slog.String("command_id", command.GetCommandId()),
-		slog.String("aircraft_id", command.GetAircraftId()),
-		slog.String("agent_id", agentID),
-		slog.String("session_id", sessionID),
-		slog.String("command_type", command.GetType().String()),
-	)
-	pending, cleanup, err := beginAircraftCommandDelivery(ctx, session, command)
+	state, owner, err := beginAircraftCommandDelivery(ctx, session, command)
 	session.ownershipMu.RUnlock()
 	if err != nil {
 		relayAircraftCommandsTotal.WithLabelValues(command.GetType().String(), "delivery_failed").Inc()
 		return nil, err
 	}
-	defer cleanup()
+	if owner {
+		slog.LogAttrs(ctx, slog.LevelInfo, "command_delivered_to_agent",
+			slog.String("command_id", command.GetCommandId()),
+			slog.String("aircraft_id", command.GetAircraftId()),
+			slog.String("agent_id", agentID),
+			slog.String("session_id", sessionID),
+			slog.String("command_type", command.GetType().String()),
+		)
+	}
 	var result *agentv1.AircraftCommandResult
 	select {
-	case outcome := <-pending:
-		if outcome.err != nil {
+	case <-state.done:
+		result, err = aircraftCommandResult(session, state)
+		if err != nil {
 			relayAircraftCommandsTotal.WithLabelValues(command.GetType().String(), "delivery_failed").Inc()
-			return nil, outcome.err
+			return nil, err
 		}
-		result = outcome.result
 	case <-ctx.Done():
+		requestErr := status.FromContextError(ctx.Err()).Err()
+		if owner {
+			finishAircraftCommand(session, command.GetCommandId(), state, nil, requestErr)
+		}
 		relayAircraftCommandsTotal.WithLabelValues(command.GetType().String(), "delivery_failed").Inc()
-		return nil, status.FromContextError(ctx.Err()).Err()
+		return nil, requestErr
 	}
 	if result == nil {
 		return nil, status.Error(codes.Internal, "agent returned an empty aircraft command result")
@@ -313,59 +332,120 @@ func (s *Relay) SendAircraftCommand(ctx context.Context, req *pb.SendAircraftCom
 	return &pb.SendAircraftCommandResponse{Result: result}, nil
 }
 
-func beginAircraftCommandDelivery(ctx context.Context, session *DroneSession, command *agentv1.AircraftCommand) (<-chan aircraftCommandOutcome, func(), error) {
-	pending := make(chan aircraftCommandOutcome, 1)
+func beginAircraftCommandDelivery(ctx context.Context, session *DroneSession, command *agentv1.AircraftCommand) (*aircraftCommandState, bool, error) {
+	encoded, err := proto.MarshalOptions{Deterministic: true}.Marshal(command)
+	if err != nil {
+		return nil, false, status.Errorf(codes.Internal, "fingerprint aircraft command: %v", err)
+	}
+	digest := sha256.Sum256(encoded)
+	fingerprint := hex.EncodeToString(digest[:])
 	session.pendingMu.Lock()
-	if session.pendingAircraft == nil {
-		session.pendingAircraft = make(map[string]chan aircraftCommandOutcome)
+	if session.aircraftCommands == nil {
+		session.aircraftCommands = make(map[string]*aircraftCommandState)
 	}
-	if _, exists := session.pendingAircraft[command.GetCommandId()]; exists {
+	pruneAircraftCommandsLocked(session, time.Now())
+	if existing := session.aircraftCommands[command.GetCommandId()]; existing != nil {
+		if existing.fingerprint != fingerprint {
+			session.pendingMu.Unlock()
+			return nil, false, status.Error(codes.AlreadyExists, "aircraft command ID was already used with a different payload")
+		}
 		session.pendingMu.Unlock()
-		return nil, nil, status.Error(codes.AlreadyExists, "aircraft command is already pending")
+		return existing, false, nil
 	}
-	session.pendingAircraft[command.GetCommandId()] = pending
+	if len(session.aircraftCommands) >= maxOperationCommands {
+		session.pendingMu.Unlock()
+		return nil, false, status.Error(codes.ResourceExhausted, "aircraft command retention is full")
+	}
+	state := &aircraftCommandState{fingerprint: fingerprint, done: make(chan struct{})}
+	session.aircraftCommands[command.GetCommandId()] = state
 	session.pendingMu.Unlock()
-	cleanup := func() {
-		session.pendingMu.Lock()
-		delete(session.pendingAircraft, command.GetCommandId())
-		session.pendingMu.Unlock()
-	}
 	if err := sendToSession(ctx, session, &agentv1.RelayStreamMessage{
 		Payload: &agentv1.RelayStreamMessage_AircraftCommand{AircraftCommand: command},
 	}); err != nil {
-		cleanup()
-		return nil, nil, err
+		finishAircraftCommand(session, command.GetCommandId(), state, nil, err)
 	}
-	return pending, cleanup, nil
+	return state, true, nil
+}
+
+func pruneAircraftCommandsLocked(session *DroneSession, now time.Time) {
+	for commandID, state := range session.aircraftCommands {
+		if state.completed && now.Sub(state.completedAt) >= operationCommandRetention {
+			delete(session.aircraftCommands, commandID)
+		}
+	}
+	for len(session.aircraftCommands) >= maxOperationCommands {
+		var oldestID string
+		var oldest time.Time
+		for commandID, state := range session.aircraftCommands {
+			if !state.completed {
+				continue
+			}
+			if oldestID == "" || state.completedAt.Before(oldest) {
+				oldestID = commandID
+				oldest = state.completedAt
+			}
+		}
+		if oldestID == "" {
+			return
+		}
+		delete(session.aircraftCommands, oldestID)
+	}
+}
+
+func finishAircraftCommand(session *DroneSession, commandID string, state *aircraftCommandState, result *agentv1.AircraftCommandResult, err error) {
+	session.pendingMu.Lock()
+	defer session.pendingMu.Unlock()
+	if session.aircraftCommands[commandID] != state || state.completed {
+		return
+	}
+	if result != nil {
+		state.result = proto.Clone(result).(*agentv1.AircraftCommandResult)
+	}
+	state.err = err
+	state.completed = true
+	state.completedAt = time.Now()
+	close(state.done)
+}
+
+func aircraftCommandResult(session *DroneSession, state *aircraftCommandState) (*agentv1.AircraftCommandResult, error) {
+	session.pendingMu.Lock()
+	defer session.pendingMu.Unlock()
+	if state.result == nil {
+		return nil, state.err
+	}
+	return proto.Clone(state.result).(*agentv1.AircraftCommandResult), state.err
 }
 
 // deliverOperationCommandToSession retains command fingerprints and terminal
 // outcomes for the session, coalesces exact concurrent retries, and rejects a
 // command ID reused with a different payload. The Agent WAL provides the
 // durable cross-session and cross-process idempotency backstop.
-func deliverOperationCommandToSession(
+func beginOperationCommandDelivery(
 	ctx context.Context,
 	session *DroneSession,
 	commandID string,
 	message *agentv1.RelayStreamMessage,
 	expected *agentv1.OperationContext,
-) (*agentv1.OperationContextCommandAck, error) {
+) (*operationCommandState, bool, error) {
 	encoded, err := proto.MarshalOptions{Deterministic: true}.Marshal(message)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "fingerprint operation-context command: %v", err)
+		return nil, false, status.Errorf(codes.Internal, "fingerprint operation-context command: %v", err)
 	}
 	digest := sha256.Sum256(encoded)
 	fingerprint := hex.EncodeToString(digest[:])
 	state, owner, err := beginOperationCommand(session, commandID, fingerprint, expected)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if owner {
 		if err := sendToSession(ctx, session, message); err != nil {
 			finishOperationCommand(session, commandID, state, nil, err)
 		}
 	}
+	return state, owner, nil
+}
 
+func awaitOperationCommand(ctx context.Context, session *DroneSession, commandID string, state *operationCommandState, owner bool) (*agentv1.OperationContextCommandAck, error) {
 	select {
 	case <-state.done:
 		return operationCommandResult(session, state)
@@ -376,6 +456,14 @@ func deliverOperationCommandToSession(
 		}
 		return nil, requestErr
 	}
+}
+
+func deliverOperationCommandToSession(ctx context.Context, session *DroneSession, commandID string, message *agentv1.RelayStreamMessage, expected *agentv1.OperationContext) (*agentv1.OperationContextCommandAck, error) {
+	state, owner, err := beginOperationCommandDelivery(ctx, session, commandID, message, expected)
+	if err != nil {
+		return nil, err
+	}
+	return awaitOperationCommand(ctx, session, commandID, state, owner)
 }
 
 func makeOperationGate() chan struct{} {

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -367,6 +367,10 @@ func beginAircraftCommandDelivery(session *DroneSession, command *agentv1.Aircra
 	}
 	digest := sha256.Sum256(encoded)
 	fingerprint := hex.EncodeToString(digest[:])
+	// Admit the pending state under the same binding fence as its write. A
+	// replacement therefore either follows the completed old-binding write and
+	// aborts its uncertain wait, or precedes admission and receives the command.
+	session.controlStreamMu.RLock()
 	session.pendingMu.Lock()
 	if session.aircraftCommands == nil {
 		session.aircraftCommands = make(map[string]*aircraftCommandState)
@@ -375,14 +379,17 @@ func beginAircraftCommandDelivery(session *DroneSession, command *agentv1.Aircra
 	if existing := session.aircraftCommands[command.GetCommandId()]; existing != nil {
 		if existing.fingerprint != fingerprint {
 			session.pendingMu.Unlock()
+			session.controlStreamMu.RUnlock()
 			return nil, false, status.Error(codes.AlreadyExists, "aircraft command ID was already used with a different payload")
 		}
 		existing.waiters++
 		session.pendingMu.Unlock()
+		session.controlStreamMu.RUnlock()
 		return existing, false, nil
 	}
 	if len(session.aircraftCommands) >= maxOperationCommands {
 		session.pendingMu.Unlock()
+		session.controlStreamMu.RUnlock()
 		return nil, false, status.Error(codes.ResourceExhausted, "aircraft command retention is full")
 	}
 	deliveryCtx, deliveryCancel := context.WithCancel(context.Background())
@@ -395,9 +402,10 @@ func beginAircraftCommandDelivery(session *DroneSession, command *agentv1.Aircra
 	command = proto.Clone(command).(*agentv1.AircraftCommand)
 	go func() {
 		defer session.ownershipMu.RUnlock()
-		if err := sendToSessionThroughWrite(deliveryCtx, session, &agentv1.RelayStreamMessage{
+		defer session.controlStreamMu.RUnlock()
+		if err := sendToSessionWithWritePolicy(deliveryCtx, session, &agentv1.RelayStreamMessage{
 			Payload: &agentv1.RelayStreamMessage_AircraftCommand{AircraftCommand: command},
-		}); err != nil {
+		}, true); err != nil {
 			finishAircraftCommand(session, command.GetCommandId(), state, nil, err)
 		}
 	}()
@@ -494,6 +502,13 @@ func beginOperationCommandDelivery(
 	}
 	digest := sha256.Sum256(encoded)
 	fingerprint := hex.EncodeToString(digest[:])
+	if waitThroughWrite {
+		// Keep admission and the completed stream write in one binding epoch.
+		// This prevents a state aborted by replacement from later being sent on
+		// the newly active binding.
+		session.controlStreamMu.RLock()
+		defer session.controlStreamMu.RUnlock()
+	}
 	state, owner, err := beginOperationCommand(session, commandID, fingerprint, expected)
 	if err != nil {
 		return nil, false, err
@@ -501,7 +516,9 @@ func beginOperationCommandDelivery(
 	if owner {
 		send := sendToSession
 		if waitThroughWrite {
-			send = sendToSessionThroughWrite
+			send = func(ctx context.Context, session *DroneSession, message *agentv1.RelayStreamMessage) error {
+				return sendToSessionWithWritePolicy(ctx, session, message, true)
+			}
 		}
 		if err := send(ctx, session, message); err != nil {
 			finishOperationCommand(session, commandID, state, nil, err)

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -13,6 +13,8 @@ package relay
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"log/slog"
 	"strings"
 	"time"
@@ -21,9 +23,15 @@ import (
 	pb "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 const operationContextControlDisabled = "operation-context control is disabled until mTLS control authentication is configured"
+
+const (
+	operationCommandRetention = 24 * time.Hour
+	maxOperationCommands      = 4096
+)
 
 // ListActiveDrones snapshots the Relay's currently admitted Agent sessions as
 // drone-status records.
@@ -71,16 +79,19 @@ func (s *Relay) GetDroneStatus(_ context.Context, req *pb.GetDroneStatusRequest)
 	return &pb.GetDroneStatusResponse{Drone: droneStatus(session)}, nil
 }
 
-// SetOperationContext rejects operation-context mutation while the Relay
-// control plane lacks its final authentication and authorization policy.
+// SetOperationContext authenticates a control-plane caller, delivers one
+// idempotent context mutation to the current Agent session, and waits for an
+// acknowledgement whose active context matches the requested value.
 //
 // Parameters:
-//   - ctx: is reserved for the future authenticated control-plane lifecycle.
-//   - request: is reserved for the future operation-context command.
+//   - ctx: bounds authorization, stream delivery, and acknowledgement waiting.
+//   - req: identifies the Agent and carries a durable command ID and context.
 //
 // Returns:
-//   - response: is always nil while the RPC is disabled.
-//   - error: is a gRPC Unimplemented status explaining the security gate.
+//   - response: contains the correlated Agent acknowledgement.
+//   - error: reports disabled or denied control access, invalid input, command
+//     ID reuse with a different payload, missing/replaced sessions, delivery or
+//     context cancellation, and malformed or mismatched acknowledgements.
 func (s *Relay) SetOperationContext(ctx context.Context, req *pb.SetOperationContextRequest) (*pb.SetOperationContextResponse, error) {
 	if err := s.authorizeControlMutation(ctx); err != nil {
 		return nil, err
@@ -101,9 +112,17 @@ func (s *Relay) SetOperationContext(ctx context.Context, req *pb.SetOperationCon
 	if err != nil {
 		return nil, err
 	}
+	release, err := acquireOperationCommandSlot(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	if !s.sessionIsCurrent(agentID, session) {
+		return nil, status.Error(codes.Aborted, "agent session changed before operation-context delivery")
+	}
 	ack, err := deliverOperationCommandToSession(ctx, session, command.GetCommandId(), &agentv1.RelayStreamMessage{
 		Payload: &agentv1.RelayStreamMessage_SetOperationContext{SetOperationContext: command},
-	})
+	}, operation)
 	if err != nil {
 		return nil, err
 	}
@@ -113,16 +132,19 @@ func (s *Relay) SetOperationContext(ctx context.Context, req *pb.SetOperationCon
 	return &pb.SetOperationContextResponse{Result: ack}, nil
 }
 
-// ClearOperationContext rejects operation-context mutation while the Relay
-// control plane lacks its final authentication and authorization policy.
+// ClearOperationContext authenticates a control-plane caller, conditionally
+// clears one flight context on the current Agent session, and waits for a
+// correlated acknowledgement of the authoritative resulting context.
 //
 // Parameters:
-//   - ctx: is reserved for the future authenticated control-plane lifecycle.
-//   - request: is reserved for the future operation-context command.
+//   - ctx: bounds authorization, stream delivery, and acknowledgement waiting.
+//   - req: identifies the Agent and carries a durable command ID and flight ID.
 //
 // Returns:
-//   - response: is always nil while the RPC is disabled.
-//   - error: is a gRPC Unimplemented status explaining the security gate.
+//   - response: contains the correlated Agent acknowledgement.
+//   - error: reports disabled or denied control access, invalid input, command
+//     ID reuse with a different payload, missing/replaced sessions, delivery or
+//     context cancellation, and malformed or mismatched acknowledgements.
 func (s *Relay) ClearOperationContext(ctx context.Context, req *pb.ClearOperationContextRequest) (*pb.ClearOperationContextResponse, error) {
 	if err := s.authorizeControlMutation(ctx); err != nil {
 		return nil, err
@@ -139,9 +161,17 @@ func (s *Relay) ClearOperationContext(ctx context.Context, req *pb.ClearOperatio
 	if err != nil {
 		return nil, err
 	}
+	release, err := acquireOperationCommandSlot(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	if !s.sessionIsCurrent(agentID, session) {
+		return nil, status.Error(codes.Aborted, "agent session changed before operation-context delivery")
+	}
 	ack, err := deliverOperationCommandToSession(ctx, session, command.GetCommandId(), &agentv1.RelayStreamMessage{
 		Payload: &agentv1.RelayStreamMessage_ClearOperationContext{ClearOperationContext: command},
-	})
+	}, expectedContextAfterClear(session, command.GetFlightId()))
 	if err != nil {
 		return nil, err
 	}
@@ -180,9 +210,10 @@ func (s *Relay) sessionIsCurrent(agentID string, expected *DroneSession) bool {
 	return current == expected
 }
 
-// SendAircraftCommand delivers an immediate ARM or DISARM command to the
-// Agent session active at RPC admission and waits for its correlated result.
-// The command is never queued for a later or replacement session.
+// SendAircraftCommand authenticates a control-plane caller, delivers an
+// immediate ARM or DISARM command to the Agent session active at RPC admission,
+// and waits for its correlated result. The command is never queued for a later
+// or replacement session.
 //
 // Parameters:
 //   - ctx: bounds delivery and the wait for the Agent/autopilot result.
@@ -190,9 +221,13 @@ func (s *Relay) sessionIsCurrent(agentID string, expected *DroneSession) bool {
 //
 // Returns:
 //   - response: contains the Agent's correlated autopilot-level result.
-//   - error: reports invalid input, an offline/replaced Agent session, stream
-//     delivery failure, deadline expiry, or a malformed Agent result.
+//   - error: reports disabled or denied control access, invalid input, an
+//     offline/replaced Agent session, stream delivery failure, deadline expiry,
+//     or a malformed Agent result.
 func (s *Relay) SendAircraftCommand(ctx context.Context, req *pb.SendAircraftCommandRequest) (*pb.SendAircraftCommandResponse, error) {
+	if err := s.authorizeControlMutation(ctx); err != nil {
+		return nil, err
+	}
 	agentID := strings.TrimSpace(req.GetAgentId())
 	command := req.GetCommand()
 	if agentID == "" || command == nil || strings.TrimSpace(command.GetCommandId()) == "" || strings.TrimSpace(command.GetAircraftId()) == "" {
@@ -292,36 +327,183 @@ func deliverAircraftCommandToSession(ctx context.Context, session *DroneSession,
 	}
 }
 
-// deliverOperationCommandToSession is experimental command-delivery machinery.
-// The public mutation RPCs remain disabled until the control plane is
-// authenticated, authorized, and its command lifecycle is finalized.
-func deliverOperationCommandToSession(ctx context.Context, session *DroneSession, commandID string, message *agentv1.RelayStreamMessage) (*agentv1.OperationContextCommandAck, error) {
-	pending := make(chan *agentv1.OperationContextCommandAck, 1)
+// deliverOperationCommandToSession retains command fingerprints and terminal
+// outcomes for the session, coalesces exact concurrent retries, and rejects a
+// command ID reused with a different payload. The Agent WAL provides the
+// durable cross-session and cross-process idempotency backstop.
+func deliverOperationCommandToSession(
+	ctx context.Context,
+	session *DroneSession,
+	commandID string,
+	message *agentv1.RelayStreamMessage,
+	expected *agentv1.OperationContext,
+) (*agentv1.OperationContextCommandAck, error) {
+	encoded, err := proto.MarshalOptions{Deterministic: true}.Marshal(message)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "fingerprint operation-context command: %v", err)
+	}
+	digest := sha256.Sum256(encoded)
+	fingerprint := hex.EncodeToString(digest[:])
+	state, owner, err := beginOperationCommand(session, commandID, fingerprint, expected)
+	if err != nil {
+		return nil, err
+	}
+	if owner {
+		if err := sendToSession(ctx, session, message); err != nil {
+			finishOperationCommand(session, commandID, state, nil, err)
+		}
+	}
+
+	select {
+	case <-state.done:
+		return operationCommandResult(session, state)
+	case <-ctx.Done():
+		requestErr := status.FromContextError(ctx.Err()).Err()
+		if owner {
+			finishOperationCommand(session, commandID, state, nil, requestErr)
+		}
+		return nil, requestErr
+	}
+}
+
+func makeOperationGate() chan struct{} {
+	gate := make(chan struct{}, 1)
+	gate <- struct{}{}
+	return gate
+}
+
+func acquireOperationCommandSlot(ctx context.Context, session *DroneSession) (func(), error) {
 	session.pendingMu.Lock()
+	if session.operationGate == nil {
+		session.operationGate = makeOperationGate()
+	}
+	gate := session.operationGate
+	session.pendingMu.Unlock()
+
+	select {
+	case <-gate:
+		return func() { gate <- struct{}{} }, nil
+	case <-ctx.Done():
+		return nil, status.FromContextError(ctx.Err()).Err()
+	}
+}
+
+func beginOperationCommand(
+	session *DroneSession,
+	commandID string,
+	fingerprint string,
+	expected *agentv1.OperationContext,
+) (*operationCommandState, bool, error) {
+	session.pendingMu.Lock()
+	defer session.pendingMu.Unlock()
 	if session.pending == nil {
 		session.pending = make(map[string]chan *agentv1.OperationContextCommandAck)
 	}
-	if _, exists := session.pending[commandID]; exists {
-		session.pendingMu.Unlock()
-		return nil, status.Error(codes.AlreadyExists, "operation-context command is already pending")
+	if session.operationCommands == nil {
+		session.operationCommands = make(map[string]*operationCommandState)
 	}
-	session.pending[commandID] = pending
-	session.pendingMu.Unlock()
-	cleanup := func() {
-		session.pendingMu.Lock()
-		delete(session.pending, commandID)
-		session.pendingMu.Unlock()
+	pruneOperationCommandsLocked(session, time.Now())
+	if existing := session.operationCommands[commandID]; existing != nil {
+		if existing.fingerprint != fingerprint {
+			return nil, false, status.Error(codes.AlreadyExists, "operation-context command ID was already used with a different payload")
+		}
+		if !existing.completed || !operationCommandRetryable(existing) {
+			return existing, false, nil
+		}
 	}
-	if err := sendToSession(ctx, session, message); err != nil {
-		cleanup()
-		return nil, err
+	if len(session.operationCommands) >= maxOperationCommands {
+		return nil, false, status.Error(codes.ResourceExhausted, "operation-context command retention is full")
 	}
-	select {
-	case ack := <-pending:
-		return ack, nil
-	case <-ctx.Done():
-		cleanup()
-		return nil, status.FromContextError(ctx.Err()).Err()
+
+	state := &operationCommandState{
+		fingerprint: fingerprint,
+		expected:    cloneOperationContext(expected),
+		done:        make(chan struct{}),
+	}
+	session.operationCommands[commandID] = state
+	session.pending[commandID] = make(chan *agentv1.OperationContextCommandAck, 1)
+	return state, true, nil
+}
+
+func pruneOperationCommandsLocked(session *DroneSession, now time.Time) {
+	for commandID, state := range session.operationCommands {
+		if state.completed && now.Sub(state.completedAt) >= operationCommandRetention {
+			delete(session.operationCommands, commandID)
+		}
+	}
+	for len(session.operationCommands) >= maxOperationCommands {
+		var oldestID string
+		var oldest time.Time
+		for commandID, state := range session.operationCommands {
+			if !state.completed {
+				continue
+			}
+			if oldestID == "" || state.completedAt.Before(oldest) {
+				oldestID = commandID
+				oldest = state.completedAt
+			}
+		}
+		if oldestID == "" {
+			return
+		}
+		delete(session.operationCommands, oldestID)
+	}
+}
+
+func operationCommandRetryable(state *operationCommandState) bool {
+	return state.err != nil || state.ack.GetStatus() == agentv1.OperationContextCommandAck_STATUS_TEMPORARY_ERROR
+}
+
+func finishOperationCommand(
+	session *DroneSession,
+	commandID string,
+	state *operationCommandState,
+	ack *agentv1.OperationContextCommandAck,
+	err error,
+) {
+	session.pendingMu.Lock()
+	defer session.pendingMu.Unlock()
+	if session.operationCommands[commandID] != state || state.completed {
+		return
+	}
+	delete(session.pending, commandID)
+	state.ack = cloneOperationAck(ack)
+	state.err = err
+	state.completed = true
+	state.completedAt = time.Now()
+	close(state.done)
+}
+
+func operationCommandResult(session *DroneSession, state *operationCommandState) (*agentv1.OperationContextCommandAck, error) {
+	session.pendingMu.Lock()
+	defer session.pendingMu.Unlock()
+	return cloneOperationAck(state.ack), state.err
+}
+
+func cloneOperationContext(value *agentv1.OperationContext) *agentv1.OperationContext {
+	if value == nil {
+		return nil
+	}
+	return proto.Clone(value).(*agentv1.OperationContext)
+}
+
+func cloneOperationAck(value *agentv1.OperationContextCommandAck) *agentv1.OperationContextCommandAck {
+	if value == nil {
+		return nil
+	}
+	return proto.Clone(value).(*agentv1.OperationContextCommandAck)
+}
+
+func expectedContextAfterClear(session *DroneSession, flightID string) *agentv1.OperationContext {
+	session.sessionMu.RLock()
+	defer session.sessionMu.RUnlock()
+	if session.FlightID == "" || session.FlightID == flightID {
+		return nil
+	}
+	return &agentv1.OperationContext{
+		FlightId:      session.FlightID,
+		IntentId:      session.IntentID,
+		IntentVersion: session.IntentVersion,
 	}
 }
 

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -124,7 +124,7 @@ func (s *Relay) SetOperationContext(ctx context.Context, req *pb.SetOperationCon
 	}
 	state, owner, err := beginOperationCommandDelivery(ctx, session, command.GetCommandId(), &agentv1.RelayStreamMessage{
 		Payload: &agentv1.RelayStreamMessage_SetOperationContext{SetOperationContext: command},
-	}, operation)
+	}, operation, true)
 	session.ownershipMu.RUnlock()
 	if err != nil {
 		return nil, err
@@ -180,7 +180,7 @@ func (s *Relay) ClearOperationContext(ctx context.Context, req *pb.ClearOperatio
 	}
 	state, owner, err := beginOperationCommandDelivery(ctx, session, command.GetCommandId(), &agentv1.RelayStreamMessage{
 		Payload: &agentv1.RelayStreamMessage_ClearOperationContext{ClearOperationContext: command},
-	}, expectedContextAfterClear(session, command.GetFlightId()))
+	}, expectedContextAfterClear(session, command.GetFlightId()), true)
 	session.ownershipMu.RUnlock()
 	if err != nil {
 		return nil, err
@@ -462,6 +462,7 @@ func beginOperationCommandDelivery(
 	commandID string,
 	message *agentv1.RelayStreamMessage,
 	expected *agentv1.OperationContext,
+	waitThroughWrite bool,
 ) (*operationCommandState, bool, error) {
 	encoded, err := proto.MarshalOptions{Deterministic: true}.Marshal(message)
 	if err != nil {
@@ -474,7 +475,11 @@ func beginOperationCommandDelivery(
 		return nil, false, err
 	}
 	if owner {
-		if err := sendToSession(ctx, session, message); err != nil {
+		send := sendToSession
+		if waitThroughWrite {
+			send = sendToSessionThroughWrite
+		}
+		if err := send(ctx, session, message); err != nil {
 			finishOperationCommand(session, commandID, state, nil, err)
 		}
 	}
@@ -495,7 +500,7 @@ func awaitOperationCommand(ctx context.Context, session *DroneSession, commandID
 }
 
 func deliverOperationCommandToSession(ctx context.Context, session *DroneSession, commandID string, message *agentv1.RelayStreamMessage, expected *agentv1.OperationContext) (*agentv1.OperationContextCommandAck, error) {
-	state, owner, err := beginOperationCommandDelivery(ctx, session, commandID, message, expected)
+	state, owner, err := beginOperationCommandDelivery(ctx, session, commandID, message, expected, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -381,7 +381,7 @@ func beginAircraftCommandDelivery(session *DroneSession, command *agentv1.Aircra
 	if session.aircraftCommands == nil {
 		session.aircraftCommands = make(map[string]*aircraftCommandState)
 	}
-	pruneAircraftCommandsLocked(session, time.Now())
+	expireAircraftCommandsLocked(session, time.Now())
 	if existing := session.aircraftCommands[command.GetCommandId()]; existing != nil {
 		if existing.fingerprint != fingerprint {
 			session.pendingMu.Unlock()
@@ -393,6 +393,7 @@ func beginAircraftCommandDelivery(session *DroneSession, command *agentv1.Aircra
 		session.controlStreamMu.RUnlock()
 		return existing, false, nil
 	}
+	makeAircraftCommandRoomLocked(session)
 	if len(session.aircraftCommands) >= maxOperationCommands {
 		session.pendingMu.Unlock()
 		session.controlStreamMu.RUnlock()
@@ -418,12 +419,15 @@ func beginAircraftCommandDelivery(session *DroneSession, command *agentv1.Aircra
 	return state, true, nil
 }
 
-func pruneAircraftCommandsLocked(session *DroneSession, now time.Time) {
+func expireAircraftCommandsLocked(session *DroneSession, now time.Time) {
 	for commandID, state := range session.aircraftCommands {
 		if state.completed && now.Sub(state.completedAt) >= operationCommandRetention {
 			delete(session.aircraftCommands, commandID)
 		}
 	}
+}
+
+func makeAircraftCommandRoomLocked(session *DroneSession) {
 	for len(session.aircraftCommands) >= maxOperationCommands {
 		var oldestID string
 		var oldest time.Time
@@ -592,7 +596,8 @@ func beginOperationCommand(
 	if session.operationCommands == nil {
 		session.operationCommands = make(map[string]*operationCommandState)
 	}
-	pruneOperationCommandsLocked(session, time.Now())
+	expireOperationCommandsLocked(session, time.Now())
+	replacingRetryable := false
 	if existing := session.operationCommands[commandID]; existing != nil {
 		if existing.fingerprint != fingerprint {
 			return nil, false, status.Error(codes.AlreadyExists, "operation-context command ID was already used with a different payload")
@@ -600,8 +605,11 @@ func beginOperationCommand(
 		if !existing.completed || !operationCommandRetryable(existing) {
 			return existing, false, nil
 		}
+		replacingRetryable = true
+	} else {
+		makeOperationCommandRoomLocked(session)
 	}
-	if len(session.operationCommands) >= maxOperationCommands {
+	if !replacingRetryable && len(session.operationCommands) >= maxOperationCommands {
 		return nil, false, status.Error(codes.ResourceExhausted, "operation-context command retention is full")
 	}
 
@@ -615,12 +623,15 @@ func beginOperationCommand(
 	return state, true, nil
 }
 
-func pruneOperationCommandsLocked(session *DroneSession, now time.Time) {
+func expireOperationCommandsLocked(session *DroneSession, now time.Time) {
 	for commandID, state := range session.operationCommands {
 		if state.completed && now.Sub(state.completedAt) >= operationCommandRetention {
 			delete(session.operationCommands, commandID)
 		}
 	}
+}
+
+func makeOperationCommandRoomLocked(session *DroneSession) {
 	for len(session.operationCommands) >= maxOperationCommands {
 		var oldestID string
 		var oldest time.Time

--- a/internal/relay/apiserver_test.go
+++ b/internal/relay/apiserver_test.go
@@ -143,12 +143,28 @@ func TestClearOperationContextAllowsAuthoritativeEmptyReconciliation(t *testing.
 		controlAuthorizer: func(context.Context) error { return nil },
 		grpcSessions:      map[string]*DroneSession{"agent-1": session},
 	}
+	_, err := relay.ClearOperationContext(context.Background(), &relayv1.ClearOperationContextRequest{
+		AgentId: "agent-1",
+		Command: &agentv1.ClearOperationContextCommand{CommandId: "legacy-empty"},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("legacy empty clear error = %v, want InvalidArgument", err)
+	}
+	_, err = relay.ClearOperationContext(context.Background(), &relayv1.ClearOperationContextRequest{
+		AgentId: "agent-1",
+		Command: &agentv1.ClearOperationContextCommand{
+			CommandId: "contradictory-clear", FlightId: "flight-1", Authoritative: true,
+		},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("contradictory authoritative clear error = %v, want InvalidArgument", err)
+	}
 	session.operationCommands = map[string]*operationCommandState{
 		"conflicting-id": {fingerprint: "different-payload"},
 	}
-	_, err := relay.ClearOperationContext(context.Background(), &relayv1.ClearOperationContextRequest{
+	_, err = relay.ClearOperationContext(context.Background(), &relayv1.ClearOperationContextRequest{
 		AgentId: "agent-1",
-		Command: &agentv1.ClearOperationContextCommand{CommandId: "conflicting-id"},
+		Command: &agentv1.ClearOperationContextCommand{CommandId: "conflicting-id", Authoritative: true},
 	})
 	if status.Code(err) != codes.AlreadyExists {
 		t.Fatalf("conflicting empty reconciliation error = %v, want AlreadyExists", err)
@@ -164,12 +180,12 @@ func TestClearOperationContextAllowsAuthoritativeEmptyReconciliation(t *testing.
 	go func() {
 		_, err := relay.ClearOperationContext(context.Background(), &relayv1.ClearOperationContextRequest{
 			AgentId: "agent-1",
-			Command: &agentv1.ClearOperationContextCommand{CommandId: "reconcile-empty"},
+			Command: &agentv1.ClearOperationContextCommand{CommandId: "reconcile-empty", Authoritative: true},
 		})
 		result <- err
 	}()
 	message := <-stream.sentAckChan
-	if command := message.GetClearOperationContext(); command == nil || command.GetFlightId() != "" {
+	if command := message.GetClearOperationContext(); command == nil || command.GetFlightId() != "" || !command.GetAuthoritative() {
 		t.Fatalf("empty reconciliation command = %#v", command)
 	}
 	session.handleOperationContextCommandAck(&agentv1.OperationContextCommandAck{
@@ -183,7 +199,7 @@ func TestClearOperationContextAllowsAuthoritativeEmptyReconciliation(t *testing.
 	}
 	retry, err := relay.ClearOperationContext(context.Background(), &relayv1.ClearOperationContextRequest{
 		AgentId: "agent-1",
-		Command: &agentv1.ClearOperationContextCommand{CommandId: "reconcile-empty"},
+		Command: &agentv1.ClearOperationContextCommand{CommandId: "reconcile-empty", Authoritative: true},
 	})
 	if err != nil || retry.GetResult().GetStatus() != agentv1.OperationContextCommandAck_STATUS_APPLIED {
 		t.Fatalf("exact empty reconciliation retry = %#v, %v", retry, err)
@@ -208,7 +224,7 @@ func TestClearOperationContextRetainedFailureRetryReleasesEmptyReservation(t *te
 	}
 	failedRequest := &relayv1.ClearOperationContextRequest{
 		AgentId: "agent-1",
-		Command: &agentv1.ClearOperationContextCommand{CommandId: "reconcile-failed"},
+		Command: &agentv1.ClearOperationContextCommand{CommandId: "reconcile-failed", Authoritative: true},
 	}
 	type clearResult struct {
 		response *relayv1.ClearOperationContextResponse
@@ -251,7 +267,7 @@ func TestClearOperationContextRetainedFailureRetryReleasesEmptyReservation(t *te
 	go func() {
 		_, err := relay.ClearOperationContext(context.Background(), &relayv1.ClearOperationContextRequest{
 			AgentId: "agent-1",
-			Command: &agentv1.ClearOperationContextCommand{CommandId: "reconcile-fresh"},
+			Command: &agentv1.ClearOperationContextCommand{CommandId: "reconcile-fresh", Authoritative: true},
 		})
 		freshResult <- err
 	}()
@@ -278,7 +294,7 @@ func TestClearOperationContextRejectsEmptyFlightAfterReconciliation(t *testing.T
 		grpcSessions:      map[string]*DroneSession{"agent-1": session},
 	}
 	_, err := relay.ClearOperationContext(context.Background(), &relayv1.ClearOperationContextRequest{
-		AgentId: "agent-1", Command: &agentv1.ClearOperationContextCommand{CommandId: "empty-after-ready"},
+		AgentId: "agent-1", Command: &agentv1.ClearOperationContextCommand{CommandId: "empty-after-ready", Authoritative: true},
 	})
 	if status.Code(err) != codes.InvalidArgument {
 		t.Fatalf("ClearOperationContext() error = %v, want InvalidArgument", err)

--- a/internal/relay/apiserver_test.go
+++ b/internal/relay/apiserver_test.go
@@ -132,6 +132,75 @@ func TestSetOperationContextRejectsMismatchedAppliedContext(t *testing.T) {
 	}
 }
 
+func TestClearOperationContextAllowsAuthoritativeEmptyReconciliation(t *testing.T) {
+	stream := &mockTelemetryStream{ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 1)}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream: &telemetryStreamBinding{stream: stream}, pending: make(map[string]chan *agentv1.OperationContextCommandAck),
+		operationContextUnreconciled: true,
+	}
+	relay := &Relay{
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      map[string]*DroneSession{"agent-1": session},
+	}
+	result := make(chan error, 1)
+	go func() {
+		_, err := relay.ClearOperationContext(context.Background(), &relayv1.ClearOperationContextRequest{
+			AgentId: "agent-1",
+			Command: &agentv1.ClearOperationContextCommand{CommandId: "reconcile-empty"},
+		})
+		result <- err
+	}()
+	message := <-stream.sentAckChan
+	if command := message.GetClearOperationContext(); command == nil || command.GetFlightId() != "" {
+		t.Fatalf("empty reconciliation command = %#v", command)
+	}
+	session.handleOperationContextCommandAck(&agentv1.OperationContextCommandAck{
+		CommandId: "reconcile-empty", Status: agentv1.OperationContextCommandAck_STATUS_APPLIED,
+	})
+	if err := <-result; err != nil {
+		t.Fatalf("ClearOperationContext() error = %v", err)
+	}
+	if session.requiresOperationContextReconciliation() {
+		t.Fatal("acknowledged empty context did not open telemetry admission")
+	}
+	retry, err := relay.ClearOperationContext(context.Background(), &relayv1.ClearOperationContextRequest{
+		AgentId: "agent-1",
+		Command: &agentv1.ClearOperationContextCommand{CommandId: "reconcile-empty"},
+	})
+	if err != nil || retry.GetResult().GetStatus() != agentv1.OperationContextCommandAck_STATUS_APPLIED {
+		t.Fatalf("exact empty reconciliation retry = %#v, %v", retry, err)
+	}
+	select {
+	case message := <-stream.sentAckChan:
+		t.Fatalf("exact empty reconciliation retry redelivered: %#v", message)
+	default:
+	}
+}
+
+func TestClearOperationContextRejectsEmptyFlightAfterReconciliation(t *testing.T) {
+	stream := &mockTelemetryStream{ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 1)}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream: &telemetryStreamBinding{stream: stream}, pending: make(map[string]chan *agentv1.OperationContextCommandAck),
+	}
+	relay := &Relay{
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      map[string]*DroneSession{"agent-1": session},
+	}
+	_, err := relay.ClearOperationContext(context.Background(), &relayv1.ClearOperationContextRequest{
+		AgentId: "agent-1", Command: &agentv1.ClearOperationContextCommand{CommandId: "empty-after-ready"},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("ClearOperationContext() error = %v, want InvalidArgument", err)
+	}
+	select {
+	case message := <-stream.sentAckChan:
+		t.Fatalf("invalid empty clear reached Agent: %#v", message)
+	default:
+	}
+}
+
 func TestSetOperationContextWaitAbortsWhenSessionRetires(t *testing.T) {
 	stream := &mockTelemetryStream{ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 1)}
 	session := &DroneSession{

--- a/internal/relay/apiserver_test.go
+++ b/internal/relay/apiserver_test.go
@@ -132,6 +132,45 @@ func TestSetOperationContextRejectsMismatchedAppliedContext(t *testing.T) {
 	}
 }
 
+func TestSetOperationContextWaitAbortsWhenSessionRetires(t *testing.T) {
+	stream := &mockTelemetryStream{ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 1)}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream:  &telemetryStreamBinding{stream: stream},
+		pending: make(map[string]chan *agentv1.OperationContextCommandAck),
+	}
+	relay := &Relay{
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      map[string]*DroneSession{"agent-1": session},
+	}
+	completed := make(chan error, 1)
+	go func() {
+		_, err := relay.SetOperationContext(context.Background(), &relayv1.SetOperationContextRequest{
+			AgentId: "agent-1",
+			Command: &agentv1.SetOperationContextCommand{
+				CommandId: "set-retired",
+				Context: &agentv1.OperationContext{
+					FlightId: "flight-1", IntentId: "intent-1", IntentVersion: 1,
+				},
+			},
+		})
+		completed <- err
+	}()
+	<-stream.sentAckChan
+	session.ownershipMu.Lock()
+	session.retired = true
+	session.abortPendingCommands()
+	session.ownershipMu.Unlock()
+	select {
+	case err := <-completed:
+		if status.Code(err) != codes.Aborted {
+			t.Fatalf("SetOperationContext() error = %v, want Aborted", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("pending operation-context command did not wake on retirement")
+	}
+}
+
 func TestConcurrentExactOperationContextRetriesShareOneDelivery(t *testing.T) {
 	stream := &mockTelemetryStream{ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 2)}
 	session := &DroneSession{

--- a/internal/relay/apiserver_test.go
+++ b/internal/relay/apiserver_test.go
@@ -143,6 +143,23 @@ func TestClearOperationContextAllowsAuthoritativeEmptyReconciliation(t *testing.
 		controlAuthorizer: func(context.Context) error { return nil },
 		grpcSessions:      map[string]*DroneSession{"agent-1": session},
 	}
+	session.operationCommands = map[string]*operationCommandState{
+		"conflicting-id": {fingerprint: "different-payload"},
+	}
+	_, err := relay.ClearOperationContext(context.Background(), &relayv1.ClearOperationContextRequest{
+		AgentId: "agent-1",
+		Command: &agentv1.ClearOperationContextCommand{CommandId: "conflicting-id"},
+	})
+	if status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("conflicting empty reconciliation error = %v, want AlreadyExists", err)
+	}
+	session.sessionMu.RLock()
+	poisonedReservation := session.emptyContextCommandID
+	session.sessionMu.RUnlock()
+	if poisonedReservation != "" {
+		t.Fatalf("failed empty reconciliation retained command ID %q", poisonedReservation)
+	}
+
 	result := make(chan error, 1)
 	go func() {
 		_, err := relay.ClearOperationContext(context.Background(), &relayv1.ClearOperationContextRequest{

--- a/internal/relay/apiserver_test.go
+++ b/internal/relay/apiserver_test.go
@@ -195,6 +195,78 @@ func TestClearOperationContextAllowsAuthoritativeEmptyReconciliation(t *testing.
 	}
 }
 
+func TestClearOperationContextRetainedFailureRetryReleasesEmptyReservation(t *testing.T) {
+	stream := &mockTelemetryStream{ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 1)}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream: &telemetryStreamBinding{stream: stream}, pending: make(map[string]chan *agentv1.OperationContextCommandAck),
+		operationContextUnreconciled: true,
+	}
+	relay := &Relay{
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      map[string]*DroneSession{"agent-1": session},
+	}
+	failedRequest := &relayv1.ClearOperationContextRequest{
+		AgentId: "agent-1",
+		Command: &agentv1.ClearOperationContextCommand{CommandId: "reconcile-failed"},
+	}
+	type clearResult struct {
+		response *relayv1.ClearOperationContextResponse
+		err      error
+	}
+	firstResult := make(chan clearResult, 1)
+	go func() {
+		response, err := relay.ClearOperationContext(context.Background(), failedRequest)
+		firstResult <- clearResult{response: response, err: err}
+	}()
+	<-stream.sentAckChan
+	session.handleOperationContextCommandAck(&agentv1.OperationContextCommandAck{
+		CommandId: "reconcile-failed", Status: agentv1.OperationContextCommandAck_STATUS_REJECTED,
+	})
+	first := <-firstResult
+	if first.err != nil || first.response.GetResult().GetStatus() != agentv1.OperationContextCommandAck_STATUS_REJECTED {
+		t.Fatalf("first failed reconciliation = %#v, %v", first.response, first.err)
+	}
+
+	// This exact retry is served from the retained terminal result. It must not
+	// re-reserve the ID, because no new ACK will arrive to release it.
+	retry, err := relay.ClearOperationContext(context.Background(), failedRequest)
+	if err != nil || retry.GetResult().GetStatus() != agentv1.OperationContextCommandAck_STATUS_REJECTED {
+		t.Fatalf("retained failed retry = %#v, %v", retry, err)
+	}
+	select {
+	case duplicate := <-stream.sentAckChan:
+		t.Fatalf("retained failed retry redelivered: %#v", duplicate)
+	default:
+	}
+	session.sessionMu.RLock()
+	reserved := session.emptyContextCommandID
+	session.sessionMu.RUnlock()
+	if reserved != "" {
+		t.Fatalf("retained failed retry poisoned empty reservation with %q", reserved)
+	}
+
+	// A fresh durable command can now reconcile the still-unreconciled session.
+	freshResult := make(chan error, 1)
+	go func() {
+		_, err := relay.ClearOperationContext(context.Background(), &relayv1.ClearOperationContextRequest{
+			AgentId: "agent-1",
+			Command: &agentv1.ClearOperationContextCommand{CommandId: "reconcile-fresh"},
+		})
+		freshResult <- err
+	}()
+	message := <-stream.sentAckChan
+	if message.GetClearOperationContext().GetCommandId() != "reconcile-fresh" {
+		t.Fatalf("fresh reconciliation delivery = %#v", message)
+	}
+	session.handleOperationContextCommandAck(&agentv1.OperationContextCommandAck{
+		CommandId: "reconcile-fresh", Status: agentv1.OperationContextCommandAck_STATUS_APPLIED,
+	})
+	if err := <-freshResult; err != nil {
+		t.Fatalf("fresh reconciliation error = %v", err)
+	}
+}
+
 func TestClearOperationContextRejectsEmptyFlightAfterReconciliation(t *testing.T) {
 	stream := &mockTelemetryStream{ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 1)}
 	session := &DroneSession{

--- a/internal/relay/apiserver_test.go
+++ b/internal/relay/apiserver_test.go
@@ -2,7 +2,10 @@ package relay
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -12,6 +15,60 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
+
+func testMessageFingerprint(t *testing.T, message proto.Message) string {
+	t.Helper()
+	encoded, err := proto.MarshalOptions{Deterministic: true}.Marshal(message)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:])
+}
+
+func TestBeginOperationCommandRetainsExactRetryAtCapacity(t *testing.T) {
+	commandID := "oldest-command"
+	message := &agentv1.RelayStreamMessage{
+		Payload: &agentv1.RelayStreamMessage_SetOperationContext{
+			SetOperationContext: &agentv1.SetOperationContextCommand{
+				CommandId: commandID,
+				Context:   &agentv1.OperationContext{FlightId: "flight-1"},
+			},
+		},
+	}
+	fingerprint := testMessageFingerprint(t, message)
+	completedAt := time.Now().Add(-operationCommandRetention / 2)
+	done := make(chan struct{})
+	close(done)
+	want := &operationCommandState{
+		fingerprint: fingerprint,
+		ack: &agentv1.OperationContextCommandAck{
+			CommandId: commandID,
+			Status:    agentv1.OperationContextCommandAck_STATUS_APPLIED,
+		},
+		done: done, completed: true, completedAt: completedAt,
+	}
+	session := &DroneSession{operationCommands: map[string]*operationCommandState{commandID: want}}
+	for i := 1; i < maxOperationCommands; i++ {
+		id := fmt.Sprintf("retained-%04d", i)
+		session.operationCommands[id] = &operationCommandState{
+			fingerprint: id,
+			ack: &agentv1.OperationContextCommandAck{
+				CommandId: id,
+				Status:    agentv1.OperationContextCommandAck_STATUS_APPLIED,
+			},
+			done: done, completed: true, completedAt: completedAt.Add(time.Duration(i)),
+		}
+	}
+
+	got, owner, err := beginOperationCommand(session, commandID, fingerprint, message.GetSetOperationContext().GetContext())
+	if err != nil || owner || got != want {
+		t.Fatalf("exact retry = (%p, %v, %v), want (%p, false, nil)", got, owner, err, want)
+	}
+	if len(session.operationCommands) != maxOperationCommands {
+		t.Fatalf("retained commands = %d, want %d", len(session.operationCommands), maxOperationCommands)
+	}
+}
 
 func TestSetOperationContextRequiresAuthorizedControlCaller(t *testing.T) {
 	want := status.Error(codes.PermissionDenied, "denied")

--- a/internal/relay/apiserver_test.go
+++ b/internal/relay/apiserver_test.go
@@ -146,6 +146,46 @@ func TestSetOperationContextDeliversToCurrentAgent(t *testing.T) {
 	}
 }
 
+func TestSetOperationContextSendErrorFencesTelemetry(t *testing.T) {
+	sendErr := errors.New("stream outcome unknown")
+	stream := &mockTelemetryStream{
+		ctx:         context.Background(),
+		sentAckChan: make(chan *agentv1.RelayStreamMessage, 1),
+		sendErr:     sendErr,
+	}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream: &telemetryStreamBinding{stream: stream},
+	}
+	relay := &Relay{
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      map[string]*DroneSession{"agent-1": session},
+	}
+	_, err := relay.SetOperationContext(context.Background(), &relayv1.SetOperationContextRequest{
+		AgentId: "agent-1",
+		Command: &agentv1.SetOperationContextCommand{
+			CommandId: "uncertain-send",
+			Context: &agentv1.OperationContext{
+				FlightId: "flight-2", IntentId: "intent-2", IntentVersion: 1,
+			},
+		},
+	})
+	if !errors.Is(err, sendErr) {
+		t.Fatalf("SetOperationContext() error = %v, want %v", err, sendErr)
+	}
+	select {
+	case message := <-stream.sentAckChan:
+		if message.GetSetOperationContext().GetCommandId() != "uncertain-send" {
+			t.Fatalf("delivered command = %#v", message.GetSetOperationContext())
+		}
+	default:
+		t.Fatal("stream error occurred before the operation command was attempted")
+	}
+	if !session.requiresOperationContextReconciliation() {
+		t.Fatal("uncertain operation-context send did not fence telemetry")
+	}
+}
+
 func TestSetOperationContextRejectsMismatchedAppliedContext(t *testing.T) {
 	stream := &mockTelemetryStream{ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 1)}
 	session := &DroneSession{

--- a/internal/relay/apiserver_test.go
+++ b/internal/relay/apiserver_test.go
@@ -10,6 +10,7 @@ import (
 	relayv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestSetOperationContextRequiresAuthorizedControlCaller(t *testing.T) {
@@ -67,6 +68,185 @@ func TestSetOperationContextDeliversToCurrentAgent(t *testing.T) {
 	}
 	if got.response.GetResult().GetStatus() != agentv1.OperationContextCommandAck_STATUS_APPLIED {
 		t.Fatalf("SetOperationContext() response = %#v", got.response)
+	}
+
+	// An exact retry returns the retained result without delivering twice.
+	retry, err := relay.SetOperationContext(context.Background(), request)
+	if err != nil || !proto.Equal(retry.GetResult(), got.response.GetResult()) {
+		t.Fatalf("exact retry = %#v, %v", retry, err)
+	}
+	select {
+	case duplicate := <-stream.sentAckChan:
+		t.Fatalf("exact retry redelivered command: %#v", duplicate)
+	default:
+	}
+
+	// A reused ID with a changed payload is rejected before delivery.
+	conflict := proto.Clone(request).(*relayv1.SetOperationContextRequest)
+	conflict.Command.Context.FlightId = "different-flight"
+	if _, err := relay.SetOperationContext(context.Background(), conflict); status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("conflicting retry error = %v, want AlreadyExists", err)
+	}
+}
+
+func TestSetOperationContextRejectsMismatchedAppliedContext(t *testing.T) {
+	stream := &mockTelemetryStream{ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 1)}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream:  &telemetryStreamBinding{stream: stream},
+		pending: make(map[string]chan *agentv1.OperationContextCommandAck),
+	}
+	relay := &Relay{
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      map[string]*DroneSession{"agent-1": session},
+	}
+	request := &relayv1.SetOperationContextRequest{
+		AgentId: "agent-1",
+		Command: &agentv1.SetOperationContextCommand{
+			CommandId: "command-mismatch",
+			Context: &agentv1.OperationContext{
+				FlightId: "flight-1", IntentId: "intent-1", IntentVersion: 2,
+			},
+		},
+	}
+	result := make(chan error, 1)
+	go func() {
+		_, err := relay.SetOperationContext(context.Background(), request)
+		result <- err
+	}()
+	<-stream.sentAckChan
+	session.handleOperationContextCommandAck(&agentv1.OperationContextCommandAck{
+		CommandId: "command-mismatch",
+		Status:    agentv1.OperationContextCommandAck_STATUS_APPLIED,
+		ActiveContext: &agentv1.OperationContext{
+			FlightId: "other-flight", IntentId: "other-intent", IntentVersion: 99,
+		},
+	})
+	if err := <-result; status.Code(err) != codes.Internal {
+		t.Fatalf("mismatched ACK error = %v, want Internal", err)
+	}
+	session.sessionMu.RLock()
+	defer session.sessionMu.RUnlock()
+	if session.FlightID != "" || session.IntentID != "" || session.IntentVersion != 0 {
+		t.Fatalf("mismatched ACK changed context to (%q, %q, %d)", session.FlightID, session.IntentID, session.IntentVersion)
+	}
+}
+
+func TestConcurrentExactOperationContextRetriesShareOneDelivery(t *testing.T) {
+	stream := &mockTelemetryStream{ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 2)}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream:  &telemetryStreamBinding{stream: stream},
+		pending: make(map[string]chan *agentv1.OperationContextCommandAck),
+	}
+	relay := &Relay{
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      map[string]*DroneSession{"agent-1": session},
+	}
+	request := &relayv1.SetOperationContextRequest{
+		AgentId: "agent-1",
+		Command: &agentv1.SetOperationContextCommand{
+			CommandId: "command-shared",
+			Context: &agentv1.OperationContext{
+				FlightId: "flight-1", IntentId: "intent-1", IntentVersion: 2,
+			},
+		},
+	}
+	results := make(chan error, 2)
+	go func() {
+		_, err := relay.SetOperationContext(context.Background(), request)
+		results <- err
+	}()
+	<-stream.sentAckChan
+	go func() {
+		_, err := relay.SetOperationContext(context.Background(), request)
+		results <- err
+	}()
+	select {
+	case duplicate := <-stream.sentAckChan:
+		t.Fatalf("concurrent retry redelivered command: %#v", duplicate)
+	case <-time.After(20 * time.Millisecond):
+	}
+	session.handleOperationContextCommandAck(&agentv1.OperationContextCommandAck{
+		CommandId:     "command-shared",
+		Status:        agentv1.OperationContextCommandAck_STATUS_APPLIED,
+		ActiveContext: proto.Clone(request.Command.Context).(*agentv1.OperationContext),
+	})
+	for range 2 {
+		if err := <-results; err != nil {
+			t.Fatalf("shared retry error = %v", err)
+		}
+	}
+}
+
+func TestOperationContextMutationsAreSerializedPerSession(t *testing.T) {
+	stream := &mockTelemetryStream{ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 2)}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream:        &telemetryStreamBinding{stream: stream},
+		pending:       make(map[string]chan *agentv1.OperationContextCommandAck),
+		FlightID:      "flight-a",
+		IntentID:      "intent-a",
+		IntentVersion: 1,
+	}
+	relay := &Relay{
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      map[string]*DroneSession{"agent-1": session},
+	}
+	setRequest := &relayv1.SetOperationContextRequest{
+		AgentId: "agent-1",
+		Command: &agentv1.SetOperationContextCommand{
+			CommandId: "set-b",
+			Context: &agentv1.OperationContext{
+				FlightId: "flight-b", IntentId: "intent-b", IntentVersion: 2,
+			},
+		},
+	}
+	clearRequest := &relayv1.ClearOperationContextRequest{
+		AgentId: "agent-1",
+		Command: &agentv1.ClearOperationContextCommand{CommandId: "clear-a", FlightId: "flight-a"},
+	}
+
+	setResult := make(chan error, 1)
+	go func() {
+		_, err := relay.SetOperationContext(context.Background(), setRequest)
+		setResult <- err
+	}()
+	<-stream.sentAckChan
+
+	clearResult := make(chan error, 1)
+	go func() {
+		_, err := relay.ClearOperationContext(context.Background(), clearRequest)
+		clearResult <- err
+	}()
+	select {
+	case message := <-stream.sentAckChan:
+		t.Fatalf("clear overtook pending set: %#v", message)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	session.handleOperationContextCommandAck(&agentv1.OperationContextCommandAck{
+		CommandId:     "set-b",
+		Status:        agentv1.OperationContextCommandAck_STATUS_APPLIED,
+		ActiveContext: proto.Clone(setRequest.Command.Context).(*agentv1.OperationContext),
+	})
+	if err := <-setResult; err != nil {
+		t.Fatalf("set result = %v", err)
+	}
+	clearMessage := <-stream.sentAckChan
+	if clearMessage.GetClearOperationContext().GetCommandId() != "clear-a" {
+		t.Fatalf("second delivery = %#v, want clear-a", clearMessage)
+	}
+	session.handleOperationContextCommandAck(&agentv1.OperationContextCommandAck{
+		CommandId:     "clear-a",
+		Status:        agentv1.OperationContextCommandAck_STATUS_APPLIED,
+		ActiveContext: proto.Clone(setRequest.Command.Context).(*agentv1.OperationContext),
+	})
+	if err := <-clearResult; err != nil {
+		t.Fatalf("clear result = %v", err)
+	}
+	if got := droneStatus(session); got.GetFlightId() != "flight-b" || got.GetIntentId() != "intent-b" || got.GetIntentVersion() != 2 {
+		t.Fatalf("final context = %#v, want flight-b/intent-b/2", got)
 	}
 }
 
@@ -157,7 +337,7 @@ func TestDeliverOperationCommandUsesCapturedSession(t *testing.T) {
 			Payload: &agentv1.RelayStreamMessage_ClearOperationContext{
 				ClearOperationContext: &agentv1.ClearOperationContextCommand{CommandId: "command-1", FlightId: "flight-1"},
 			},
-		})
+		}, nil)
 		resultChannel <- result{ack: ack, err: err}
 	}()
 
@@ -182,7 +362,7 @@ func TestDeliverOperationCommandUsesCapturedSession(t *testing.T) {
 		if got.err != nil {
 			t.Fatalf("deliverOperationCommandToSession() error = %v", got.err)
 		}
-		if got.ack != wantAck {
+		if !proto.Equal(got.ack, wantAck) {
 			t.Fatalf("ACK = %#v, want %#v", got.ack, wantAck)
 		}
 	case <-time.After(time.Second):
@@ -215,7 +395,7 @@ func TestDeliverOperationCommandReturnsWhenSendOutlivesContext(t *testing.T) {
 			Payload: &agentv1.RelayStreamMessage_ClearOperationContext{
 				ClearOperationContext: &agentv1.ClearOperationContextCommand{CommandId: "command-1", FlightId: "flight-1"},
 			},
-		})
+		}, nil)
 		result <- err
 	}()
 

--- a/internal/relay/apiserver_test.go
+++ b/internal/relay/apiserver_test.go
@@ -752,3 +752,52 @@ func TestSetOperationContextHoldsSessionLeaseUntilBlockedSendCompletes(t *testin
 		t.Fatal("session replacement did not resume after old context write completed")
 	}
 }
+
+func TestSetOperationContextTimeoutAfterDeliveryRefencesTelemetry(t *testing.T) {
+	stream := &mockTelemetryStream{ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 1)}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream: &telemetryStreamBinding{stream: stream},
+	}
+	relay := &Relay{
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      map[string]*DroneSession{"agent-1": session},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		_, err := relay.SetOperationContext(ctx, &relayv1.SetOperationContextRequest{
+			AgentId: "agent-1",
+			Command: &agentv1.SetOperationContextCommand{
+				CommandId: "delivered-timeout",
+				Context: &agentv1.OperationContext{
+					FlightId: "flight-new", IntentId: "intent-new", IntentVersion: 2,
+				},
+			},
+		})
+		result <- err
+	}()
+	select {
+	case <-stream.sentAckChan:
+	case <-time.After(time.Second):
+		t.Fatal("operation-context mutation was not delivered")
+	}
+	if err := <-result; status.Code(err) != codes.DeadlineExceeded {
+		t.Fatalf("SetOperationContext() error = %v, want DeadlineExceeded", err)
+	}
+	if !session.requiresOperationContextReconciliation() {
+		t.Fatal("delivered mutation timeout did not re-fence telemetry")
+	}
+
+	// Its uncorrelated late ACK cannot reopen admission; only API replay can.
+	session.handleOperationContextCommandAck(&agentv1.OperationContextCommandAck{
+		CommandId: "delivered-timeout", Status: agentv1.OperationContextCommandAck_STATUS_APPLIED,
+		ActiveContext: &agentv1.OperationContext{
+			FlightId: "flight-new", IntentId: "intent-new", IntentVersion: 2,
+		},
+	})
+	if !session.requiresOperationContextReconciliation() {
+		t.Fatal("late ACK reopened telemetry after its correlation was retired")
+	}
+}

--- a/internal/relay/apiserver_test.go
+++ b/internal/relay/apiserver_test.go
@@ -512,3 +512,69 @@ func TestDeliverOperationCommandReturnsWhenSendOutlivesContext(t *testing.T) {
 	}
 	close(stream.sendBlock)
 }
+
+func TestSetOperationContextHoldsSessionLeaseUntilBlockedSendCompletes(t *testing.T) {
+	stream := &mockTelemetryStream{
+		ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 1),
+		sendStarted: make(chan struct{}, 1), sendBlock: make(chan struct{}),
+	}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream: &telemetryStreamBinding{stream: stream},
+	}
+	relay := &Relay{
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      map[string]*DroneSession{"agent-1": session},
+	}
+	commandCtx, cancelCommand := context.WithCancel(context.Background())
+	commandResult := make(chan error, 1)
+	go func() {
+		_, err := relay.SetOperationContext(commandCtx, &relayv1.SetOperationContextRequest{
+			AgentId: "agent-1",
+			Command: &agentv1.SetOperationContextCommand{
+				CommandId: "context-replace",
+				Context: &agentv1.OperationContext{
+					FlightId: "flight-1", IntentId: "intent-1", IntentVersion: 1,
+				},
+			},
+		})
+		commandResult <- err
+	}()
+	<-stream.sendStarted
+
+	replaced := make(chan error, 1)
+	go func() {
+		_, err := relay.Register(context.Background(), &agentv1.RegisterRequest{AgentId: "agent-1"})
+		replaced <- err
+	}()
+	select {
+	case err := <-replaced:
+		t.Fatalf("session replaced while old context send was blocked: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	cancelCommand()
+	select {
+	case err := <-commandResult:
+		t.Fatalf("context caller returned before its started write completed: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	select {
+	case err := <-replaced:
+		t.Fatalf("context cancellation released lease before old send completed: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(stream.sendBlock)
+	<-stream.sentAckChan
+	if err := <-commandResult; status.Code(err) != codes.Canceled && status.Code(err) != codes.Aborted {
+		t.Fatalf("context caller error = %v, want Canceled or Aborted", err)
+	}
+	select {
+	case err := <-replaced:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("session replacement did not resume after old context write completed")
+	}
+}

--- a/internal/relay/apiserver_test.go
+++ b/internal/relay/apiserver_test.go
@@ -171,6 +171,58 @@ func TestSetOperationContextWaitAbortsWhenSessionRetires(t *testing.T) {
 	}
 }
 
+func TestSetOperationContextPinsSessionOnlyThroughDelivery(t *testing.T) {
+	stream := &mockTelemetryStream{
+		ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 1),
+		sendStarted: make(chan struct{}, 1), sendBlock: make(chan struct{}),
+	}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream: &telemetryStreamBinding{stream: stream}, pending: make(map[string]chan *agentv1.OperationContextCommandAck),
+	}
+	relay := &Relay{
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      map[string]*DroneSession{"agent-1": session},
+	}
+	completed := make(chan error, 1)
+	go func() {
+		_, err := relay.SetOperationContext(context.Background(), &relayv1.SetOperationContextRequest{
+			AgentId: "agent-1",
+			Command: &agentv1.SetOperationContextCommand{
+				CommandId: "set-pinned",
+				Context: &agentv1.OperationContext{
+					FlightId: "flight-1", IntentId: "intent-1", IntentVersion: 1,
+				},
+			},
+		})
+		completed <- err
+	}()
+	<-stream.sendStarted
+
+	leaseAcquired := make(chan struct{})
+	go func() {
+		session.ownershipMu.Lock()
+		close(leaseAcquired)
+		session.retired = true
+		session.abortPendingCommands()
+		session.ownershipMu.Unlock()
+	}()
+	select {
+	case <-leaseAcquired:
+		t.Fatal("session retired before operation-context delivery completed")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(stream.sendBlock)
+	select {
+	case <-leaseAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("session lease remained held while awaiting operation-context ACK")
+	}
+	if err := <-completed; status.Code(err) != codes.Aborted {
+		t.Fatalf("SetOperationContext() error = %v, want Aborted", err)
+	}
+}
+
 func TestConcurrentExactOperationContextRetriesShareOneDelivery(t *testing.T) {
 	stream := &mockTelemetryStream{ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 2)}
 	session := &DroneSession{

--- a/internal/relay/apiserver_test.go
+++ b/internal/relay/apiserver_test.go
@@ -125,6 +125,9 @@ func TestSetOperationContextRejectsMismatchedAppliedContext(t *testing.T) {
 	if err := <-result; status.Code(err) != codes.Internal {
 		t.Fatalf("mismatched ACK error = %v, want Internal", err)
 	}
+	if !session.requiresOperationContextReconciliation() {
+		t.Fatal("mismatched applied ACK did not re-fence telemetry")
+	}
 	session.sessionMu.RLock()
 	defer session.sessionMu.RUnlock()
 	if session.FlightID != "" || session.IntentID != "" || session.IntentVersion != 0 {

--- a/internal/relay/apiserver_test.go
+++ b/internal/relay/apiserver_test.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -10,6 +11,84 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+func TestSetOperationContextRequiresAuthorizedControlCaller(t *testing.T) {
+	want := status.Error(codes.PermissionDenied, "denied")
+	relay := &Relay{controlAuthorizer: func(context.Context) error { return want }}
+	_, err := relay.SetOperationContext(context.Background(), &relayv1.SetOperationContextRequest{})
+	if !errors.Is(err, want) {
+		t.Fatalf("SetOperationContext() error = %v, want %v", err, want)
+	}
+}
+
+func TestSetOperationContextDeliversToCurrentAgent(t *testing.T) {
+	stream := &mockTelemetryStream{ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 1)}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1",
+		stream:  &telemetryStreamBinding{stream: stream},
+		pending: make(map[string]chan *agentv1.OperationContextCommandAck),
+	}
+	relay := &Relay{
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      map[string]*DroneSession{"agent-1": session},
+	}
+	request := &relayv1.SetOperationContextRequest{
+		AgentId: "agent-1",
+		Command: &agentv1.SetOperationContextCommand{
+			CommandId: "command-1",
+			Context: &agentv1.OperationContext{
+				FlightId: "flight-1", IntentId: "intent-1", IntentVersion: 2,
+			},
+		},
+	}
+	type result struct {
+		response *relayv1.SetOperationContextResponse
+		err      error
+	}
+	resultChannel := make(chan result, 1)
+	go func() {
+		response, err := relay.SetOperationContext(context.Background(), request)
+		resultChannel <- result{response: response, err: err}
+	}()
+	message := <-stream.sentAckChan
+	if message.GetSetOperationContext().GetContext().GetFlightId() != "flight-1" {
+		t.Fatalf("delivered command = %#v", message.GetSetOperationContext())
+	}
+	session.handleOperationContextCommandAck(&agentv1.OperationContextCommandAck{
+		CommandId: "command-1",
+		Status:    agentv1.OperationContextCommandAck_STATUS_APPLIED,
+		ActiveContext: &agentv1.OperationContext{
+			FlightId: "flight-1", IntentId: "intent-1", IntentVersion: 2,
+		},
+	})
+	got := <-resultChannel
+	if got.err != nil {
+		t.Fatalf("SetOperationContext() error = %v", got.err)
+	}
+	if got.response.GetResult().GetStatus() != agentv1.OperationContextCommandAck_STATUS_APPLIED {
+		t.Fatalf("SetOperationContext() response = %#v", got.response)
+	}
+}
+
+func TestOperationContextRequestValidation(t *testing.T) {
+	relay := &Relay{controlAuthorizer: func(context.Context) error { return nil }}
+	for name, call := range map[string]func() error{
+		"set": func() error {
+			_, err := relay.SetOperationContext(context.Background(), &relayv1.SetOperationContextRequest{AgentId: "agent-1"})
+			return err
+		},
+		"clear": func() error {
+			_, err := relay.ClearOperationContext(context.Background(), &relayv1.ClearOperationContextRequest{AgentId: "agent-1"})
+			return err
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := call(); status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("operation-context validation error = %v, want InvalidArgument", err)
+			}
+		})
+	}
+}
 
 func TestOperationContextRPCsDisabledWithoutAuthenticatedControlPlane(t *testing.T) {
 	relay := &Relay{}

--- a/internal/relay/controlauth.go
+++ b/internal/relay/controlauth.go
@@ -1,0 +1,94 @@
+package relay
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/makinje/aero-arc-relay/internal/config"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+type controlPlaneAuthorizer func(context.Context) error
+
+func newControlPlaneAuthorizer(cfg config.ControlAuthConfig) (controlPlaneAuthorizer, error) {
+	if !cfg.Enabled {
+		return nil, nil
+	}
+	if cfg.ClientCAFile == "" {
+		return nil, errors.New("control-plane client CA file is required")
+	}
+	if len(cfg.AllowedIdentities) == 0 {
+		return nil, errors.New("at least one control-plane identity is required")
+	}
+	allowed := make(map[string]struct{}, len(cfg.AllowedIdentities))
+	for _, identity := range cfg.AllowedIdentities {
+		if identity == "" {
+			return nil, errors.New("control-plane identity cannot be empty")
+		}
+		allowed[identity] = struct{}{}
+	}
+	return func(ctx context.Context) error {
+		remote, ok := peer.FromContext(ctx)
+		if !ok {
+			return status.Error(codes.Unauthenticated, "verified control-plane client certificate is required")
+		}
+		tlsInfo, ok := remote.AuthInfo.(credentials.TLSInfo)
+		if !ok || len(tlsInfo.State.VerifiedChains) == 0 || len(tlsInfo.State.PeerCertificates) == 0 {
+			return status.Error(codes.Unauthenticated, "verified control-plane client certificate is required")
+		}
+		leaf := tlsInfo.State.PeerCertificates[0]
+		if certificateIdentityAllowed(leaf, allowed) {
+			return nil
+		}
+		return status.Error(codes.PermissionDenied, "control-plane client identity is not authorized")
+	}, nil
+}
+
+func certificateIdentityAllowed(certificate *x509.Certificate, allowed map[string]struct{}) bool {
+	if certificate == nil {
+		return false
+	}
+	identities := make([]string, 0, 1+len(certificate.DNSNames)+len(certificate.URIs))
+	identities = append(identities, certificate.Subject.CommonName)
+	identities = append(identities, certificate.DNSNames...)
+	for _, uri := range certificate.URIs {
+		identities = append(identities, uri.String())
+	}
+	for _, identity := range identities {
+		if _, ok := allowed[identity]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func serverTransportCredentials(cfg *config.Config, certificatePath, keyPath string) (credentials.TransportCredentials, error) {
+	certificate, err := tls.LoadX509KeyPair(certificatePath, keyPath)
+	if err != nil {
+		return nil, err
+	}
+	tlsConfig := &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{certificate},
+	}
+	if cfg.ControlAuth.Enabled {
+		contents, err := os.ReadFile(cfg.ControlAuth.ClientCAFile)
+		if err != nil {
+			return nil, fmt.Errorf("read control-plane client CA: %w", err)
+		}
+		roots := x509.NewCertPool()
+		if !roots.AppendCertsFromPEM(contents) {
+			return nil, errors.New("control-plane client CA contains no certificates")
+		}
+		tlsConfig.ClientAuth = tls.VerifyClientCertIfGiven
+		tlsConfig.ClientCAs = roots
+	}
+	return credentials.NewTLS(tlsConfig), nil
+}

--- a/internal/relay/controlauth_test.go
+++ b/internal/relay/controlauth_test.go
@@ -1,0 +1,58 @@
+package relay
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"net/url"
+	"testing"
+
+	"github.com/makinje/aero-arc-relay/internal/config"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+func TestControlPlaneAuthorizerRequiresVerifiedAllowedIdentity(t *testing.T) {
+	authorize, err := newControlPlaneAuthorizer(config.ControlAuthConfig{
+		Enabled: true, ClientCAFile: "unused-by-authorizer.pem", AllowedIdentities: []string{"spiffe://aero-arc/api"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := authorize(context.Background()); status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("missing certificate error = %v, want Unauthenticated", err)
+	}
+
+	certificate := &x509.Certificate{
+		Subject: pkix.Name{CommonName: "not-api"},
+		URIs:    mustParseURIs(t, "spiffe://aero-arc/api"),
+	}
+	ctx := peer.NewContext(context.Background(), &peer.Peer{AuthInfo: credentials.TLSInfo{State: tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{certificate},
+		VerifiedChains:   [][]*x509.Certificate{{certificate}},
+	}}})
+	if err := authorize(ctx); err != nil {
+		t.Fatalf("allowed URI identity rejected: %v", err)
+	}
+
+	certificate.URIs = mustParseURIs(t, "spiffe://aero-arc/other")
+	if err := authorize(ctx); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("wrong identity error = %v, want PermissionDenied", err)
+	}
+}
+
+func mustParseURIs(t *testing.T, values ...string) []*url.URL {
+	t.Helper()
+	result := make([]*url.URL, 0, len(values))
+	for _, value := range values {
+		parsed, err := url.Parse(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result = append(result, parsed)
+	}
+	return result
+}

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -258,6 +258,18 @@ func newSessionID() (string, error) {
 }
 
 func sendToSession(ctx context.Context, session *DroneSession, message *agentv1.RelayStreamMessage) error {
+	return sendToSessionWithWritePolicy(ctx, session, message, false)
+}
+
+// sendToSessionThroughWrite keeps its caller blocked after a stream Send has
+// started until that write returns. Aircraft-command delivery uses this while
+// holding the session ownership lease so replacement cannot publish ahead of a
+// command that is still capable of reaching the retired stream.
+func sendToSessionThroughWrite(ctx context.Context, session *DroneSession, message *agentv1.RelayStreamMessage) error {
+	return sendToSessionWithWritePolicy(ctx, session, message, true)
+}
+
+func sendToSessionWithWritePolicy(ctx context.Context, session *DroneSession, message *agentv1.RelayStreamMessage, waitThroughWrite bool) error {
 	for {
 		if err := ctx.Err(); err != nil {
 			return status.FromContextError(err).Err()
@@ -282,6 +294,11 @@ func sendToSession(ctx context.Context, session *DroneSession, message *agentv1.
 		if err := ctx.Err(); err != nil {
 			binding.sendMu.Unlock()
 			return status.FromContextError(err).Err()
+		}
+		if waitThroughWrite {
+			err := binding.stream.Send(message)
+			binding.sendMu.Unlock()
+			return err
 		}
 		sent := make(chan error, 1)
 		go func() {

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -388,6 +388,9 @@ func (session *DroneSession) handleOperationContextCommandAck(ack *agentv1.Opera
 		ack.Status == agentv1.OperationContextCommandAck_STATUS_ALREADY_APPLIED {
 		if !proto.Equal(ack.ActiveContext, state.expected) {
 			ackErr = status.Error(codes.Internal, "agent acknowledged an operation context different from the requested result")
+			session.sessionMu.Lock()
+			session.operationContextUnreconciled = true
+			session.sessionMu.Unlock()
 		} else {
 			session.sessionMu.Lock()
 			if state.expected == nil {
@@ -523,6 +526,15 @@ func (session *DroneSession) restoreContextIntoAndAbortPending(replacement *Dron
 	replacement.IntentVersion = session.IntentVersion
 	replacement.operationContextUnreconciled = session.operationContextUnreconciled
 	replacement.emptyContextCommandID = session.emptyContextCommandID
+	for _, state := range session.operationCommands {
+		if !state.completed && state.delivered {
+			// The retiring Agent may have applied this mutation even though Relay
+			// never received its ACK. The replacement must not inherit the prior
+			// attribution as if the outcome were known.
+			replacement.operationContextUnreconciled = true
+			break
+		}
+	}
 	if replacement.operationContextUnreconciled && replacement.emptyContextCommandID != "" {
 		state := session.operationCommands[replacement.emptyContextCommandID]
 		if state == nil || state.completed {

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -171,11 +171,11 @@ func (r *Relay) TelemetryStream(stream agentv1.AgentGateway_TelemetryStreamServe
 		}
 
 		if commandAck := message.GetOperationContextCommandAck(); commandAck != nil {
-			streamSession.handleOperationContextCommandAck(commandAck)
+			streamSession.handleOperationContextCommandAckFrom(streamBinding, commandAck)
 			continue
 		}
 		if commandResult := message.GetAircraftCommandResult(); commandResult != nil {
-			streamSession.handleAircraftCommandResult(commandResult)
+			streamSession.handleAircraftCommandResultFrom(streamBinding, commandResult)
 			continue
 		}
 		frame := message.GetTelemetryFrame()
@@ -270,6 +270,8 @@ func sendToSession(ctx context.Context, session *DroneSession, message *agentv1.
 // holding the session ownership lease so replacement cannot publish ahead of a
 // command that is still capable of reaching the retired stream.
 func sendToSessionThroughWrite(ctx context.Context, session *DroneSession, message *agentv1.RelayStreamMessage) error {
+	session.controlStreamMu.RLock()
+	defer session.controlStreamMu.RUnlock()
 	return sendToSessionWithWritePolicy(ctx, session, message, true)
 }
 
@@ -387,6 +389,21 @@ func (session *DroneSession) handleOperationContextCommandAck(ack *agentv1.Opera
 	}
 }
 
+func (session *DroneSession) handleOperationContextCommandAckFrom(binding *telemetryStreamBinding, ack *agentv1.OperationContextCommandAck) {
+	if session == nil || binding == nil || ack == nil {
+		return
+	}
+	session.controlStreamMu.RLock()
+	defer session.controlStreamMu.RUnlock()
+	session.sessionMu.RLock()
+	isCurrent := session.stream == binding && !binding.closed
+	session.sessionMu.RUnlock()
+	if !isCurrent {
+		return
+	}
+	session.handleOperationContextCommandAck(ack)
+}
+
 func (session *DroneSession) handleAircraftCommandResult(result *agentv1.AircraftCommandResult) {
 	if session == nil || result == nil {
 		return
@@ -401,6 +418,21 @@ func (session *DroneSession) handleAircraftCommandResult(result *agentv1.Aircraf
 	state.completed = true
 	state.completedAt = time.Now()
 	close(state.done)
+}
+
+func (session *DroneSession) handleAircraftCommandResultFrom(binding *telemetryStreamBinding, result *agentv1.AircraftCommandResult) {
+	if session == nil || binding == nil || result == nil {
+		return
+	}
+	session.controlStreamMu.RLock()
+	defer session.controlStreamMu.RUnlock()
+	session.sessionMu.RLock()
+	isCurrent := session.stream == binding && !binding.closed
+	session.sessionMu.RUnlock()
+	if !isCurrent {
+		return
+	}
+	session.handleAircraftCommandResult(result)
 }
 
 func (session *DroneSession) abortPendingCommands() {

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -367,6 +367,14 @@ func (session *DroneSession) handleOperationContextCommandAck(ack *agentv1.Opera
 			session.sessionMu.Unlock()
 		}
 	}
+	if (ack.Status != agentv1.OperationContextCommandAck_STATUS_APPLIED &&
+		ack.Status != agentv1.OperationContextCommandAck_STATUS_ALREADY_APPLIED) || ackErr != nil {
+		session.sessionMu.Lock()
+		if session.emptyContextCommandID == ack.CommandId {
+			session.emptyContextCommandID = ""
+		}
+		session.sessionMu.Unlock()
+	}
 	state.ack = cloneOperationAck(ack)
 	state.err = ackErr
 	state.completed = true
@@ -409,6 +417,7 @@ func (session *DroneSession) restoreContextIntoAndAbortPending(replacement *Dron
 	replacement.IntentID = session.IntentID
 	replacement.IntentVersion = session.IntentVersion
 	replacement.operationContextUnreconciled = session.operationContextUnreconciled
+	replacement.emptyContextCommandID = session.emptyContextCommandID
 	session.sessionMu.RUnlock()
 	session.abortPendingCommandsLocked(time.Now())
 }
@@ -417,6 +426,19 @@ func (session *DroneSession) requiresOperationContextReconciliation() bool {
 	session.sessionMu.RLock()
 	defer session.sessionMu.RUnlock()
 	return session.operationContextUnreconciled
+}
+
+func (session *DroneSession) reserveEmptyContextReconciliation(commandID string) bool {
+	session.sessionMu.Lock()
+	defer session.sessionMu.Unlock()
+	if session.emptyContextCommandID != "" {
+		return session.emptyContextCommandID == commandID
+	}
+	if !session.operationContextUnreconciled {
+		return false
+	}
+	session.emptyContextCommandID = commandID
+	return true
 }
 
 func (session *DroneSession) abortPendingCommandsLocked(now time.Time) {

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -50,18 +50,19 @@ func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*ag
 		return nil, status.Errorf(codes.Internal, "generate session ID: %v", err)
 	}
 	newSession := &DroneSession{
-		agentID:           agentID,
-		SessionID:         sessionID,
-		ConnectedAt:       time.Now(),
-		LastHeartbeat:     time.Now(),
-		Position:          nil,
-		Attitude:          nil,
-		VfrHud:            nil,
-		SystemStatus:      nil,
-		pending:           make(map[string]chan *agentv1.OperationContextCommandAck),
-		operationCommands: make(map[string]*operationCommandState),
-		operationGate:     makeOperationGate(),
-		aircraftCommands:  make(map[string]*aircraftCommandState),
+		agentID:                      agentID,
+		SessionID:                    sessionID,
+		ConnectedAt:                  time.Now(),
+		LastHeartbeat:                time.Now(),
+		Position:                     nil,
+		Attitude:                     nil,
+		VfrHud:                       nil,
+		SystemStatus:                 nil,
+		operationContextUnreconciled: r.controlAuthorizer != nil,
+		pending:                      make(map[string]chan *agentv1.OperationContextCommandAck),
+		operationCommands:            make(map[string]*operationCommandState),
+		operationGate:                makeOperationGate(),
+		aircraftCommands:             make(map[string]*aircraftCommandState),
 	}
 
 	// Retire the previous session before publishing its replacement. Do not hold
@@ -218,6 +219,9 @@ func (r *Relay) TelemetryStream(stream agentv1.AgentGateway_TelemetryStreamServe
 		} else if frameWALIDErr != nil || frameWALUUID == uuid.Nil {
 			ack.Status = agentv1.TelemetryAck_STATUS_PERMANENT_ERROR
 			ack.Error = "telemetry frame WAL generation ID is invalid"
+		} else if streamSession.requiresOperationContextReconciliation() {
+			ack.Status = agentv1.TelemetryAck_STATUS_RETRY_WITH_BACKOFF
+			ack.Error = "operation context has not been reconciled for this Relay session"
 		} else {
 			// Process the frame (e.g., forward to outputs).
 			frame.WalId = frameWALUUID.String()
@@ -359,6 +363,7 @@ func (session *DroneSession) handleOperationContextCommandAck(ack *agentv1.Opera
 				session.IntentID = state.expected.IntentId
 				session.IntentVersion = state.expected.IntentVersion
 			}
+			session.operationContextUnreconciled = false
 			session.sessionMu.Unlock()
 		}
 	}
@@ -403,8 +408,15 @@ func (session *DroneSession) restoreContextIntoAndAbortPending(replacement *Dron
 	replacement.FlightID = session.FlightID
 	replacement.IntentID = session.IntentID
 	replacement.IntentVersion = session.IntentVersion
+	replacement.operationContextUnreconciled = session.operationContextUnreconciled
 	session.sessionMu.RUnlock()
 	session.abortPendingCommandsLocked(time.Now())
+}
+
+func (session *DroneSession) requiresOperationContextReconciliation() bool {
+	session.sessionMu.RLock()
+	defer session.sessionMu.RUnlock()
+	return session.operationContextUnreconciled
 }
 
 func (session *DroneSession) abortPendingCommandsLocked(now time.Time) {

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -139,7 +139,28 @@ func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*ag
 	}, nil
 }
 
-// TelemetryStream handles bidirectional telemetry streaming.
+// TelemetryStream authenticates and binds one Agent's bidirectional stream,
+// admits durable telemetry in receive order, and correlates control evidence
+// with commands written on that exact active binding.
+//
+// Parameters:
+//   - stream: supplies the authenticated Agent/session metadata, inbound WAL
+//     frames and command evidence, and serialized outbound telemetry
+//     acknowledgements and control commands.
+//
+// Returns:
+//   - error: reports missing or invalid identity/session metadata,
+//     authentication failure, stale session ownership, Registry publication
+//     failure, stream receive/send failure, or context cancellation. Telemetry
+//     admission failures are returned to the Agent as retryable or permanent
+//     per-frame acknowledgements instead of terminating the stream.
+//
+// A successfully published binding owns Registry liveness until cleanup. A
+// replacement aborts old-binding command waiters and fences uncertain operation
+// context before it can admit telemetry. Operation-context ACKs and aircraft
+// results are handled ahead of telemetry routing and remain bound to the stream
+// that received them. Cleanup removes only this binding, so a superseding stream
+// remains active.
 func (r *Relay) TelemetryStream(stream agentv1.AgentGateway_TelemetryStreamServer) error {
 	ctx := stream.Context()
 
@@ -181,10 +202,6 @@ func (r *Relay) TelemetryStream(stream agentv1.AgentGateway_TelemetryStreamServe
 	}
 
 	defer r.deleteStream(agentID, streamSession, streamBinding)
-
-	// TODO: In a real implementation, you might want to start a goroutine to send ACKs back
-	// independently of receiving frames, but for strict request-response style streaming
-	// (or simple acking), a simple loop works.
 
 	for {
 		select {
@@ -296,7 +313,8 @@ func newSessionID() (string, error) {
 }
 
 func sendToSession(ctx context.Context, session *DroneSession, message *agentv1.RelayStreamMessage) error {
-	return sendToSessionWithWritePolicy(ctx, session, message, false)
+	_, err := sendToSessionWithWritePolicy(ctx, session, message, false)
+	return err
 }
 
 // sendToSessionThroughWrite keeps its caller blocked after a stream Send has
@@ -306,23 +324,27 @@ func sendToSession(ctx context.Context, session *DroneSession, message *agentv1.
 func sendToSessionThroughWrite(ctx context.Context, session *DroneSession, message *agentv1.RelayStreamMessage) error {
 	session.controlStreamMu.RLock()
 	defer session.controlStreamMu.RUnlock()
-	return sendToSessionWithWritePolicy(ctx, session, message, true)
+	_, err := sendToSessionWithWritePolicy(ctx, session, message, true)
+	return err
 }
 
-func sendToSessionWithWritePolicy(ctx context.Context, session *DroneSession, message *agentv1.RelayStreamMessage, waitThroughWrite bool) error {
+// sendToSessionWithWritePolicy reports whether the active stream's Send method
+// was invoked. Once invoked, either a nil or error result is delivery-uncertain:
+// the peer may have applied the message before Relay observed the outcome.
+func sendToSessionWithWritePolicy(ctx context.Context, session *DroneSession, message *agentv1.RelayStreamMessage, waitThroughWrite bool) (bool, error) {
 	for {
 		if err := ctx.Err(); err != nil {
-			return status.FromContextError(err).Err()
+			return false, status.FromContextError(err).Err()
 		}
 		session.sessionMu.RLock()
 		binding := session.stream
 		session.sessionMu.RUnlock()
 		if binding == nil {
-			return status.Error(codes.Unavailable, "agent stream is not connected")
+			return false, status.Error(codes.Unavailable, "agent stream is not connected")
 		}
 
 		if err := binding.sendMu.Lock(ctx); err != nil {
-			return status.FromContextError(err).Err()
+			return false, status.FromContextError(err).Err()
 		}
 		session.sessionMu.RLock()
 		isCurrent := session.stream == binding
@@ -333,12 +355,12 @@ func sendToSessionWithWritePolicy(ctx context.Context, session *DroneSession, me
 		}
 		if err := ctx.Err(); err != nil {
 			binding.sendMu.Unlock()
-			return status.FromContextError(err).Err()
+			return false, status.FromContextError(err).Err()
 		}
 		if waitThroughWrite {
 			err := binding.stream.Send(message)
 			binding.sendMu.Unlock()
-			return err
+			return true, err
 		}
 		sent := make(chan error, 1)
 		go func() {
@@ -348,13 +370,13 @@ func sendToSessionWithWritePolicy(ctx context.Context, session *DroneSession, me
 		}()
 		select {
 		case err := <-sent:
-			return err
+			return true, err
 		case <-ctx.Done():
 			select {
 			case err := <-sent:
-				return err
+				return true, err
 			default:
-				return status.FromContextError(ctx.Err()).Err()
+				return true, status.FromContextError(ctx.Err()).Err()
 			}
 		}
 	}

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -61,7 +61,7 @@ func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*ag
 		pending:           make(map[string]chan *agentv1.OperationContextCommandAck),
 		operationCommands: make(map[string]*operationCommandState),
 		operationGate:     makeOperationGate(),
-		pendingAircraft:   make(map[string]chan aircraftCommandOutcome),
+		aircraftCommands:  make(map[string]*aircraftCommandState),
 	}
 
 	// Retire the previous session before publishing its replacement. Do not hold
@@ -362,18 +362,15 @@ func (session *DroneSession) handleAircraftCommandResult(result *agentv1.Aircraf
 		return
 	}
 	session.pendingMu.Lock()
-	pending := session.pendingAircraft[result.GetCommandId()]
-	if pending != nil {
-		delete(session.pendingAircraft, result.GetCommandId())
-	}
-	session.pendingMu.Unlock()
-	if pending == nil {
+	defer session.pendingMu.Unlock()
+	state := session.aircraftCommands[result.GetCommandId()]
+	if state == nil || state.completed {
 		return
 	}
-	select {
-	case pending <- aircraftCommandOutcome{result: result}:
-	default:
-	}
+	state.result = proto.Clone(result).(*agentv1.AircraftCommandResult)
+	state.completed = true
+	state.completedAt = time.Now()
+	close(state.done)
 }
 
 func (session *DroneSession) abortPendingCommands() {
@@ -390,12 +387,14 @@ func (session *DroneSession) abortPendingCommands() {
 		state.completedAt = now
 		close(state.done)
 	}
-	for commandID, pending := range session.pendingAircraft {
-		delete(session.pendingAircraft, commandID)
-		select {
-		case pending <- aircraftCommandOutcome{err: status.Error(codes.Aborted, "agent session retired while awaiting aircraft command result")}:
-		default:
+	for _, state := range session.aircraftCommands {
+		if state.completed {
+			continue
 		}
+		state.err = status.Error(codes.Aborted, "agent session retired while awaiting aircraft command result")
+		state.completed = true
+		state.completedAt = now
+		close(state.done)
 	}
 }
 

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -84,7 +84,7 @@ func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*ag
 		}
 		if previous != nil {
 			previous.retired = true
-			previous.abortPendingCommands()
+			previous.restoreContextIntoAndAbortPending(newSession)
 			if r.registryReporter != nil {
 				r.registryReporter.StopAgent(agentID)
 			}
@@ -376,7 +376,21 @@ func (session *DroneSession) handleAircraftCommandResult(result *agentv1.Aircraf
 func (session *DroneSession) abortPendingCommands() {
 	session.pendingMu.Lock()
 	defer session.pendingMu.Unlock()
-	now := time.Now()
+	session.abortPendingCommandsLocked(time.Now())
+}
+
+func (session *DroneSession) restoreContextIntoAndAbortPending(replacement *DroneSession) {
+	session.pendingMu.Lock()
+	defer session.pendingMu.Unlock()
+	session.sessionMu.RLock()
+	replacement.FlightID = session.FlightID
+	replacement.IntentID = session.IntentID
+	replacement.IntentVersion = session.IntentVersion
+	session.sessionMu.RUnlock()
+	session.abortPendingCommandsLocked(time.Now())
+}
+
+func (session *DroneSession) abortPendingCommandsLocked(now time.Time) {
 	for commandID, state := range session.operationCommands {
 		if state.completed {
 			continue

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -47,7 +47,9 @@ import (
 //   - response: contains the authenticated Agent ID, newly generated session
 //     ID, and advertised telemetry in-flight limit.
 //   - error: reports a missing Agent ID, failed authentication, or failure to
-//     generate a cryptographically random session ID.
+//     generate a cryptographically random session ID. Cancellation while
+//     waiting to replace an owned session preserves that live session and
+//     returns the corresponding context status.
 func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*agentv1.RegisterResponse, error) {
 	agentID := strings.TrimSpace(req.AgentId)
 	slog.Info(
@@ -90,6 +92,12 @@ func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*ag
 		if previous != nil {
 			previous.ownershipMu.Lock()
 		}
+		if err := ctx.Err(); err != nil {
+			if previous != nil {
+				previous.ownershipMu.Unlock()
+			}
+			return nil, status.FromContextError(err).Err()
+		}
 
 		r.sessionsMu.Lock()
 		if r.grpcSessions[agentID] != previous {
@@ -98,6 +106,16 @@ func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*ag
 				previous.ownershipMu.Unlock()
 			}
 			continue
+		}
+		// This is the replacement linearization point. Recheck cancellation
+		// while the map is stable so a caller that gave up while waiting for the
+		// ownership lease cannot retire the session it still knows how to use.
+		if err := ctx.Err(); err != nil {
+			r.sessionsMu.Unlock()
+			if previous != nil {
+				previous.ownershipMu.Unlock()
+			}
+			return nil, status.FromContextError(err).Err()
 		}
 		if previous != nil {
 			previous.retired = true

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -31,7 +31,23 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// Register handles the initial connection handshake from an agent.
+// Register authenticates an Agent identity and publishes a fresh logical
+// session generation for its next TelemetryStream. A first session starts with
+// operation context unreconciled when control mutations are enabled. Replacing
+// an existing generation takes that session's ownership lease, copies its last
+// API-authoritative context and reconciliation state, aborts its pending
+// operation and aircraft commands, stops its Registry liveness, and atomically
+// installs the replacement before releasing the old session.
+//
+// Parameters:
+//   - ctx: carries Agent authentication and bounds request processing.
+//   - req: supplies the stable Agent ID that owns the new session generation.
+//
+// Returns:
+//   - response: contains the authenticated Agent ID, newly generated session
+//     ID, and advertised telemetry in-flight limit.
+//   - error: reports a missing Agent ID, failed authentication, or failure to
+//     generate a cryptographically random session ID.
 func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*agentv1.RegisterResponse, error) {
 	agentID := strings.TrimSpace(req.AgentId)
 	slog.Info(

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -49,15 +49,16 @@ func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*ag
 		return nil, status.Errorf(codes.Internal, "generate session ID: %v", err)
 	}
 	newSession := &DroneSession{
-		agentID:       agentID,
-		SessionID:     sessionID,
-		ConnectedAt:   time.Now(),
-		LastHeartbeat: time.Now(),
-		Position:      nil,
-		Attitude:      nil,
-		VfrHud:        nil,
-		SystemStatus:  nil,
-		pending:       make(map[string]chan *agentv1.OperationContextCommandAck),
+		agentID:         agentID,
+		SessionID:       sessionID,
+		ConnectedAt:     time.Now(),
+		LastHeartbeat:   time.Now(),
+		Position:        nil,
+		Attitude:        nil,
+		VfrHud:          nil,
+		SystemStatus:    nil,
+		pending:         make(map[string]chan *agentv1.OperationContextCommandAck),
+		pendingAircraft: make(map[string]chan *agentv1.AircraftCommandResult),
 	}
 
 	// Retire the previous session before publishing its replacement. Do not hold
@@ -166,6 +167,10 @@ func (r *Relay) TelemetryStream(stream agentv1.AgentGateway_TelemetryStreamServe
 
 		if commandAck := message.GetOperationContextCommandAck(); commandAck != nil {
 			streamSession.handleOperationContextCommandAck(commandAck)
+			continue
+		}
+		if commandResult := message.GetAircraftCommandResult(); commandResult != nil {
+			streamSession.handleAircraftCommandResult(commandResult)
 			continue
 		}
 		frame := message.GetTelemetryFrame()
@@ -325,6 +330,25 @@ func (session *DroneSession) handleOperationContextCommandAck(ack *agentv1.Opera
 	}
 	select {
 	case pending <- ack:
+	default:
+	}
+}
+
+func (session *DroneSession) handleAircraftCommandResult(result *agentv1.AircraftCommandResult) {
+	if session == nil || result == nil {
+		return
+	}
+	session.pendingMu.Lock()
+	pending := session.pendingAircraft[result.GetCommandId()]
+	if pending != nil {
+		delete(session.pendingAircraft, result.GetCommandId())
+	}
+	session.pendingMu.Unlock()
+	if pending == nil {
+		return
+	}
+	select {
+	case pending <- result:
 	default:
 	}
 }

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -50,16 +50,18 @@ func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*ag
 		return nil, status.Errorf(codes.Internal, "generate session ID: %v", err)
 	}
 	newSession := &DroneSession{
-		agentID:         agentID,
-		SessionID:       sessionID,
-		ConnectedAt:     time.Now(),
-		LastHeartbeat:   time.Now(),
-		Position:        nil,
-		Attitude:        nil,
-		VfrHud:          nil,
-		SystemStatus:    nil,
-		pending:         make(map[string]chan *agentv1.OperationContextCommandAck),
-		pendingAircraft: make(map[string]chan *agentv1.AircraftCommandResult),
+		agentID:           agentID,
+		SessionID:         sessionID,
+		ConnectedAt:       time.Now(),
+		LastHeartbeat:     time.Now(),
+		Position:          nil,
+		Attitude:          nil,
+		VfrHud:            nil,
+		SystemStatus:      nil,
+		pending:           make(map[string]chan *agentv1.OperationContextCommandAck),
+		operationCommands: make(map[string]*operationCommandState),
+		operationGate:     makeOperationGate(),
+		pendingAircraft:   make(map[string]chan *agentv1.AircraftCommandResult),
 	}
 
 	// Retire the previous session before publishing its replacement. Do not hold
@@ -317,27 +319,37 @@ func (session *DroneSession) handleOperationContextCommandAck(ack *agentv1.Opera
 	// be allowed to change telemetry attribution.
 	session.pendingMu.Lock()
 	pending := session.pending[ack.CommandId]
-	if pending != nil {
-		delete(session.pending, ack.CommandId)
-	}
-	session.pendingMu.Unlock()
-	if pending == nil {
+	state := session.operationCommands[ack.CommandId]
+	if pending == nil || state == nil || state.completed {
+		session.pendingMu.Unlock()
 		return
 	}
+	delete(session.pending, ack.CommandId)
+	var ackErr error
 	if ack.Status == agentv1.OperationContextCommandAck_STATUS_APPLIED ||
 		ack.Status == agentv1.OperationContextCommandAck_STATUS_ALREADY_APPLIED {
-		session.sessionMu.Lock()
-		if active := ack.ActiveContext; active != nil {
-			session.FlightID = active.FlightId
-			session.IntentID = active.IntentId
-			session.IntentVersion = active.IntentVersion
+		if !proto.Equal(ack.ActiveContext, state.expected) {
+			ackErr = status.Error(codes.Internal, "agent acknowledged an operation context different from the requested result")
 		} else {
-			session.FlightID = ""
-			session.IntentID = ""
-			session.IntentVersion = 0
+			session.sessionMu.Lock()
+			if state.expected == nil {
+				session.FlightID = ""
+				session.IntentID = ""
+				session.IntentVersion = 0
+			} else {
+				session.FlightID = state.expected.FlightId
+				session.IntentID = state.expected.IntentId
+				session.IntentVersion = state.expected.IntentVersion
+			}
+			session.sessionMu.Unlock()
 		}
-		session.sessionMu.Unlock()
 	}
+	state.ack = cloneOperationAck(ack)
+	state.err = ackErr
+	state.completed = true
+	state.completedAt = time.Now()
+	close(state.done)
+	session.pendingMu.Unlock()
 	select {
 	case pending <- ack:
 	default:

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -441,6 +441,14 @@ func (session *DroneSession) reserveEmptyContextReconciliation(commandID string)
 	return true
 }
 
+func (session *DroneSession) releaseEmptyContextReconciliation(commandID string) {
+	session.sessionMu.Lock()
+	defer session.sessionMu.Unlock()
+	if session.emptyContextCommandID == commandID && session.operationContextUnreconciled {
+		session.emptyContextCommandID = ""
+	}
+}
+
 func (session *DroneSession) abortPendingCommandsLocked(now time.Time) {
 	for commandID, state := range session.operationCommands {
 		if state.completed {

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -408,6 +408,7 @@ func (session *DroneSession) abortPendingCommandsLocked(now time.Time) {
 		state.err = status.Error(codes.Aborted, "agent session retired while awaiting aircraft command result")
 		state.completed = true
 		state.completedAt = now
+		state.deliveryCancel()
 		close(state.done)
 	}
 }

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -84,7 +84,7 @@ func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*ag
 		}
 		if previous != nil {
 			previous.retired = true
-			previous.abortPendingAircraftCommands()
+			previous.abortPendingCommands()
 			if r.registryReporter != nil {
 				r.registryReporter.StopAgent(agentID)
 			}
@@ -376,9 +376,20 @@ func (session *DroneSession) handleAircraftCommandResult(result *agentv1.Aircraf
 	}
 }
 
-func (session *DroneSession) abortPendingAircraftCommands() {
+func (session *DroneSession) abortPendingCommands() {
 	session.pendingMu.Lock()
 	defer session.pendingMu.Unlock()
+	now := time.Now()
+	for commandID, state := range session.operationCommands {
+		if state.completed {
+			continue
+		}
+		delete(session.pending, commandID)
+		state.err = status.Error(codes.Aborted, "agent session retired while awaiting operation-context acknowledgement")
+		state.completed = true
+		state.completedAt = now
+		close(state.done)
+	}
 	for commandID, pending := range session.pendingAircraft {
 		delete(session.pendingAircraft, commandID)
 		select {

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -512,6 +512,15 @@ func (session *DroneSession) restoreContextIntoAndAbortPending(replacement *Dron
 	replacement.IntentVersion = session.IntentVersion
 	replacement.operationContextUnreconciled = session.operationContextUnreconciled
 	replacement.emptyContextCommandID = session.emptyContextCommandID
+	if replacement.operationContextUnreconciled && replacement.emptyContextCommandID != "" {
+		state := session.operationCommands[replacement.emptyContextCommandID]
+		if state == nil || state.completed {
+			// A failed or not-yet-admitted attempt has no in-flight outcome to
+			// protect. Its caller may not have run deferred reservation cleanup yet,
+			// so do not copy that transient reservation into the replacement.
+			replacement.emptyContextCommandID = ""
+		}
+	}
 	session.sessionMu.RUnlock()
 	session.abortPendingCommandsLocked(time.Now())
 }

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -479,10 +479,12 @@ func (session *DroneSession) abortPendingCommandsForStreamReplacement() {
 	session.pendingMu.Lock()
 	defer session.pendingMu.Unlock()
 	now := time.Now()
+	contextOutcomeUncertain := false
 	for commandID, state := range session.operationCommands {
 		if state.completed {
 			continue
 		}
+		contextOutcomeUncertain = true
 		delete(session.pending, commandID)
 		state.err = status.Error(codes.Aborted, "agent stream replaced while awaiting operation-context acknowledgement")
 		state.completed = true
@@ -500,6 +502,15 @@ func (session *DroneSession) abortPendingCommandsForStreamReplacement() {
 			state.deliveryCancel()
 		}
 		close(state.done)
+	}
+	if contextOutcomeUncertain {
+		// The old stream may have applied Set/Clear before its ACK was lost.
+		// Fence telemetry on the replacement until the API replays its current
+		// authoritative context; retaining the prior acknowledged attribution is
+		// unsafe while the Agent's durable state may now differ.
+		session.sessionMu.Lock()
+		session.operationContextUnreconciled = true
+		session.sessionMu.Unlock()
 	}
 }
 

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -61,7 +61,7 @@ func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*ag
 		pending:           make(map[string]chan *agentv1.OperationContextCommandAck),
 		operationCommands: make(map[string]*operationCommandState),
 		operationGate:     makeOperationGate(),
-		pendingAircraft:   make(map[string]chan *agentv1.AircraftCommandResult),
+		pendingAircraft:   make(map[string]chan aircraftCommandOutcome),
 	}
 
 	// Retire the previous session before publishing its replacement. Do not hold
@@ -84,6 +84,7 @@ func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*ag
 		}
 		if previous != nil {
 			previous.retired = true
+			previous.abortPendingAircraftCommands()
 			if r.registryReporter != nil {
 				r.registryReporter.StopAgent(agentID)
 			}
@@ -370,8 +371,20 @@ func (session *DroneSession) handleAircraftCommandResult(result *agentv1.Aircraf
 		return
 	}
 	select {
-	case pending <- result:
+	case pending <- aircraftCommandOutcome{result: result}:
 	default:
+	}
+}
+
+func (session *DroneSession) abortPendingAircraftCommands() {
+	session.pendingMu.Lock()
+	defer session.pendingMu.Unlock()
+	for commandID, pending := range session.pendingAircraft {
+		delete(session.pendingAircraft, commandID)
+		select {
+		case pending <- aircraftCommandOutcome{err: status.Error(codes.Aborted, "agent session retired while awaiting aircraft command result")}:
+		default:
+		}
 	}
 }
 

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -457,6 +457,34 @@ func (session *DroneSession) abortPendingCommands() {
 	session.abortPendingCommandsLocked(time.Now())
 }
 
+func (session *DroneSession) abortPendingCommandsForStreamReplacement() {
+	session.pendingMu.Lock()
+	defer session.pendingMu.Unlock()
+	now := time.Now()
+	for commandID, state := range session.operationCommands {
+		if state.completed {
+			continue
+		}
+		delete(session.pending, commandID)
+		state.err = status.Error(codes.Aborted, "agent stream replaced while awaiting operation-context acknowledgement")
+		state.completed = true
+		state.completedAt = now
+		close(state.done)
+	}
+	for _, state := range session.aircraftCommands {
+		if state.completed {
+			continue
+		}
+		state.err = status.Error(codes.Aborted, "agent stream replaced after aircraft command delivery; outcome is uncertain")
+		state.completed = true
+		state.completedAt = now
+		if state.deliveryCancel != nil {
+			state.deliveryCancel()
+		}
+		close(state.done)
+	}
+}
+
 func (session *DroneSession) restoreContextIntoAndAbortPending(replacement *DroneSession) {
 	session.pendingMu.Lock()
 	defer session.pendingMu.Unlock()

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -636,6 +636,32 @@ func TestSameSessionReplacementWaitsForControlWriteAndRejectsOldEvidence(t *test
 	case <-time.After(time.Second):
 		t.Fatal("control write did not start")
 	}
+	oldContextState := &operationCommandState{done: make(chan struct{})}
+	_, cancelOldAircraft := context.WithCancel(context.Background())
+	oldAircraftState := &aircraftCommandState{done: make(chan struct{}), deliveryCancel: cancelOldAircraft}
+	session.pendingMu.Lock()
+	session.pending["old-context-command"] = make(chan *agentv1.OperationContextCommandAck, 1)
+	session.operationCommands["old-context-command"] = oldContextState
+	session.aircraftCommands["old-aircraft-command"] = oldAircraftState
+	session.pendingMu.Unlock()
+	releaseOperationSlot, err := acquireOperationCommandSlot(context.Background(), session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contextWaitDone := make(chan error, 1)
+	go func() {
+		_, waitErr := awaitOperationCommand(
+			context.Background(), session, "old-context-command", oldContextState, true,
+		)
+		releaseOperationSlot()
+		contextWaitDone <- waitErr
+	}()
+	aircraftWaitDone := make(chan error, 1)
+	go func() {
+		<-oldAircraftState.done
+		_, waitErr := takeAircraftCommandResult(session, oldAircraftState)
+		aircraftWaitDone <- waitErr
+	}()
 
 	type replacementResult struct {
 		binding *telemetryStreamBinding
@@ -673,6 +699,25 @@ func TestSameSessionReplacementWaitsForControlWriteAndRejectsOldEvidence(t *test
 	newBinding := replacement.binding
 	if newBinding == nil {
 		t.Fatal("replacement binding is nil")
+	}
+	if waitErr := <-contextWaitDone; status.Code(waitErr) != codes.Aborted {
+		t.Fatalf("operation-context wait error = %v, want Aborted", waitErr)
+	}
+	if waitErr := <-aircraftWaitDone; status.Code(waitErr) != codes.Aborted {
+		t.Fatalf("aircraft-command wait error = %v, want Aborted", waitErr)
+	}
+	gateCtx, cancelGate := context.WithTimeout(context.Background(), time.Second)
+	defer cancelGate()
+	releaseNextOperationSlot, err := acquireOperationCommandSlot(gateCtx, session)
+	if err != nil {
+		t.Fatalf("replacement left operation gate blocked: %v", err)
+	}
+	releaseNextOperationSlot()
+	session.pendingMu.Lock()
+	_, oldContextStillPending := session.pending["old-context-command"]
+	session.pendingMu.Unlock()
+	if oldContextStillPending {
+		t.Fatal("replacement retained the superseded context ACK route")
 	}
 
 	contextState := &operationCommandState{done: make(chan struct{})}
@@ -714,6 +759,59 @@ func TestSameSessionReplacementWaitsForControlWriteAndRejectsOldEvidence(t *test
 	case <-aircraftState.done:
 	default:
 		t.Fatal("active stream did not complete the aircraft command")
+	}
+}
+
+func TestRegistryBackedStreamReplacementAbortsPendingCommandsAtCommit(t *testing.T) {
+	relay := relayWithRegistryReporter(t, &recordingAgentRegistrar{})
+	oldBinding := &telemetryStreamBinding{stream: &mockTelemetryStream{}, generation: 1}
+	contextState := &operationCommandState{done: make(chan struct{})}
+	_, cancelAircraft := context.WithCancel(context.Background())
+	aircraftState := &aircraftCommandState{done: make(chan struct{}), deliveryCancel: cancelAircraft}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1", stream: oldBinding, streamGeneration: 1,
+		pending: map[string]chan *agentv1.OperationContextCommandAck{
+			"context-command": make(chan *agentv1.OperationContextCommandAck, 1),
+		},
+		operationCommands: map[string]*operationCommandState{"context-command": contextState},
+		aircraftCommands:  map[string]*aircraftCommandState{"aircraft-command": aircraftState},
+	}
+	relay.grpcSessions[session.agentID] = session
+
+	_, replacement, previous, err := relay.updateStream(session.agentID, session.SessionID, &mockTelemetryStream{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-contextState.done:
+		t.Fatal("pending publication aborted commands before becoming active")
+	default:
+	}
+	if err := relay.registerActiveAgent(context.Background(), session.agentID, session, replacement, previous); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-contextState.done:
+	default:
+		t.Fatal("active replacement did not abort operation-context wait")
+	}
+	select {
+	case <-aircraftState.done:
+	default:
+		t.Fatal("active replacement did not abort aircraft-command wait")
+	}
+	session.pendingMu.Lock()
+	contextErr := contextState.err
+	aircraftErr := aircraftState.err
+	session.pendingMu.Unlock()
+	if status.Code(contextErr) != codes.Aborted || status.Code(aircraftErr) != codes.Aborted {
+		t.Fatalf("replacement errors = (%v, %v), want Aborted", contextErr, aircraftErr)
+	}
+	session.sessionMu.RLock()
+	active := session.stream
+	session.sessionMu.RUnlock()
+	if active != replacement {
+		t.Fatal("published replacement did not become active")
 	}
 }
 

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -1755,6 +1755,44 @@ func TestRegisterReplacementRestoresAcknowledgedOperationContext(t *testing.T) {
 	}
 }
 
+func TestRegisterReplacementDropsCompletedEmptyReconciliationReservation(t *testing.T) {
+	relay := relayWithSinks(mock.NewMockSink())
+	relay.grpcSessions = make(map[string]*DroneSession)
+	old := &DroneSession{
+		agentID: "agent-1", SessionID: "old-session",
+		operationContextUnreconciled: true,
+		emptyContextCommandID:        "reconcile-failed",
+		pending:                      make(map[string]chan *agentv1.OperationContextCommandAck),
+		operationCommands: map[string]*operationCommandState{
+			"reconcile-failed": {
+				done: make(chan struct{}), ack: &agentv1.OperationContextCommandAck{
+					CommandId: "reconcile-failed",
+					Status:    agentv1.OperationContextCommandAck_STATUS_REJECTED,
+				}, completed: true, completedAt: time.Now(),
+			},
+		},
+	}
+	relay.grpcSessions[old.agentID] = old
+	if _, err := relay.Register(context.Background(), &agentv1.RegisterRequest{AgentId: old.agentID}); err != nil {
+		t.Fatal(err)
+	}
+	relay.sessionsMu.RLock()
+	replacement := relay.grpcSessions[old.agentID]
+	relay.sessionsMu.RUnlock()
+	if replacement == old || !old.retired {
+		t.Fatal("registration did not replace and retire the old session")
+	}
+	replacement.sessionMu.RLock()
+	reserved := replacement.emptyContextCommandID
+	replacement.sessionMu.RUnlock()
+	if reserved != "" {
+		t.Fatalf("replacement inherited completed reconciliation reservation %q", reserved)
+	}
+	if !replacement.reserveEmptyContextReconciliation("reconcile-fresh") {
+		t.Fatal("completed reservation poisoned fresh empty reconciliation")
+	}
+}
+
 func TestFreshRelaySessionRetainsTelemetryUntilContextReconciles(t *testing.T) {
 	mockSink := mock.NewMockSink()
 	relay := relayWithSinks(mockSink)

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -871,6 +871,7 @@ type mockTelemetryStream struct {
 	errChan     chan error
 	sendStarted chan struct{}
 	sendBlock   chan struct{}
+	sendErr     error
 }
 
 func (m *mockTelemetryStream) Context() context.Context {
@@ -907,7 +908,7 @@ func (m *mockTelemetryStream) Send(ack *agentv1.RelayStreamMessage) error {
 	}
 	select {
 	case m.sentAckChan <- ack:
-		return nil
+		return m.sendErr
 	case <-m.ctx.Done():
 		return m.ctx.Err()
 	}

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -610,6 +610,102 @@ func TestStreamCleanupStopsOldLivenessBeforePublishingReplacementSession(t *test
 	}
 }
 
+func TestSameSessionReplacementWaitsForControlWriteAndRejectsOldEvidence(t *testing.T) {
+	oldStream := &mockTelemetryStream{
+		ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 1),
+		sendStarted: make(chan struct{}, 1), sendBlock: make(chan struct{}),
+	}
+	oldBinding := &telemetryStreamBinding{stream: oldStream, generation: 1}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1", stream: oldBinding, streamGeneration: 1,
+		pending:           make(map[string]chan *agentv1.OperationContextCommandAck),
+		operationCommands: make(map[string]*operationCommandState),
+		aircraftCommands:  make(map[string]*aircraftCommandState),
+	}
+	relay := &Relay{grpcSessions: map[string]*DroneSession{"agent-1": session}}
+	sendDone := make(chan error, 1)
+	go func() {
+		sendDone <- sendToSessionThroughWrite(context.Background(), session, &agentv1.RelayStreamMessage{
+			Payload: &agentv1.RelayStreamMessage_ClearOperationContext{
+				ClearOperationContext: &agentv1.ClearOperationContextCommand{CommandId: "context-command"},
+			},
+		})
+	}()
+	select {
+	case <-oldStream.sendStarted:
+	case <-time.After(time.Second):
+		t.Fatal("control write did not start")
+	}
+
+	type replacementResult struct {
+		binding *telemetryStreamBinding
+		err     error
+	}
+	replacementDone := make(chan replacementResult, 1)
+	go func() {
+		_, binding, _, err := relay.updateStream("agent-1", "session-1", &mockTelemetryStream{})
+		replacementDone <- replacementResult{binding: binding, err: err}
+	}()
+	select {
+	case <-replacementDone:
+		t.Fatal("same-session replacement committed during a control write")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(oldStream.sendBlock)
+	if err := <-sendDone; err != nil {
+		t.Fatalf("control write error = %v", err)
+	}
+	replacement := <-replacementDone
+	if replacement.err != nil {
+		t.Fatalf("updateStream() error = %v", replacement.err)
+	}
+	newBinding := replacement.binding
+	if newBinding == nil {
+		t.Fatal("replacement binding is nil")
+	}
+
+	contextState := &operationCommandState{done: make(chan struct{})}
+	session.pendingMu.Lock()
+	session.pending["context-command"] = make(chan *agentv1.OperationContextCommandAck, 1)
+	session.operationCommands["context-command"] = contextState
+	session.pendingMu.Unlock()
+	contextACK := &agentv1.OperationContextCommandAck{
+		CommandId: "context-command", Status: agentv1.OperationContextCommandAck_STATUS_APPLIED,
+	}
+	session.handleOperationContextCommandAckFrom(oldBinding, contextACK)
+	select {
+	case <-contextState.done:
+		t.Fatal("superseded stream completed the operation-context command")
+	default:
+	}
+	session.handleOperationContextCommandAckFrom(newBinding, contextACK)
+	select {
+	case <-contextState.done:
+	default:
+		t.Fatal("active stream did not complete the operation-context command")
+	}
+
+	aircraftState := &aircraftCommandState{done: make(chan struct{})}
+	session.pendingMu.Lock()
+	session.aircraftCommands["aircraft-command"] = aircraftState
+	session.pendingMu.Unlock()
+	aircraftResult := &agentv1.AircraftCommandResult{
+		CommandId: "aircraft-command", Status: agentv1.AircraftCommandResult_STATUS_ACCEPTED,
+	}
+	session.handleAircraftCommandResultFrom(oldBinding, aircraftResult)
+	select {
+	case <-aircraftState.done:
+		t.Fatal("superseded stream completed the aircraft command")
+	default:
+	}
+	session.handleAircraftCommandResultFrom(newBinding, aircraftResult)
+	select {
+	case <-aircraftState.done:
+	default:
+		t.Fatal("active stream did not complete the aircraft command")
+	}
+}
+
 // mockTelemetryStream implements agentv1.AgentGateway_TelemetryStreamServer
 type mockTelemetryStream struct {
 	grpc.ServerStream

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -1368,6 +1368,14 @@ func TestTelemetryStream_CommandACKStaysBoundToReceivingSession(t *testing.T) {
 		pending: map[string]chan *agentv1.OperationContextCommandAck{
 			"shared-command": oldPending,
 		},
+		operationCommands: map[string]*operationCommandState{
+			"shared-command": {
+				expected: &agentv1.OperationContext{
+					FlightId: "old-flight", IntentId: "old-intent", IntentVersion: 7,
+				},
+				done: make(chan struct{}),
+			},
+		},
 	}
 	relay.grpcSessions[agentID] = oldSession
 
@@ -1391,6 +1399,12 @@ func TestTelemetryStream_CommandACKStaysBoundToReceivingSession(t *testing.T) {
 	replacementPending := make(chan *agentv1.OperationContextCommandAck, 1)
 	replacementSession.pendingMu.Lock()
 	replacementSession.pending["shared-command"] = replacementPending
+	replacementSession.operationCommands["shared-command"] = &operationCommandState{
+		expected: &agentv1.OperationContext{
+			FlightId: "replacement-flight", IntentId: "replacement-intent", IntentVersion: 8,
+		},
+		done: make(chan struct{}),
+	}
 	replacementSession.pendingMu.Unlock()
 
 	commandAck := &agentv1.OperationContextCommandAck{

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -1362,6 +1362,12 @@ func TestTelemetryStream_CommandACKStaysBoundToReceivingSession(t *testing.T) {
 	relay.grpcSessions = make(map[string]*DroneSession)
 	agentID := "reconnecting-agent"
 	oldPending := make(chan *agentv1.OperationContextCommandAck, 1)
+	oldState := &operationCommandState{
+		expected: &agentv1.OperationContext{
+			FlightId: "old-flight", IntentId: "old-intent", IntentVersion: 7,
+		},
+		done: make(chan struct{}),
+	}
 	oldSession := &DroneSession{
 		agentID:   agentID,
 		SessionID: "old-session",
@@ -1369,12 +1375,7 @@ func TestTelemetryStream_CommandACKStaysBoundToReceivingSession(t *testing.T) {
 			"shared-command": oldPending,
 		},
 		operationCommands: map[string]*operationCommandState{
-			"shared-command": {
-				expected: &agentv1.OperationContext{
-					FlightId: "old-flight", IntentId: "old-intent", IntentVersion: 7,
-				},
-				done: make(chan struct{}),
-			},
+			"shared-command": oldState,
 		},
 	}
 	relay.grpcSessions[agentID] = oldSession
@@ -1395,6 +1396,14 @@ func TestTelemetryStream_CommandACKStaysBoundToReceivingSession(t *testing.T) {
 	relay.sessionsMu.RUnlock()
 	if replacementSession == oldSession {
 		t.Fatal("registration did not replace the old session")
+	}
+	select {
+	case <-oldState.done:
+		if status.Code(oldState.err) != codes.Aborted {
+			t.Fatalf("old pending command error = %v, want Aborted", oldState.err)
+		}
+	default:
+		t.Fatal("replacement did not abort the old pending command")
 	}
 	replacementPending := make(chan *agentv1.OperationContextCommandAck, 1)
 	replacementSession.pendingMu.Lock()
@@ -1421,13 +1430,10 @@ func TestTelemetryStream_CommandACKStaysBoundToReceivingSession(t *testing.T) {
 	}
 	select {
 	case got := <-oldPending:
-		if got != commandAck {
-			t.Fatalf("old pending command received ACK %#v, want %#v", got, commandAck)
-		}
+		t.Fatalf("retired pending command received late ACK %#v", got)
 	case <-replacementPending:
 		t.Fatal("replacement session received a command ACK from the old stream")
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for command ACK on the receiving session")
+	case <-time.After(20 * time.Millisecond):
 	}
 
 	oldSession.sessionMu.RLock()
@@ -1435,8 +1441,8 @@ func TestTelemetryStream_CommandACKStaysBoundToReceivingSession(t *testing.T) {
 	oldIntentID := oldSession.IntentID
 	oldIntentVersion := oldSession.IntentVersion
 	oldSession.sessionMu.RUnlock()
-	if oldFlightID != "old-flight" || oldIntentID != "old-intent" || oldIntentVersion != 7 {
-		t.Fatalf("old session context = (%q, %q, %d)", oldFlightID, oldIntentID, oldIntentVersion)
+	if oldFlightID != "" || oldIntentID != "" || oldIntentVersion != 0 {
+		t.Fatalf("late ACK changed retired session context to (%q, %q, %d)", oldFlightID, oldIntentID, oldIntentVersion)
 	}
 	replacementSession.sessionMu.RLock()
 	replacementFlightID := replacementSession.FlightID

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -1500,6 +1500,76 @@ func TestRegisterReplacementRestoresAcknowledgedOperationContext(t *testing.T) {
 	if got := droneStatus(replacement); got.GetFlightId() != "flight-1" || got.GetIntentId() != "intent-1" || got.GetIntentVersion() != 7 {
 		t.Fatalf("replacement context = %#v, want flight-1/intent-1/7", got)
 	}
+	if replacement.requiresOperationContextReconciliation() {
+		t.Fatal("same-process replacement lost reconciled operation context")
+	}
+}
+
+func TestFreshRelaySessionRetainsTelemetryUntilContextReconciles(t *testing.T) {
+	mockSink := mock.NewMockSink()
+	relay := relayWithSinks(mockSink)
+	relay.controlAuthorizer = func(context.Context) error { return nil }
+	relay.grpcSessions = make(map[string]*DroneSession)
+
+	registration, err := relay.Register(context.Background(), &agentv1.RegisterRequest{AgentId: "agent-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	relay.sessionsMu.RLock()
+	session := relay.grpcSessions["agent-1"]
+	relay.sessionsMu.RUnlock()
+	if !session.requiresOperationContextReconciliation() {
+		t.Fatal("first session in Relay process started with an implicitly empty context")
+	}
+
+	stream, cancel := newAgentTelemetryStream("agent-1", registration.GetSessionId())
+	defer cancel()
+	streamErr := make(chan error, 1)
+	go func() { streamErr <- relay.TelemetryStream(stream) }()
+
+	frame := &agentv1.TelemetryFrame{
+		AgentId: "agent-1", SessionId: registration.GetSessionId(), Seq: 1,
+		MsgName: "Heartbeat", WalId: testWALGenerationID, SentAtUnixNs: time.Now().UnixNano(),
+	}
+	stream.recvChan <- telemetryStreamMessage(frame)
+	message := <-stream.sentAckChan
+	ack := message.GetTelemetryAck()
+	if ack == nil || ack.GetStatus() != agentv1.TelemetryAck_STATUS_RETRY_WITH_BACKOFF ||
+		!strings.Contains(ack.GetError(), "operation context") {
+		t.Fatalf("unreconciled telemetry ACK = %#v, want retry", ack)
+	}
+	if mockSink.GetMessageCount() != 0 {
+		t.Fatal("unreconciled telemetry reached an output")
+	}
+
+	pending := make(chan *agentv1.OperationContextCommandAck, 1)
+	session.pendingMu.Lock()
+	session.pending["reconcile-clear"] = pending
+	session.operationCommands["reconcile-clear"] = &operationCommandState{
+		expected: nil, done: make(chan struct{}),
+	}
+	session.pendingMu.Unlock()
+	stream.recvChan <- &agentv1.AgentStreamMessage{Payload: &agentv1.AgentStreamMessage_OperationContextCommandAck{
+		OperationContextCommandAck: &agentv1.OperationContextCommandAck{
+			CommandId: "reconcile-clear", Status: agentv1.OperationContextCommandAck_STATUS_APPLIED,
+		},
+	}}
+
+	frame.Seq = 2
+	stream.recvChan <- telemetryStreamMessage(frame)
+	message = <-stream.sentAckChan
+	ack = message.GetTelemetryAck()
+	if ack == nil || ack.GetStatus() != agentv1.TelemetryAck_STATUS_OK {
+		t.Fatalf("reconciled telemetry ACK = %#v, want OK", ack)
+	}
+	if mockSink.GetMessageCount() != 1 {
+		t.Fatalf("reconciled telemetry output count = %d, want 1", mockSink.GetMessageCount())
+	}
+
+	close(stream.recvChan)
+	if err := <-streamErr; err != nil {
+		t.Fatalf("TelemetryStream() error = %v", err)
+	}
 }
 
 func TestOperationContextCommandACKRequiresPendingCommand(t *testing.T) {

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -1479,6 +1479,29 @@ func TestTelemetryStream_CommandACKStaysBoundToReceivingSession(t *testing.T) {
 	}
 }
 
+func TestRegisterReplacementRestoresAcknowledgedOperationContext(t *testing.T) {
+	relay := relayWithSinks(mock.NewMockSink())
+	relay.grpcSessions = make(map[string]*DroneSession)
+	old := &DroneSession{
+		agentID: "agent-1", SessionID: "old-session",
+		FlightID: "flight-1", IntentID: "intent-1", IntentVersion: 7,
+		pending: make(map[string]chan *agentv1.OperationContextCommandAck),
+	}
+	relay.grpcSessions["agent-1"] = old
+	if _, err := relay.Register(context.Background(), &agentv1.RegisterRequest{AgentId: "agent-1"}); err != nil {
+		t.Fatal(err)
+	}
+	relay.sessionsMu.RLock()
+	replacement := relay.grpcSessions["agent-1"]
+	relay.sessionsMu.RUnlock()
+	if replacement == old {
+		t.Fatal("registration did not replace the old session")
+	}
+	if got := droneStatus(replacement); got.GetFlightId() != "flight-1" || got.GetIntentId() != "intent-1" || got.GetIntentVersion() != 7 {
+		t.Fatalf("replacement context = %#v, want flight-1/intent-1/7", got)
+	}
+}
+
 func TestOperationContextCommandACKRequiresPendingCommand(t *testing.T) {
 	session := &DroneSession{
 		FlightID:      "existing-flight",

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -257,6 +257,47 @@ func TestRegisterDoesNotPublishAgentBeforeTelemetryStream(t *testing.T) {
 	}
 }
 
+func TestCanceledRegisterPreservesSessionHeldByInFlightWork(t *testing.T) {
+	const agentID = "agent-1"
+	previous := &DroneSession{agentID: agentID, SessionID: "session-1"}
+	reporter := &recordingAgentRegistrar{}
+	relay := relayWithRegistryReporter(t, reporter)
+	relay.grpcSessions[agentID] = previous
+	previous.ownershipMu.RLock()
+	ctx, cancel := context.WithCancel(authenticatedAgentContext(agentID))
+	registrationDone := make(chan error, 1)
+	go func() {
+		_, err := relay.Register(ctx, &agentv1.RegisterRequest{AgentId: agentID})
+		registrationDone <- err
+	}()
+	select {
+	case err := <-registrationDone:
+		previous.ownershipMu.RUnlock()
+		t.Fatalf("Register() completed while session ownership was held: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	cancel()
+	previous.ownershipMu.RUnlock()
+	select {
+	case err := <-registrationDone:
+		if status.Code(err) != codes.Canceled {
+			t.Fatalf("Register() error = %v, want Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled Register() did not return after ownership was released")
+	}
+	relay.sessionsMu.RLock()
+	current := relay.grpcSessions[agentID]
+	relay.sessionsMu.RUnlock()
+	if current != previous || previous.retired {
+		t.Fatal("canceled registration replaced or retired the live session")
+	}
+	if len(reporter.stopped) != 0 {
+		t.Fatalf("canceled registration stopped Registry liveness: %v", reporter.stopped)
+	}
+}
+
 func TestRegisterSucceedsWhileRegistryIsUnavailable(t *testing.T) {
 	reporter := &recordingAgentRegistrar{err: errors.New("registry unavailable")}
 	relay := relayWithRegistryReporter(t, reporter)

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -1485,7 +1485,8 @@ func TestRegisterReplacementRestoresAcknowledgedOperationContext(t *testing.T) {
 	old := &DroneSession{
 		agentID: "agent-1", SessionID: "old-session",
 		FlightID: "flight-1", IntentID: "intent-1", IntentVersion: 7,
-		pending: make(map[string]chan *agentv1.OperationContextCommandAck),
+		emptyContextCommandID: "reconcile-empty",
+		pending:               make(map[string]chan *agentv1.OperationContextCommandAck),
 	}
 	relay.grpcSessions["agent-1"] = old
 	if _, err := relay.Register(context.Background(), &agentv1.RegisterRequest{AgentId: "agent-1"}); err != nil {
@@ -1502,6 +1503,9 @@ func TestRegisterReplacementRestoresAcknowledgedOperationContext(t *testing.T) {
 	}
 	if replacement.requiresOperationContextReconciliation() {
 		t.Fatal("same-process replacement lost reconciled operation context")
+	}
+	if !replacement.reserveEmptyContextReconciliation("reconcile-empty") || replacement.reserveEmptyContextReconciliation("different-empty") {
+		t.Fatal("same-process replacement lost the retained empty-context command identity")
 	}
 }
 

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -654,8 +654,8 @@ func TestSameSessionReplacementWaitsForControlWriteAndRejectsOldEvidence(t *test
 	globalWrite := make(chan struct{})
 	go func() {
 		relay.sessionsMu.Lock()
-		relay.sessionsMu.Unlock()
 		close(globalWrite)
+		relay.sessionsMu.Unlock()
 	}()
 	select {
 	case <-globalWrite:

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -651,6 +651,17 @@ func TestSameSessionReplacementWaitsForControlWriteAndRejectsOldEvidence(t *test
 		t.Fatal("same-session replacement committed during a control write")
 	case <-time.After(20 * time.Millisecond):
 	}
+	globalWrite := make(chan struct{})
+	go func() {
+		relay.sessionsMu.Lock()
+		relay.sessionsMu.Unlock()
+		close(globalWrite)
+	}()
+	select {
+	case <-globalWrite:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("per-session stream fence blocked the Relay-wide session map")
+	}
 	close(oldStream.sendBlock)
 	if err := <-sendDone; err != nil {
 		t.Fatalf("control write error = %v", err)

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -744,6 +744,9 @@ func TestSameSessionReplacementWaitsForControlWriteAndRejectsOldEvidence(t *test
 	if waitErr := <-contextWaitDone; status.Code(waitErr) != codes.Aborted {
 		t.Fatalf("operation-context wait error = %v, want Aborted", waitErr)
 	}
+	if !session.requiresOperationContextReconciliation() {
+		t.Fatal("uncertain context handoff did not re-enter telemetry reconciliation")
+	}
 	if waitErr := <-aircraftWaitDone; status.Code(waitErr) != codes.Aborted {
 		t.Fatalf("aircraft-command wait error = %v, want Aborted", waitErr)
 	}
@@ -835,6 +838,9 @@ func TestRegistryBackedStreamReplacementAbortsPendingCommandsAtCommit(t *testing
 	case <-contextState.done:
 	default:
 		t.Fatal("active replacement did not abort operation-context wait")
+	}
+	if !session.requiresOperationContextReconciliation() {
+		t.Fatal("Registry-backed uncertain context handoff did not fence telemetry")
 	}
 	select {
 	case <-aircraftState.done:

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -1618,7 +1618,7 @@ func TestTelemetryStream_CommandACKStaysBoundToReceivingSession(t *testing.T) {
 		expected: &agentv1.OperationContext{
 			FlightId: "old-flight", IntentId: "old-intent", IntentVersion: 7,
 		},
-		done: make(chan struct{}),
+		done: make(chan struct{}), delivered: true,
 	}
 	oldSession := &DroneSession{
 		agentID:   agentID,
@@ -1648,6 +1648,9 @@ func TestTelemetryStream_CommandACKStaysBoundToReceivingSession(t *testing.T) {
 	relay.sessionsMu.RUnlock()
 	if replacementSession == oldSession {
 		t.Fatal("registration did not replace the old session")
+	}
+	if !replacementSession.requiresOperationContextReconciliation() {
+		t.Fatal("replacement inherited reconciled telemetry admission after an uncertain delivered mutation")
 	}
 	select {
 	case <-oldState.done:

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -80,29 +80,34 @@ type registryService interface {
 }
 
 type DroneSession struct {
-	stream            *telemetryStreamBinding
-	pendingStream     *telemetryStreamBinding
-	streamGeneration  uint64
-	agentID           string
-	SessionID         string
-	ConnectedAt       time.Time
-	LastHeartbeat     time.Time
-	Position          *common.MessageGlobalPositionInt
-	Attitude          *common.MessageAttitude
-	VfrHud            *common.MessageVfrHud
-	SystemStatus      *common.MessageSysStatus
-	FlightID          string
-	IntentID          string
-	IntentVersion     uint32
-	sessionMu         sync.RWMutex
-	pendingMu         sync.Mutex
-	pending           map[string]chan *agentv1.OperationContextCommandAck
-	operationCommands map[string]*operationCommandState
-	operationGate     chan struct{}
-	aircraftCommands  map[string]*aircraftCommandState
-	ownershipMu       sync.RWMutex
-	publicationMu     sync.Mutex
-	retired           bool
+	stream           *telemetryStreamBinding
+	pendingStream    *telemetryStreamBinding
+	streamGeneration uint64
+	agentID          string
+	SessionID        string
+	ConnectedAt      time.Time
+	LastHeartbeat    time.Time
+	Position         *common.MessageGlobalPositionInt
+	Attitude         *common.MessageAttitude
+	VfrHud           *common.MessageVfrHud
+	SystemStatus     *common.MessageSysStatus
+	FlightID         string
+	IntentID         string
+	IntentVersion    uint32
+	// operationContextUnreconciled is set for the first Agent session seen by a
+	// Relay process with context control enabled. Telemetry remains retryable
+	// until the API replays an authoritative Set/Clear command; same-process
+	// replacements inherit the previous session's reconciled state.
+	operationContextUnreconciled bool
+	sessionMu                    sync.RWMutex
+	pendingMu                    sync.Mutex
+	pending                      map[string]chan *agentv1.OperationContextCommandAck
+	operationCommands            map[string]*operationCommandState
+	operationGate                chan struct{}
+	aircraftCommands             map[string]*aircraftCommandState
+	ownershipMu                  sync.RWMutex
+	publicationMu                sync.Mutex
+	retired                      bool
 }
 
 type operationCommandState struct {

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -99,7 +99,7 @@ type DroneSession struct {
 	pending           map[string]chan *agentv1.OperationContextCommandAck
 	operationCommands map[string]*operationCommandState
 	operationGate     chan struct{}
-	pendingAircraft   map[string]chan aircraftCommandOutcome
+	aircraftCommands  map[string]*aircraftCommandState
 	ownershipMu       sync.RWMutex
 	publicationMu     sync.Mutex
 	retired           bool
@@ -115,9 +115,13 @@ type operationCommandState struct {
 	completedAt time.Time
 }
 
-type aircraftCommandOutcome struct {
-	result *agentv1.AircraftCommandResult
-	err    error
+type aircraftCommandState struct {
+	fingerprint string
+	done        chan struct{}
+	result      *agentv1.AircraftCommandResult
+	err         error
+	completed   bool
+	completedAt time.Time
 }
 
 type telemetryStreamBinding struct {

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -59,6 +59,7 @@ type Relay struct {
 	registryReporter   agentRegistryReporter
 	registryLifecycle  registryLifecycle
 	agentAuthenticator func(context.Context, string) error
+	controlAuthorizer  controlPlaneAuthorizer
 	relayv1.UnimplementedRelayControlServer
 	agentv1.UnimplementedAgentGatewayServer
 }
@@ -170,6 +171,9 @@ var (
 //   - relay: owns initialized outputs but is not yet serving.
 //   - error: reports authentication or output initialization failure.
 func New(cfg *config.Config) (*Relay, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("relay configuration is required")
+	}
 	authenticator, err := newAgentTokenAuthenticator(cfg.AgentAuth.Tokens)
 	if err != nil {
 		return nil, err
@@ -177,11 +181,16 @@ func New(cfg *config.Config) (*Relay, error) {
 	if cfg.Registry.Enabled && authenticator == nil {
 		return nil, fmt.Errorf("agent authentication is required when registry reporting is enabled")
 	}
+	controlAuthorizer, err := newControlPlaneAuthorizer(cfg.ControlAuth)
+	if err != nil {
+		return nil, fmt.Errorf("configure control-plane authentication: %w", err)
+	}
 	relay := &Relay{
 		config:             cfg,
 		sinks:              make([]sinks.Sink, 0),
 		grpcSessions:       make(map[string]*DroneSession),
 		agentAuthenticator: authenticator,
+		controlAuthorizer:  controlAuthorizer,
 	}
 
 	if err := relay.initializeOutputs(); err != nil {
@@ -220,7 +229,7 @@ func (r *Relay) Start(ctx context.Context) error {
 	var creds credentials.TransportCredentials
 	var homeDir string
 
-	creds, err = credentials.NewServerTLSFromFile(r.config.TLSCertPath, r.config.TLSKeyPath)
+	creds, err = serverTransportCredentials(r.config, r.config.TLSCertPath, r.config.TLSKeyPath)
 	if r.config.Debug {
 		homeDir, err = os.UserHomeDir()
 		if err != nil {
@@ -230,7 +239,7 @@ func (r *Relay) Start(ctx context.Context) error {
 
 		certPath := fmt.Sprintf("%s/%s", homeDir, DebugTLSCertPath)
 		keyPath := fmt.Sprintf("%s/%s", homeDir, DebugTLSKeyPath)
-		creds, err = credentials.NewServerTLSFromFile(certPath, keyPath)
+		creds, err = serverTransportCredentials(r.config, certPath, keyPath)
 	}
 
 	if err != nil {

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -116,13 +116,14 @@ type operationCommandState struct {
 }
 
 type aircraftCommandState struct {
-	fingerprint string
-	done        chan struct{}
-	waiters     int
-	result      *agentv1.AircraftCommandResult
-	err         error
-	completed   bool
-	completedAt time.Time
+	fingerprint    string
+	done           chan struct{}
+	deliveryCancel context.CancelFunc
+	waiters        int
+	result         *agentv1.AircraftCommandResult
+	err            error
+	completed      bool
+	completedAt    time.Time
 }
 
 type telemetryStreamBinding struct {

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -118,6 +118,7 @@ type operationCommandState struct {
 type aircraftCommandState struct {
 	fingerprint string
 	done        chan struct{}
+	waiters     int
 	result      *agentv1.AircraftCommandResult
 	err         error
 	completed   bool

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -109,9 +109,13 @@ type DroneSession struct {
 	operationCommands     map[string]*operationCommandState
 	operationGate         chan struct{}
 	aircraftCommands      map[string]*aircraftCommandState
-	ownershipMu           sync.RWMutex
-	publicationMu         sync.Mutex
-	retired               bool
+	// controlStreamMu keeps command writes and command evidence on one active
+	// telemetry-stream binding. Same-session stream replacement takes the write
+	// side only for the binding swap, not for Registry publication or telemetry.
+	controlStreamMu sync.RWMutex
+	ownershipMu     sync.RWMutex
+	publicationMu   sync.Mutex
+	retired         bool
 }
 
 type operationCommandState struct {

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -99,15 +99,19 @@ type DroneSession struct {
 	// until the API replays an authoritative Set/Clear command; same-process
 	// replacements inherit the previous session's reconciled state.
 	operationContextUnreconciled bool
-	sessionMu                    sync.RWMutex
-	pendingMu                    sync.Mutex
-	pending                      map[string]chan *agentv1.OperationContextCommandAck
-	operationCommands            map[string]*operationCommandState
-	operationGate                chan struct{}
-	aircraftCommands             map[string]*aircraftCommandState
-	ownershipMu                  sync.RWMutex
-	publicationMu                sync.Mutex
-	retired                      bool
+	// emptyContextCommandID retains the one durable command permitted to assert
+	// an authoritative empty context, including exact retries after admission
+	// opens and same-process session replacement.
+	emptyContextCommandID string
+	sessionMu             sync.RWMutex
+	pendingMu             sync.Mutex
+	pending               map[string]chan *agentv1.OperationContextCommandAck
+	operationCommands     map[string]*operationCommandState
+	operationGate         chan struct{}
+	aircraftCommands      map[string]*aircraftCommandState
+	ownershipMu           sync.RWMutex
+	publicationMu         sync.Mutex
+	retired               bool
 }
 
 type operationCommandState struct {

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -80,27 +80,39 @@ type registryService interface {
 }
 
 type DroneSession struct {
-	stream           *telemetryStreamBinding
-	pendingStream    *telemetryStreamBinding
-	streamGeneration uint64
-	agentID          string
-	SessionID        string
-	ConnectedAt      time.Time
-	LastHeartbeat    time.Time
-	Position         *common.MessageGlobalPositionInt
-	Attitude         *common.MessageAttitude
-	VfrHud           *common.MessageVfrHud
-	SystemStatus     *common.MessageSysStatus
-	FlightID         string
-	IntentID         string
-	IntentVersion    uint32
-	sessionMu        sync.RWMutex
-	pendingMu        sync.Mutex
-	pending          map[string]chan *agentv1.OperationContextCommandAck
-	pendingAircraft  map[string]chan *agentv1.AircraftCommandResult
-	ownershipMu      sync.RWMutex
-	publicationMu    sync.Mutex
-	retired          bool
+	stream            *telemetryStreamBinding
+	pendingStream     *telemetryStreamBinding
+	streamGeneration  uint64
+	agentID           string
+	SessionID         string
+	ConnectedAt       time.Time
+	LastHeartbeat     time.Time
+	Position          *common.MessageGlobalPositionInt
+	Attitude          *common.MessageAttitude
+	VfrHud            *common.MessageVfrHud
+	SystemStatus      *common.MessageSysStatus
+	FlightID          string
+	IntentID          string
+	IntentVersion     uint32
+	sessionMu         sync.RWMutex
+	pendingMu         sync.Mutex
+	pending           map[string]chan *agentv1.OperationContextCommandAck
+	operationCommands map[string]*operationCommandState
+	operationGate     chan struct{}
+	pendingAircraft   map[string]chan *agentv1.AircraftCommandResult
+	ownershipMu       sync.RWMutex
+	publicationMu     sync.Mutex
+	retired           bool
+}
+
+type operationCommandState struct {
+	fingerprint string
+	expected    *agentv1.OperationContext
+	done        chan struct{}
+	ack         *agentv1.OperationContextCommandAck
+	err         error
+	completed   bool
+	completedAt time.Time
 }
 
 type telemetryStreamBinding struct {

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -99,7 +99,7 @@ type DroneSession struct {
 	pending           map[string]chan *agentv1.OperationContextCommandAck
 	operationCommands map[string]*operationCommandState
 	operationGate     chan struct{}
-	pendingAircraft   map[string]chan *agentv1.AircraftCommandResult
+	pendingAircraft   map[string]chan aircraftCommandOutcome
 	ownershipMu       sync.RWMutex
 	publicationMu     sync.Mutex
 	retired           bool
@@ -113,6 +113,11 @@ type operationCommandState struct {
 	err         error
 	completed   bool
 	completedAt time.Time
+}
+
+type aircraftCommandOutcome struct {
+	result *agentv1.AircraftCommandResult
+	err    error
 }
 
 type telemetryStreamBinding struct {

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -96,6 +96,7 @@ type DroneSession struct {
 	sessionMu        sync.RWMutex
 	pendingMu        sync.Mutex
 	pending          map[string]chan *agentv1.OperationContextCommandAck
+	pendingAircraft  map[string]chan *agentv1.AircraftCommandResult
 	ownershipMu      sync.RWMutex
 	publicationMu    sync.Mutex
 	retired          bool
@@ -157,6 +158,16 @@ var (
 		Name: "aero_relay_sink_errors_total",
 		Help: "Errors returned while forwarding telemetry to sinks.",
 	}, []string{"sink"})
+
+	relayAircraftCommandsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "aero_relay_aircraft_commands_total",
+		Help: "Immediate aircraft commands handled by the relay.",
+	}, []string{"command_type", "result"})
+
+	relayAircraftCommandDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "aero_relay_aircraft_command_duration_seconds",
+		Help: "Time from Relay command receipt to Agent result.",
+	}, []string{"command_type"})
 )
 
 // New validates Agent authentication requirements and constructs a Relay with

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -124,6 +124,7 @@ type operationCommandState struct {
 	done        chan struct{}
 	ack         *agentv1.OperationContextCommandAck
 	err         error
+	delivered   bool
 	completed   bool
 	completedAt time.Time
 }

--- a/internal/relay/streams.go
+++ b/internal/relay/streams.go
@@ -126,6 +126,7 @@ func (r *Relay) deleteStream(agentID string, expectedSession *DroneSession, expe
 	session.sessionMu.Unlock()
 	if isCurrentStream {
 		session.retired = true
+		session.abortPendingAircraftCommands()
 		delete(r.grpcSessions, agentID)
 		// Stop liveness before releasing the session-map lock. Otherwise a new
 		// registration could publish and activate a replacement stream between

--- a/internal/relay/streams.go
+++ b/internal/relay/streams.go
@@ -26,6 +26,10 @@ func (r *Relay) updateStream(agentID, sessionID string, stream agentv1.AgentGate
 		return nil, nil, nil, ErrSessionNotFound
 	}
 
+	if r.registryReporter == nil {
+		session.controlStreamMu.Lock()
+		defer session.controlStreamMu.Unlock()
+	}
 	session.sessionMu.Lock()
 	defer session.sessionMu.Unlock()
 
@@ -91,6 +95,10 @@ func (r *Relay) registerActiveAgent(
 		return err
 	}
 
+	// Publication may remain slow without blocking accepted telemetry. Only the
+	// final active-binding swap excludes command writes and command evidence.
+	expectedSession.controlStreamMu.Lock()
+	defer expectedSession.controlStreamMu.Unlock()
 	expectedSession.sessionMu.Lock()
 	defer expectedSession.sessionMu.Unlock()
 	if isActive {

--- a/internal/relay/streams.go
+++ b/internal/relay/streams.go
@@ -126,7 +126,7 @@ func (r *Relay) deleteStream(agentID string, expectedSession *DroneSession, expe
 	session.sessionMu.Unlock()
 	if isCurrentStream {
 		session.retired = true
-		session.abortPendingAircraftCommands()
+		session.abortPendingCommands()
 		delete(r.grpcSessions, agentID)
 		// Stop liveness before releasing the session-map lock. Otherwise a new
 		// registration could publish and activate a replacement stream between

--- a/internal/relay/streams.go
+++ b/internal/relay/streams.go
@@ -19,16 +19,27 @@ import (
 
 func (r *Relay) updateStream(agentID, sessionID string, stream agentv1.AgentGateway_TelemetryStreamServer) (*DroneSession, *telemetryStreamBinding, *telemetryStreamBinding, error) {
 	r.sessionsMu.RLock()
-	defer r.sessionsMu.RUnlock()
-
 	session, ok := r.grpcSessions[agentID]
-	if !ok || session.SessionID != sessionID || session.retired {
+	valid := ok && session.SessionID == sessionID && !session.retired
+	r.sessionsMu.RUnlock()
+	if !valid {
 		return nil, nil, nil, ErrSessionNotFound
 	}
 
+	// Never wait for one Agent's stream fences while holding the Relay-wide map
+	// lock. Pin this session, then briefly revalidate map ownership before
+	// publishing a binding; unrelated Agent registration and cleanup stay live.
+	session.ownershipMu.RLock()
+	defer session.ownershipMu.RUnlock()
 	if r.registryReporter == nil {
 		session.controlStreamMu.Lock()
 		defer session.controlStreamMu.Unlock()
+	}
+	r.sessionsMu.RLock()
+	isCurrent := r.grpcSessions[agentID] == session && session.SessionID == sessionID && !session.retired
+	r.sessionsMu.RUnlock()
+	if !isCurrent {
+		return nil, nil, nil, ErrSessionNotFound
 	}
 	session.sessionMu.Lock()
 	defer session.sessionMu.Unlock()

--- a/internal/relay/streams.go
+++ b/internal/relay/streams.go
@@ -42,8 +42,6 @@ func (r *Relay) updateStream(agentID, sessionID string, stream agentv1.AgentGate
 		return nil, nil, nil, ErrSessionNotFound
 	}
 	session.sessionMu.Lock()
-	defer session.sessionMu.Unlock()
-
 	previous := session.stream
 	session.streamGeneration++
 	binding := &telemetryStreamBinding{
@@ -54,6 +52,13 @@ func (r *Relay) updateStream(agentID, sessionID string, stream agentv1.AgentGate
 		session.stream = binding
 	} else {
 		session.pendingStream = binding
+	}
+	session.sessionMu.Unlock()
+	if r.registryReporter == nil && previous != nil && previous != binding {
+		// The old binding can no longer provide authoritative command evidence.
+		// Complete its pending waits while the control write fence still excludes
+		// both old evidence and new command admission.
+		session.abortPendingCommandsForStreamReplacement()
 	}
 
 	return session, binding, previous, nil
@@ -111,17 +116,23 @@ func (r *Relay) registerActiveAgent(
 	expectedSession.controlStreamMu.Lock()
 	defer expectedSession.controlStreamMu.Unlock()
 	expectedSession.sessionMu.Lock()
-	defer expectedSession.sessionMu.Unlock()
 	if isActive {
+		expectedSession.sessionMu.Unlock()
 		return nil
 	}
 	if expectedSession.pendingStream != expectedStream || expectedStream.closed {
+		expectedSession.sessionMu.Unlock()
 		return ErrSessionNotFound
 	}
 	// The prior accepted binding stays current and can route telemetry throughout
 	// the Registry RPC. Commit the replacement only after publication succeeds.
+	previousStream := expectedSession.stream
 	expectedSession.stream = expectedStream
 	expectedSession.pendingStream = nil
+	expectedSession.sessionMu.Unlock()
+	if previousStream != nil && previousStream != expectedStream {
+		expectedSession.abortPendingCommandsForStreamReplacement()
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- implement authenticated SetOperationContext and ClearOperationContext control
  commands
- keep Agent bearer-token connections compatible on the shared TLS listener
- require a verified, allow-listed mTLS identity for control mutations
- validate requests, fence session replacement, deliver context to the current
  Agent stream, and wait for Agent acknowledgement
- merge the authenticated ARM/DISARM aircraft-command handler into the same
  Relay feature path used by the no-seed observer stack
- apply the mTLS control authorization gate to ARM/DISARM as well as context
  mutations
- retain deterministic payload fingerprints and terminal outcomes so exact
  retries coalesce while command-ID reuse with another payload is rejected
- resolve retained command IDs before capacity eviction, so an exact retry at
  the bounded 4,096-entry limit cannot evict its own outcome and redeliver
- validate successful Agent acknowledgements against the API-requested context
  and update telemetry attribution only from that authoritative expectation
- serialize context mutations per Agent session so concurrent set/clear calls
  cannot calculate an expected context from stale in-flight state
- pin each selected session through operation-context pending-state creation and
  stream delivery, then release it before waiting for the Agent ACK
- retain ARM/DISARM payload fingerprints and terminal correlation outcomes so
  exact retries do not redeliver and conflicting command-ID reuse is rejected
- release the Agent-session ownership lease after aircraft-command delivery and
  abort pending aircraft and operation-context waits on retirement, so a lost
  result cannot block disconnect cleanup, Agent reconnection, or an unbounded
  control caller
- preserve the last API-authoritative acknowledged flight/intent context across
  same-process Agent session replacement, while fencing delayed ACKs from the
  retired session
- when context control is enabled, start the first Agent session after Relay
  process startup behind a reconciliation gate; retain telemetry in the Agent
  WAL with retry ACKs until the API replays an authoritative Set or Clear
- allow one explicitly authoritative empty-flight Clear to represent the API's
  no-active-flight state during that reconciliation; reject omitted legacy and
  contradictory clear modes, retain the command identity for exact retries,
  reject new authoritative clears after admission opens, and roll back
  reservations that fail payload/command-ID validation or return a retained
  terminal failure
- carry an empty-context reconciliation reservation across session replacement
  only while its matching command is genuinely pending; completed failures and
  not-yet-admitted attempts cannot poison the replacement session
- give exact concurrent aircraft commands a shared, session-cancellable delivery
  lifecycle; callers detach independently even while stream send is blocked, so
  one canceled caller cannot finalize or strand callers still waiting
- hold the old session ownership lease through the actual aircraft-command
  stream write, preventing Agent replacement from publishing while ARM/DISARM
  can still reach the retired stream
- apply the same through-write session fence to operation-context mutations, so
  timed-out Set/Clear writes cannot land after replacement and split Agent state
  from Relay telemetry attribution
- linearize through-write control sends with same-session active-stream swaps;
  operation-context ACKs and aircraft results from a superseded binding cannot
  complete shared command state even though the session ID is unchanged
- release the Relay-wide session-map lock before waiting on per-session stream
  fences, then revalidate ownership before the swap, so one flow-controlled
  Agent cannot stall unrelated registration, cleanup, or reconnection
- abort pending operation-context and aircraft-command waits when a newer stream
  becomes active, releasing the serialized context gate instead of waiting for
  evidence that is no longer authoritative; aircraft results remain explicitly
  outcome-uncertain and are not automatically redelivered
- re-enter operation-context reconciliation whenever replacement loses a
  delivered Set/Clear outcome, so telemetry cannot resume under the prior
  attribution until the API replays its authoritative state
- carry that uncertainty into a newly registered full replacement whenever an
  outstanding Set/Clear had crossed stream delivery, rather than copying the
  prior reconciled attribution before aborting the old wait
- re-fence telemetry when an Agent claims a successful context different from
  the API-requested result; rejecting the ACK alone is not sufficient while the
  two sides report divergent durable state
- track successful Set/Clear stream delivery and apply the same reconciliation
  fence when its caller times out before the ACK; uncorrelated late ACKs cannot
  reopen telemetry admission
- distinguish failures before stream Send from errors returned after Send was
  invoked; the latter remain outcome-uncertain and re-fence telemetry because
  the Agent may have durably applied the context before Relay saw the error
- fence command admission with its stream write so a command queued behind the
  replacement swap is delivered only to the newly active binding, never first
  reported aborted and then sent
- recheck Agent registration cancellation at the session-replacement commit
  point, preserving the live session and Registry liveness when a reconnecting
  caller expires behind an in-flight command write
- disable control mutations by default unless control authentication is
  explicitly configured

## Dependency

- Aero-Arc/aero-arc-protos#14 formalizes the wire-compatible authoritative
  empty-context reconciliation discriminator and this branch pins that revision

## Why

Telemetry needs trustworthy flight/intent context on the correct live Agent
session. Commands also need to target that same authenticated, current session;
otherwise a stale connection could receive an operational mutation. Relay
restart must not silently convert an active flight into unattributed telemetry,
and Relay must not become a competing durable owner of API state.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- `go test -tags=integration -timeout=10m ./internal/integration ./internal/registryreporter ./internal/relay`
- targeted context, authentication, session-fencing, command-delivery, and
  listener-lifecycle tests, including concurrent retries, conflicting command
  IDs, mismatched acknowledgements, overlapping set/clear mutations, shared
  caller cancellation before and after stream delivery, and context-preserving
  session replacement, including replacement racing blocked aircraft and
  operation-context writes; restart reconciliation coverage proves telemetry is
  retryable and not routed before API replay, then resumes after acknowledged
  authoritative context; empty-state coverage includes exact retries and
  same-process replacement retention plus recovery from a conflicting command
  ID or retained terminal failure without poisoning the next valid
  reconciliation, including replacement before deferred reservation cleanup;
  same-session replacement coverage blocks the active swap
  through a control write, aborts old-binding waiters, releases the context
  gate, re-fences telemetry after uncertain context delivery, and rejects
  operation and aircraft evidence from the superseded binding while proving the
  global session map stays writable; Registry-backed coverage proves aborts and
  re-fencing happen at successful active-binding commit rather than while a
  replacement is only pending publication; canceled-registration coverage
  proves an expired replacement cannot retire the session the Agent still owns;
  delivered-timeout coverage proves caller cancellation re-fences telemetry and
  an ignored late ACK cannot reopen it; send-error coverage proves a mutation
  that reached the stream remains fenced even when Send reports an error;
  full-replacement and mismatched-success coverage prove both uncertainty paths
  remain gated until API replay;
  retention-cap coverage proves the oldest exact aircraft and context retries
  remain idempotent even when their outcome maps are full
- live mTLS context application acknowledged by the SITL Agent
- authenticated ARM/DISARM responses correlated through Relay and Agent
- end-to-end telemetry tagged with aircraft, flight, intent, intent version,
  WAL generation, sequence, and frame identity

All commits include a DCO sign-off.
