### PR TITLE
Route durable mission deployments to bound Agent sessions

### DIFF
--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -149,7 +149,8 @@ type is rejected. A new deliberate vehicle action therefore requires a new
 command ID.
 
 `DeployMission` is the durable deployment path for a bounded canonical mission
-plan. Before delivery, Relay recomputes the plan's deterministic SHA-256 digest,
+plan. Before delivery, Relay recomputes the plan's schema-one canonical-byte
+SHA-256 digest,
 rejects unsupported schema/frame/command values and more than 200 items, and
 requires every immutable binding field. Schema-1 plans use only
 `MAV_FRAME_GLOBAL` (0) and `NAV_WAYPOINT` (16), `NAV_LAND` (21), or
@@ -160,7 +161,9 @@ autopilot execution/readback state cannot change the digest; and carry exact
 The canonical form also requires positive-zero params 1–3, positive-zero param
 4 for waypoint/takeoff, exactly `+1` param 4 for `NAV_LAND`, and finite float32
 altitude that round-trips through ArduPilot's signed-centimeter storage. The
-binding's operator and aircraft must match
+digest bytes use the `aeroarc-mission-plan-v1\0` domain prefix, a big-endian
+item count, and fixed-width big-endian item fields; protobuf wire bytes are not
+part of the digest. The binding's operator and aircraft must match
 `telemetry.agent_mappings` for the routed Agent. Its aircraft, flight, intent,
 and intent version must also exactly match the session's
 reconciled operation context; a legacy context without `aircraft_id` or an

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -42,16 +42,18 @@ Registering the same authenticated agent ID again replaces the map entry with a
 new `DroneSession` and a new session ID. The old stream handler can still be
 running, but it no longer owns the active registered session. Without Agent
 authentication, replacement still aborts the old session and pending commands,
-but the new session inherits no operation context and remains unreconciled for
-API replay.
+but it does not inherit operation context. When context control is enabled, the
+new session remains unreconciled for API replay; when control is disabled, the
+Relay continues its context-free behavior.
 
 When an authenticated admitted stream disconnects, Relay removes its live
 session but retains the last API-authoritative operation context in a
 process-local reconnect cache. The next authenticated registration for that
 exact agent ID inherits the cached context before its new session is published.
 When Agent authentication is not configured, Relay neither retains nor restores
-reconnect context; every new session remains unreconciled until the API replays
-its durable authority.
+reconnect context. With context control enabled, every new session remains
+unreconciled until the API replays its durable authority; control-disabled
+sessions do not require that replay.
 If a delivered Set or Clear lost its acknowledgement during disconnect, the
 cached state is marked unreconciled instead, and telemetry remains retryable
 until the API replays its durable authority. Entries expire after five minutes,
@@ -341,13 +343,16 @@ If the agent registers again instead of only replacing its stream, the new map
 entry has a different `DroneSession` pointer and session ID. The old handler's
 cleanup is rejected by the session pointer check. Frames from the old registration
 also fail the active-session-identity validation and receive their error ACK on
-the old stream. Relay atomically copies the last API-authoritative acknowledged
-operation context into the replacement before publishing it, so reconnecting
-telemetry keeps its flight and intent attribution. Delayed operation-command
-ACKs received by the old handler remain bound to the old session and cannot
-update the replacement session's context or pending commands.
-If no prior in-process session exists, Relay does not infer an empty context:
-telemetry remains retryable until the API explicitly replays Set or Clear.
+the old stream. For an authenticated Agent, Relay atomically copies the last
+API-authoritative acknowledged operation context into the replacement before
+publishing it, so reconnecting telemetry keeps its flight and intent
+attribution. Without Agent authentication, Relay copies no context; when context
+control is enabled, replacement telemetry remains retryable until the API
+explicitly replays Set or Clear. Delayed operation-command ACKs received by the
+old handler remain bound to the old session and cannot update the replacement
+session's context or pending commands. If no prior in-process session exists,
+control-enabled Relay does not infer an empty context and applies the same API
+replay fence.
 
 ## 6. Disconnect and Cleanup
 

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -151,8 +151,11 @@ command ID.
 `DeployMission` is the durable deployment path for a bounded canonical mission
 plan. Before delivery, Relay recomputes the plan's deterministic SHA-256 digest,
 rejects unsupported schema/frame/command values and more than 200 items, and
-requires every immutable binding field. The binding's operator and aircraft
-must match `telemetry.agent_mappings` for the routed Agent. Its aircraft,
+requires every immutable binding field. Schema-1 plans exclude autopilot HOME
+and export metadata, and every canonical item's reserved `current` flag must be
+false so autopilot execution/readback state cannot change the digest. The
+binding's operator and aircraft must match `telemetry.agent_mappings` for the
+routed Agent. Its aircraft,
 flight, intent, and intent version must also exactly match the session's
 reconciled operation context; a legacy context without `aircraft_id` or an
 unreconciled session cannot receive a mission. The mission route

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -204,11 +204,14 @@ the first caller's deadline. The last waiter ending cancels pre-effect admission
 retryable outcome may be redispatched only while the session still has the exact
 mission binding; otherwise Relay fails the active-context precondition without
 writing to the Agent stream. Successful Agent evidence is accepted only when its
-full binding matches, its onboard digest matches the requested digest, and its
-uploaded item count matches the canonical plan. The Relay wait is capped at two
-minutes across any required serialized command-gate admission and result
-correlation, even when the caller does not provide a shorter deadline. New
-commands must use a validity window no longer than five minutes.
+full binding and onboard digest match the requested mission. `APPLIED` proves a
+new upload and must report the canonical plan's exact item count;
+`ALREADY_APPLIED` proves readback-only recovery and must report zero newly
+uploaded items. A nonzero `ALREADY_APPLIED` count is rejected as ambiguous. The
+Relay wait is capped at two minutes across any required serialized command-gate
+admission and result correlation, even when the caller does not provide a
+shorter deadline. New commands must use a validity window no longer than five
+minutes.
 
 Relay deliberately forwards an expired exact command to the current Agent. Its
 in-memory command retention cannot distinguish a first expired request from

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -56,9 +56,10 @@ If a delivered Set or Clear lost its acknowledgement during disconnect, the
 cached state is marked unreconciled instead, and telemetry remains retryable
 until the API replays its durable authority. Entries expire after five minutes,
 the cache is hard-capped at 1,024 agents with deterministic oldest-entry
-eviction, and a fully empty reconciled context is not retained. The cache does
-not survive Relay restart, so the fresh-process reconciliation rule above
-remains the fail-closed backstop.
+eviction. A reconciled empty context is retained as an authoritative presence
+marker so an authenticated reconnect preserves the API's acknowledged decision
+that no operation is active. The cache does not survive Relay restart, so the
+fresh-process reconciliation rule above remains the fail-closed backstop.
 
 ## 2. Attaching a Telemetry Stream
 

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -154,9 +154,11 @@ rejects unsupported schema/frame/command values and more than 200 items, and
 requires every immutable binding field. Schema-1 plans exclude autopilot HOME
 and export metadata, and every canonical item's reserved `current` flag must be
 false so autopilot execution/readback state cannot change the digest. The
-binding's operator and aircraft must match `telemetry.agent_mappings` for the
-routed Agent. Its aircraft,
-flight, intent, and intent version must also exactly match the session's
+canonical form also requires positive-zero params 1–3, positive-zero param 4
+for waypoint/takeoff, and exactly `+1` param 4 for `NAV_LAND`, matching stable
+ArduPilot readback. The binding's operator and aircraft must match
+`telemetry.agent_mappings` for the routed Agent. Its aircraft, flight, intent,
+and intent version must also exactly match the session's
 reconciled operation context; a legacy context without `aircraft_id` or an
 unreconciled session cannot receive a mission. The mission route
 does not replace or reshape the operational intent.

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -186,7 +186,9 @@ for the gate; concurrent callers attach to that reservation, so even another
 immediate retryable Agent result produces only one stream write. A
 generation-scoped admission task takes the gate while any waiter remains, so
 one caller's shorter deadline detaches only that caller and cannot cancel other
-coalesced waiters. The last waiter ending cancels pre-effect admission. A
+coalesced waiters. Every caller retains its own capped admission window, so a
+later exact retry contributes its full remaining window rather than inheriting
+the first caller's deadline. The last waiter ending cancels pre-effect admission. A
 retryable outcome may be redispatched only while the session still has the exact
 mission binding; otherwise Relay fails the active-context precondition without
 writing to the Agent stream. Successful Agent evidence is accepted only when its

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -198,13 +198,16 @@ for the gate; concurrent callers attach to that reservation, so even another
 immediate retryable Agent result produces only one stream write. A
 generation-scoped admission task takes the gate while any waiter remains, so
 one caller's shorter deadline detaches only that caller and cannot cancel other
-coalesced waiters. Every caller retains its own capped admission window, so a
-later exact retry contributes its full remaining window rather than inheriting
-the first caller's deadline. The last waiter ending cancels pre-effect admission. A
-retryable outcome may be redispatched only while the session still has the exact
-mission binding; otherwise Relay fails the active-context precondition without
-writing to the Agent stream. Successful Agent evidence is accepted only when its
-full binding and onboard digest match the requested mission. `APPLIED` proves a
+coalesced waiters. Relay ignores delayed results from the preceding delivery
+while the next generation is still reserved; only an admitted generation may
+consume Agent evidence. Every caller retains its own capped admission window,
+so a later exact retry contributes its full remaining window rather than
+inheriting the first caller's deadline. The last waiter ending cancels
+pre-effect admission. A retryable outcome may be redispatched only while the
+session still has the exact mission binding; otherwise Relay fails the
+active-context precondition without writing to the Agent stream. Successful
+Agent evidence is accepted only when its full binding and onboard digest match
+the requested mission. `APPLIED` proves a
 new upload and must report the canonical plan's exact item count;
 `ALREADY_APPLIED` proves readback-only recovery and must report zero newly
 uploaded items. A nonzero `ALREADY_APPLIED` count is rejected as ambiguous. The

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -181,8 +181,9 @@ the exact mission binding; otherwise Relay fails the active-context precondition
 without writing to the Agent stream. Successful Agent evidence is accepted only
 when its full binding matches, its onboard digest matches the requested digest,
 and its uploaded item count matches the canonical plan. The Relay wait is capped
-at two minutes even when the caller does not provide a shorter deadline, and new
-commands must use a validity window no longer than five minutes.
+at two minutes across serialized command-gate admission and result correlation,
+even when the caller does not provide a shorter deadline. New commands must use
+a validity window no longer than five minutes.
 
 Relay deliberately forwards an expired exact command to the current Agent. Its
 in-memory command retention cannot distinguish a first expired request from

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -44,12 +44,15 @@ but it no longer owns the active registered session.
 
 When an admitted stream disconnects, Relay removes its live session but retains
 the last API-authoritative operation context in a process-local reconnect cache.
-The next successfully authenticated registration for that exact agent ID
-inherits the cached context before its new session is published. If a delivered
-Set or Clear lost its acknowledgement during disconnect, the cached state is
-marked unreconciled instead, and telemetry remains retryable until the API
-replays its durable authority. This cache does not survive Relay restart, so the
-fresh-process reconciliation rule above remains the fail-closed backstop.
+The next registration for that exact agent ID that passes any configured
+authentication inherits the cached context before its new session is published.
+If a delivered Set or Clear lost its acknowledgement during disconnect, the
+cached state is marked unreconciled instead, and telemetry remains retryable
+until the API replays its durable authority. Entries expire after five minutes,
+the cache is hard-capped at 1,024 agents with deterministic oldest-entry
+eviction, and a fully empty reconciled context is not retained. The cache does
+not survive Relay restart, so the fresh-process reconciliation rule above
+remains the fail-closed backstop.
 
 ## 2. Attaching a Telemetry Stream
 
@@ -348,8 +351,8 @@ The relay removes the live session only when both conditions hold. Consequently:
 Once the active session is removed, the agent must register again before opening
 another telemetry stream. A successful same-agent registration consumes the
 cached snapshot and receives a fresh session ID. Cache loss on Relay restart, or
-an outcome-uncertain operation-context mutation at disconnect, keeps telemetry
-gated until explicit API reconciliation.
+after expiry or capacity eviction, and an outcome-uncertain operation-context
+mutation at disconnect keep telemetry gated until explicit API reconciliation.
 
 ## Synchronization and Ownership
 

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -151,12 +151,16 @@ command ID.
 `DeployMission` is the durable deployment path for a bounded canonical mission
 plan. Before delivery, Relay recomputes the plan's deterministic SHA-256 digest,
 rejects unsupported schema/frame/command values and more than 200 items, and
-requires every immutable binding field. Schema-1 plans exclude autopilot HOME
-and export metadata, and every canonical item's reserved `current` flag must be
-false so autopilot execution/readback state cannot change the digest. The
-canonical form also requires positive-zero params 1–3, positive-zero param 4
-for waypoint/takeoff, and exactly `+1` param 4 for `NAV_LAND`, matching stable
-ArduPilot readback. The binding's operator and aircraft must match
+requires every immutable binding field. Schema-1 plans use only
+`MAV_FRAME_GLOBAL` (0) and `NAV_WAYPOINT` (16), `NAV_LAND` (21), or
+`NAV_TAKEOFF` (22). They exclude autopilot HOME and export metadata; require
+contiguous sequences, `autocontinue=true`, and the reserved `current=false` so
+autopilot execution/readback state cannot change the digest; and carry exact
+`MISSION_ITEM_INT` E7 coordinates without a legacy float-coordinate constraint.
+The canonical form also requires positive-zero params 1–3, positive-zero param
+4 for waypoint/takeoff, exactly `+1` param 4 for `NAV_LAND`, and finite float32
+altitude that round-trips through ArduPilot's signed-centimeter storage. The
+binding's operator and aircraft must match
 `telemetry.agent_mappings` for the routed Agent. Its aircraft, flight, intent,
 and intent version must also exactly match the session's
 reconciled operation context; a legacy context without `aircraft_id` or an
@@ -171,6 +175,17 @@ digest matches the requested digest, and its uploaded item count matches the
 canonical plan. The Relay wait is capped at two minutes even when the caller
 does not provide a shorter deadline, and new commands must use a validity
 window no longer than five minutes.
+
+Relay deliberately forwards an expired exact command to the current Agent. Its
+in-memory command retention cannot distinguish a first expired request from
+reconciliation after a Relay restart. The Agent's durable journal is therefore
+the final effect fence: it may use an expired command only to read back an
+already uncertain effect under the same command ID and payload, and must reject
+a first expired effect before touching MAVLink. A matching readback may produce
+`ALREADY_APPLIED`; a complete mismatch must be terminal and must not authorize a
+replacement upload after expiry. Roll out an Agent implementing both durable
+expiry fences before enabling this Relay/API path. This forwarding does not
+extend the API reconciliation deadline.
 
 Unlike a telemetry ACK, an operation-context command is not a response to a
 message received on a particular stream. It targets the current admitted Agent

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -174,16 +174,22 @@ does not replace or reshape the operational intent.
 Mission command fingerprints cover the entire command, binding, and plan.
 Concurrent exact retries share one delivery and terminal outcomes are retained;
 reusing the command ID with another byte-level payload or retained command kind
-is rejected. An exact retained terminal outcome remains replayable after the
-session operation context advances because replay cannot cause another vehicle
-effect. A retryable outcome may be redispatched only while the session still has
-the exact mission binding; otherwise Relay fails the active-context precondition
-without writing to the Agent stream. Successful Agent evidence is accepted only
-when its full binding matches, its onboard digest matches the requested digest,
-and its uploaded item count matches the canonical plan. The Relay wait is capped
-at two minutes across serialized command-gate admission and result correlation,
-even when the caller does not provide a shorter deadline. New commands must use
-a validity window no longer than five minutes.
+is rejected. Exact retries attach to an already-running deployment or replay a
+retained terminal outcome before contending for the serialized cross-operation
+gate. They therefore remain recoverable while another operation is waiting for
+Agent evidence, and one caller ending its wait cannot turn a coalesced in-flight
+deployment into an unnecessary uncertain redelivery. An exact retained terminal
+outcome remains replayable after the session operation context advances because
+replay cannot cause another vehicle effect. Only a request that may initiate a
+new stream delivery takes the gate. A retryable outcome may be redispatched only
+while the session still has the exact mission binding; otherwise Relay fails the
+active-context precondition without writing to the Agent stream. Successful
+Agent evidence is accepted only when its full binding matches, its onboard
+digest matches the requested digest, and its uploaded item count matches the
+canonical plan. The Relay wait is capped at two minutes across any required
+serialized command-gate admission and result correlation, even when the caller
+does not provide a shorter deadline. New commands must use a validity window no
+longer than five minutes.
 
 Relay deliberately forwards an expired exact command to the current Agent. Its
 in-memory command retention cannot distinguish a first expired request from

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -38,9 +38,12 @@ flight and intent. This is required after Relay restart; Registry discovery and
 stream admission provide the API-to-Relay replay path. Relays with context
 control disabled preserve their context-free telemetry behavior.
 
-Registering the same agent ID again replaces the map entry with a new
-`DroneSession` and a new session ID. The old stream handler can still be running,
-but it no longer owns the active registered session.
+Registering the same authenticated agent ID again replaces the map entry with a
+new `DroneSession` and a new session ID. The old stream handler can still be
+running, but it no longer owns the active registered session. Without Agent
+authentication, replacement still aborts the old session and pending commands,
+but the new session inherits no operation context and remains unreconciled for
+API replay.
 
 When an authenticated admitted stream disconnects, Relay removes its live
 session but retains the last API-authoritative operation context in a
@@ -203,9 +206,15 @@ generation-scoped admission task takes the gate while any waiter remains, so
 one caller's shorter deadline detaches only that caller and cannot cancel other
 coalesced waiters. Relay ignores delayed results from the preceding delivery
 while the next generation is reserved or waiting to begin its stream write;
-Relay keeps the fence closed through the serialized Send call and admits Agent
-evidence only after that delivery attempt returns. Every caller retains its own
-capped admission window,
+immediately before Send, Relay atomically commits that exact immutable command
+to effect start and opens command-level result admission. After this point Send
+is invoked unconditionally, even if correlated evidence completes the shared
+state or the last caller ends its wait. Evidence before commit is ignored;
+evidence after commit is authoritative for the exact command ID and payload.
+The protocol does not claim per-attempt provenance: a delayed retryable result
+can cause another exact idempotent delivery, while delayed terminal evidence
+proves the command-level effect and cannot suppress the already-committed Send.
+Every caller retains its own capped admission window,
 so a later exact retry contributes its full remaining window rather than
 inheriting the first caller's deadline. The last waiter ending cancels
 pre-effect admission. A retryable outcome may be redispatched only while the

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -350,9 +350,9 @@ attribution. Without Agent authentication, Relay copies no context; when context
 control is enabled, replacement telemetry remains retryable until the API
 explicitly replays Set or Clear. Delayed operation-command ACKs received by the
 old handler remain bound to the old session and cannot update the replacement
-session's context or pending commands. If no prior in-process session exists,
-control-enabled Relay does not infer an empty context and applies the same API
-replay fence.
+session's context or pending commands. For an authenticated Agent, if neither a
+prior live session nor a retained reconnect snapshot exists, control-enabled
+Relay does not infer an empty context and applies the same API replay fence.
 
 ## 6. Disconnect and Cleanup
 

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -180,16 +180,19 @@ gate. They therefore remain recoverable while another operation is waiting for
 Agent evidence, and one caller ending its wait cannot turn a coalesced in-flight
 deployment into an unnecessary uncertain redelivery. An exact retained terminal
 outcome remains replayable after the session operation context advances because
-replay cannot cause another vehicle effect. Only a request that may initiate a
-new stream delivery takes the gate. A retryable outcome may be redispatched only
-while the session still has the exact mission binding; otherwise Relay fails the
-active-context precondition without writing to the Agent stream. Successful
-Agent evidence is accepted only when its full binding matches, its onboard
-digest matches the requested digest, and its uploaded item count matches the
-canonical plan. The Relay wait is capped at two minutes across any required
-serialized command-gate admission and result correlation, even when the caller
-does not provide a shorter deadline. New commands must use a validity window no
-longer than five minutes.
+replay cannot cause another vehicle effect. For a retained retryable outcome,
+the first exact retry reserves one pending delivery generation before waiting
+for the gate; concurrent callers attach to that reservation, so even another
+immediate retryable Agent result produces only one stream write. Only the owner
+of a generation that may initiate a new stream delivery takes the gate. A
+retryable outcome may be redispatched only while the session still has the exact
+mission binding; otherwise Relay fails the active-context precondition without
+writing to the Agent stream. Successful Agent evidence is accepted only when its
+full binding matches, its onboard digest matches the requested digest, and its
+uploaded item count matches the canonical plan. The Relay wait is capped at two
+minutes across any required serialized command-gate admission and result
+correlation, even when the caller does not provide a shorter deadline. New
+commands must use a validity window no longer than five minutes.
 
 Relay deliberately forwards an expired exact command to the current Agent. Its
 in-memory command retention cannot distinguish a first expired request from

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -42,10 +42,13 @@ Registering the same agent ID again replaces the map entry with a new
 `DroneSession` and a new session ID. The old stream handler can still be running,
 but it no longer owns the active registered session.
 
-When an admitted stream disconnects, Relay removes its live session but retains
-the last API-authoritative operation context in a process-local reconnect cache.
-The next registration for that exact agent ID that passes any configured
-authentication inherits the cached context before its new session is published.
+When an authenticated admitted stream disconnects, Relay removes its live
+session but retains the last API-authoritative operation context in a
+process-local reconnect cache. The next authenticated registration for that
+exact agent ID inherits the cached context before its new session is published.
+When Agent authentication is not configured, Relay neither retains nor restores
+reconnect context; every new session remains unreconciled until the API replays
+its durable authority.
 If a delivered Set or Clear lost its acknowledgement during disconnect, the
 cached state is marked unreconciled instead, and telemetry remains retryable
 until the API replays its durable authority. Entries expire after five minutes,
@@ -199,8 +202,10 @@ immediate retryable Agent result produces only one stream write. A
 generation-scoped admission task takes the gate while any waiter remains, so
 one caller's shorter deadline detaches only that caller and cannot cancel other
 coalesced waiters. Relay ignores delayed results from the preceding delivery
-while the next generation is still reserved; only an admitted generation may
-consume Agent evidence. Every caller retains its own capped admission window,
+while the next generation is reserved or waiting to begin its stream write;
+Relay keeps the fence closed through the serialized Send call and admits Agent
+evidence only after that delivery attempt returns. Every caller retains its own
+capped admission window,
 so a later exact retry contributes its full remaining window rather than
 inheriting the first caller's deadline. The last waiter ending cancels
 pre-effect admission. A retryable outcome may be redispatched only while the

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -42,6 +42,15 @@ Registering the same agent ID again replaces the map entry with a new
 `DroneSession` and a new session ID. The old stream handler can still be running,
 but it no longer owns the active registered session.
 
+When an admitted stream disconnects, Relay removes its live session but retains
+the last API-authoritative operation context in a process-local reconnect cache.
+The next successfully authenticated registration for that exact agent ID
+inherits the cached context before its new session is published. If a delivered
+Set or Clear lost its acknowledgement during disconnect, the cached state is
+marked unreconciled instead, and telemetry remains retryable until the API
+replays its durable authority. This cache does not survive Relay restart, so the
+fresh-process reconciliation rule above remains the fail-closed backstop.
+
 ## 2. Attaching a Telemetry Stream
 
 The agent opens the bidirectional `TelemetryStream` RPC and supplies its agent
@@ -325,17 +334,22 @@ holding the session map lock:
 1. The map still contains the exact `DroneSession` captured by this handler.
 2. The captured stream generation is still the session's active generation.
 
-The relay removes the session only when both conditions hold. Consequently:
+The relay removes the live session only when both conditions hold. Consequently:
 
 - An old registration cannot delete a newly registered session.
 - An old stream generation cannot delete a replacement stream in the same
   session.
-- Closing the currently active stream removes its session from the active map.
+- Closing the currently active stream removes its session from the active map,
+  stops Registry liveness, aborts pending control waits, and retains only its
+  operation-context snapshot for an authenticated same-Relay reconnect.
 - Any older handler that remains alive after active-session removal rejects new
   telemetry instead of routing it.
 
 Once the active session is removed, the agent must register again before opening
-another telemetry stream.
+another telemetry stream. A successful same-agent registration consumes the
+cached snapshot and receives a fresh session ID. Cache loss on Relay restart, or
+an outcome-uncertain operation-context mutation at disconnect, keeps telemetry
+gated until explicit API reconciliation.
 
 ## Synchronization and Ownership
 

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -160,7 +160,8 @@ autopilot execution/readback state cannot change the digest; and carry exact
 `MISSION_ITEM_INT` E7 coordinates without a legacy float-coordinate constraint.
 The canonical form also requires positive-zero params 1–3, positive-zero param
 4 for waypoint/takeoff, exactly `+1` param 4 for `NAV_LAND`, and finite float32
-altitude that round-trips through ArduPilot's signed-centimeter storage. The
+altitude that round-trips through ArduPilot's float32 multiply, truncating
+signed-centimeter storage, and float32 readback conversion. The
 digest bytes use the `aeroarc-mission-plan-v1\0` domain prefix, a big-endian
 item count, and fixed-width big-endian item fields; protobuf wire bytes are not
 part of the digest. The binding's operator and aircraft must match
@@ -172,16 +173,16 @@ does not replace or reshape the operational intent.
 
 Mission command fingerprints cover the entire command, binding, and plan.
 Concurrent exact retries share one delivery and terminal outcomes are retained;
-reusing the command ID with another byte-level payload is rejected. An exact
-retained terminal outcome remains replayable after the session operation context
-advances because replay cannot cause another vehicle effect. A retryable outcome
-may be redispatched only while the session still has the exact mission binding;
-otherwise Relay fails the active-context precondition without writing to the
-Agent stream. Successful Agent evidence is accepted only when its full binding
-matches, its onboard digest matches the requested digest, and its uploaded item
-count matches the canonical plan. The Relay wait is capped at two minutes even
-when the caller does not provide a shorter deadline, and new commands must use a
-validity window no longer than five minutes.
+reusing the command ID with another byte-level payload or retained command kind
+is rejected. An exact retained terminal outcome remains replayable after the
+session operation context advances because replay cannot cause another vehicle
+effect. A retryable outcome may be redispatched only while the session still has
+the exact mission binding; otherwise Relay fails the active-context precondition
+without writing to the Agent stream. Successful Agent evidence is accepted only
+when its full binding matches, its onboard digest matches the requested digest,
+and its uploaded item count matches the canonical plan. The Relay wait is capped
+at two minutes even when the caller does not provide a shorter deadline, and new
+commands must use a validity window no longer than five minutes.
 
 Relay deliberately forwards an expired exact command to the current Agent. Its
 in-memory command retention cannot distinguish a first expired request from

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -148,6 +148,25 @@ outcome without redelivery; reusing a command ID for another aircraft or command
 type is rejected. A new deliberate vehicle action therefore requires a new
 command ID.
 
+`DeployMission` is the durable deployment path for a bounded canonical mission
+plan. Before delivery, Relay recomputes the plan's deterministic SHA-256 digest,
+rejects unsupported schema/frame/command values and more than 200 items, and
+requires every immutable binding field. The binding's operator and aircraft
+must match `telemetry.agent_mappings` for the routed Agent. Its aircraft,
+flight, intent, and intent version must also exactly match the session's
+reconciled operation context; a legacy context without `aircraft_id` or an
+unreconciled session cannot receive a mission. The mission route
+does not replace or reshape the operational intent.
+
+Mission command fingerprints cover the entire command, binding, and plan.
+Concurrent exact retries share one delivery and terminal outcomes are retained;
+reusing the command ID with another byte-level payload is rejected. Successful
+Agent evidence is accepted only when its full binding matches, its onboard
+digest matches the requested digest, and its uploaded item count matches the
+canonical plan. The Relay wait is capped at two minutes even when the caller
+does not provide a shorter deadline, and new commands must use a validity
+window no longer than five minutes.
+
 Unlike a telemetry ACK, an operation-context command is not a response to a
 message received on a particular stream. It targets the current admitted Agent
 session. If that session changes before the ACK is returned, the Relay reports
@@ -180,7 +199,8 @@ commands use the same through-write session fence in their shared delivery task,
 but an individual caller may detach at its deadline and must treat that command
 outcome as uncertain while the started write finishes.
 
-Incoming operation-context ACKs and aircraft-command results are applied only
+Incoming operation-context ACKs, aircraft-command results, and mission results
+are applied only
 when their command ID matches a pending request on the session captured by the
 receiving stream handler and that handler still owns the active stream binding.
 The pending entry is consumed before an applied ACK may update active flight and
@@ -220,11 +240,17 @@ After replacement:
   evidence that is no longer authoritative. An aircraft-command caller must
   treat this result as outcome-uncertain because the old Agent may have passed
   the command to the autopilot before reconnecting.
+- A delivered mission awaiting evidence completes as `OUTCOME_UNKNOWN` when its
+  exact stream is replaced. The retained command is not automatically sent on
+  the replacement binding, and evidence arriving on the superseded binding is
+  ignored. A send that was invoked but returned a transport error has the same
+  uncertainty because the Agent may have accepted it before the failure became
+  visible to Relay.
 - Command admission is fenced with its stream write. A command waiting behind
   the swap is admitted only after the replacement becomes active, so Relay
   cannot abort it and then deliver it on the new binding.
-- Operation-context ACKs and aircraft-command results from the superseded
-  binding are ignored, even though it shares the same session ID.
+- Operation-context ACKs, aircraft-command results, and mission results from the
+  superseded binding are ignored, even though it shares the same session ID.
 - A frame already read, or subsequently read, by the old handler is ACKed on the
   old stream while the shared session remains registered.
 - Sends remain serialized independently on each stream binding.

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -172,12 +172,16 @@ does not replace or reshape the operational intent.
 
 Mission command fingerprints cover the entire command, binding, and plan.
 Concurrent exact retries share one delivery and terminal outcomes are retained;
-reusing the command ID with another byte-level payload is rejected. Successful
-Agent evidence is accepted only when its full binding matches, its onboard
-digest matches the requested digest, and its uploaded item count matches the
-canonical plan. The Relay wait is capped at two minutes even when the caller
-does not provide a shorter deadline, and new commands must use a validity
-window no longer than five minutes.
+reusing the command ID with another byte-level payload is rejected. An exact
+retained terminal outcome remains replayable after the session operation context
+advances because replay cannot cause another vehicle effect. A retryable outcome
+may be redispatched only while the session still has the exact mission binding;
+otherwise Relay fails the active-context precondition without writing to the
+Agent stream. Successful Agent evidence is accepted only when its full binding
+matches, its onboard digest matches the requested digest, and its uploaded item
+count matches the canonical plan. The Relay wait is capped at two minutes even
+when the caller does not provide a shorter deadline, and new commands must use a
+validity window no longer than five minutes.
 
 Relay deliberately forwards an expired exact command to the current Agent. Its
 in-memory command retention cannot distinguish a first expired request from

--- a/docs/agent-telemetry-stream-lifecycle.md
+++ b/docs/agent-telemetry-stream-lifecycle.md
@@ -183,8 +183,10 @@ outcome remains replayable after the session operation context advances because
 replay cannot cause another vehicle effect. For a retained retryable outcome,
 the first exact retry reserves one pending delivery generation before waiting
 for the gate; concurrent callers attach to that reservation, so even another
-immediate retryable Agent result produces only one stream write. Only the owner
-of a generation that may initiate a new stream delivery takes the gate. A
+immediate retryable Agent result produces only one stream write. A
+generation-scoped admission task takes the gate while any waiter remains, so
+one caller's shorter deadline detaches only that caller and cannot cancel other
+coalesced waiters. The last waiter ending cancels pre-effect admission. A
 retryable outcome may be redispatched only while the session still has the exact
 mission binding; otherwise Relay fails the active-context precondition without
 writing to the Agent stream. Successful Agent evidence is accepted only when its

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/bigquery v1.71.0
 	cloud.google.com/go/storage v1.57.0
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.10.0
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260827000821-5dda92b25784
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260830085710-8443743cad08
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/bluenviron/gomavlib/v2 v2.2.0
 	github.com/elastic/go-elasticsearch/v8 v8.15.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/bigquery v1.71.0
 	cloud.google.com/go/storage v1.57.0
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.10.0
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260826232053-d943a2f30cd7
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260826234032-c0923342841c
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/bluenviron/gomavlib/v2 v2.2.0
 	github.com/elastic/go-elasticsearch/v8 v8.15.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/bigquery v1.71.0
 	cloud.google.com/go/storage v1.57.0
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.10.0
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260830124910-d3b38f2bb04e
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260830131659-8cbf71853746
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/bluenviron/gomavlib/v2 v2.2.0
 	github.com/elastic/go-elasticsearch/v8 v8.15.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/bigquery v1.71.0
 	cloud.google.com/go/storage v1.57.0
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.10.0
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260826234032-c0923342841c
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260827000821-5dda92b25784
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/bluenviron/gomavlib/v2 v2.2.0
 	github.com/elastic/go-elasticsearch/v8 v8.15.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/bigquery v1.71.0
 	cloud.google.com/go/storage v1.57.0
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.10.0
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260830085710-8443743cad08
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260830091518-450d4856add7
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/bluenviron/gomavlib/v2 v2.2.0
 	github.com/elastic/go-elasticsearch/v8 v8.15.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/bigquery v1.71.0
 	cloud.google.com/go/storage v1.57.0
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.10.0
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260830091518-450d4856add7
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260830124910-d3b38f2bb04e
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/bluenviron/gomavlib/v2 v2.2.0
 	github.com/elastic/go-elasticsearch/v8 v8.15.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/bigquery v1.71.0
 	cloud.google.com/go/storage v1.57.0
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.10.0
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260830131659-8cbf71853746
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260830133103-af0b6757de47
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/bluenviron/gomavlib/v2 v2.2.0
 	github.com/elastic/go-elasticsearch/v8 v8.15.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/bigquery v1.71.0
 	cloud.google.com/go/storage v1.57.0
 	github.com/InfluxCommunity/influxdb3-go/v2 v2.10.0
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260824210440-607329537377
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260826232053-d943a2f30cd7
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/bluenviron/gomavlib/v2 v2.2.0
 	github.com/elastic/go-elasticsearch/v8 v8.15.0

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMz
 github.com/actgardner/gogen-avro/v10 v10.1.0/go.mod h1:o+ybmVjEa27AAr35FRqU98DJu1fXES56uXniYFv4yDA=
 github.com/actgardner/gogen-avro/v10 v10.2.1/go.mod h1:QUhjeHPchheYmMDni/Nx7VB0RsT/ee8YIgGY/xpEQgQ=
 github.com/actgardner/gogen-avro/v9 v9.1.0/go.mod h1:nyTj6wPqDJoxM3qdnjcLv+EnMDSDFqE0qDpva2QRmKc=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260830091518-450d4856add7 h1:J0uGEy3e+Y09zo5fqJa5+4N7zhLRXNOaulhpbfq1iv8=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260830091518-450d4856add7/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260830124910-d3b38f2bb04e h1:6M76S/IBT+80csF+8i7JVU/EDgdt0stjYcKBiVUEr/A=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260830124910-d3b38f2bb04e/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/go.sum
+++ b/go.sum
@@ -49,12 +49,8 @@ github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMz
 github.com/actgardner/gogen-avro/v10 v10.1.0/go.mod h1:o+ybmVjEa27AAr35FRqU98DJu1fXES56uXniYFv4yDA=
 github.com/actgardner/gogen-avro/v10 v10.2.1/go.mod h1:QUhjeHPchheYmMDni/Nx7VB0RsT/ee8YIgGY/xpEQgQ=
 github.com/actgardner/gogen-avro/v9 v9.1.0/go.mod h1:nyTj6wPqDJoxM3qdnjcLv+EnMDSDFqE0qDpva2QRmKc=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260823010059-9c3641b684b5 h1:+dfJoWW2FXDq8Pi1ydVKFS4mJEXv5LueEl02jFH/T8M=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260823010059-9c3641b684b5/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260824205409-4a2f13cc719f h1:FMaKzCx+K02+vOE8duBns1tZUT5RgS/Ow1/XA+ASbHM=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260824205409-4a2f13cc719f/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260824210440-607329537377 h1:XT1wflfh4eHB+Km5VXilPVXm09RXj8I3GFq4czSBiqc=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260824210440-607329537377/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260826232053-d943a2f30cd7 h1:2am22bDyGuC0rJDzuJZ8J0corU4RSh2k9OgpBT+p4vA=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260826232053-d943a2f30cd7/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/actgardner/gogen-avro/v10 v10.2.1/go.mod h1:QUhjeHPchheYmMDni/Nx7VB0R
 github.com/actgardner/gogen-avro/v9 v9.1.0/go.mod h1:nyTj6wPqDJoxM3qdnjcLv+EnMDSDFqE0qDpva2QRmKc=
 github.com/aero-arc/aero-arc-protos v0.0.0-20260830131659-8cbf71853746 h1:dYQp/OirTRYHI1e9QkswtNs9fi5dS9P5aj4OQQzZTQI=
 github.com/aero-arc/aero-arc-protos v0.0.0-20260830131659-8cbf71853746/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260830133103-af0b6757de47 h1:9iNhYNrpT45YiuiT5NbhIVDFz0RADC+cxi64J7kLFlc=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260830133103-af0b6757de47/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMz
 github.com/actgardner/gogen-avro/v10 v10.1.0/go.mod h1:o+ybmVjEa27AAr35FRqU98DJu1fXES56uXniYFv4yDA=
 github.com/actgardner/gogen-avro/v10 v10.2.1/go.mod h1:QUhjeHPchheYmMDni/Nx7VB0RsT/ee8YIgGY/xpEQgQ=
 github.com/actgardner/gogen-avro/v9 v9.1.0/go.mod h1:nyTj6wPqDJoxM3qdnjcLv+EnMDSDFqE0qDpva2QRmKc=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260827000821-5dda92b25784 h1:UILCuKSKS7X+df8POX4ayWnicO6fqtUlo4eToSINV0w=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260827000821-5dda92b25784/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260830085710-8443743cad08 h1:zUSAvYMntTthMtzsBJ9bIhzP1djYAkjHabxkOPTb6Hs=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260830085710-8443743cad08/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMz
 github.com/actgardner/gogen-avro/v10 v10.1.0/go.mod h1:o+ybmVjEa27AAr35FRqU98DJu1fXES56uXniYFv4yDA=
 github.com/actgardner/gogen-avro/v10 v10.2.1/go.mod h1:QUhjeHPchheYmMDni/Nx7VB0RsT/ee8YIgGY/xpEQgQ=
 github.com/actgardner/gogen-avro/v9 v9.1.0/go.mod h1:nyTj6wPqDJoxM3qdnjcLv+EnMDSDFqE0qDpva2QRmKc=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260830085710-8443743cad08 h1:zUSAvYMntTthMtzsBJ9bIhzP1djYAkjHabxkOPTb6Hs=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260830085710-8443743cad08/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260830091518-450d4856add7 h1:J0uGEy3e+Y09zo5fqJa5+4N7zhLRXNOaulhpbfq1iv8=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260830091518-450d4856add7/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMz
 github.com/actgardner/gogen-avro/v10 v10.1.0/go.mod h1:o+ybmVjEa27AAr35FRqU98DJu1fXES56uXniYFv4yDA=
 github.com/actgardner/gogen-avro/v10 v10.2.1/go.mod h1:QUhjeHPchheYmMDni/Nx7VB0RsT/ee8YIgGY/xpEQgQ=
 github.com/actgardner/gogen-avro/v9 v9.1.0/go.mod h1:nyTj6wPqDJoxM3qdnjcLv+EnMDSDFqE0qDpva2QRmKc=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260826234032-c0923342841c h1:ADOuNVDPh2TJ0eM6ZFQ3EuY1CYulFpEiGsOO2X1Ib+w=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260826234032-c0923342841c/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260827000821-5dda92b25784 h1:UILCuKSKS7X+df8POX4ayWnicO6fqtUlo4eToSINV0w=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260827000821-5dda92b25784/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMz
 github.com/actgardner/gogen-avro/v10 v10.1.0/go.mod h1:o+ybmVjEa27AAr35FRqU98DJu1fXES56uXniYFv4yDA=
 github.com/actgardner/gogen-avro/v10 v10.2.1/go.mod h1:QUhjeHPchheYmMDni/Nx7VB0RsT/ee8YIgGY/xpEQgQ=
 github.com/actgardner/gogen-avro/v9 v9.1.0/go.mod h1:nyTj6wPqDJoxM3qdnjcLv+EnMDSDFqE0qDpva2QRmKc=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260830124910-d3b38f2bb04e h1:6M76S/IBT+80csF+8i7JVU/EDgdt0stjYcKBiVUEr/A=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260830124910-d3b38f2bb04e/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260830131659-8cbf71853746 h1:dYQp/OirTRYHI1e9QkswtNs9fi5dS9P5aj4OQQzZTQI=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260830131659-8cbf71853746/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMz
 github.com/actgardner/gogen-avro/v10 v10.1.0/go.mod h1:o+ybmVjEa27AAr35FRqU98DJu1fXES56uXniYFv4yDA=
 github.com/actgardner/gogen-avro/v10 v10.2.1/go.mod h1:QUhjeHPchheYmMDni/Nx7VB0RsT/ee8YIgGY/xpEQgQ=
 github.com/actgardner/gogen-avro/v9 v9.1.0/go.mod h1:nyTj6wPqDJoxM3qdnjcLv+EnMDSDFqE0qDpva2QRmKc=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260826232053-d943a2f30cd7 h1:2am22bDyGuC0rJDzuJZ8J0corU4RSh2k9OgpBT+p4vA=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260826232053-d943a2f30cd7/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260826234032-c0923342841c h1:ADOuNVDPh2TJ0eM6ZFQ3EuY1CYulFpEiGsOO2X1Ib+w=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260826234032-c0923342841c/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -718,6 +718,7 @@ func expectedContextAfterClear(session *DroneSession, flightID string, authorita
 		return nil
 	}
 	return &agentv1.OperationContext{
+		AircraftId:    session.AircraftID,
 		FlightId:      session.FlightID,
 		IntentId:      session.IntentID,
 		IntentVersion: session.IntentVersion,

--- a/internal/relay/apiserver.go
+++ b/internal/relay/apiserver.go
@@ -33,6 +33,27 @@ const (
 	maxOperationCommands      = 4096
 )
 
+type retainedCommandKind uint8
+
+const (
+	retainedOperationCommand retainedCommandKind = iota
+	retainedAircraftCommand
+	retainedMissionDeployment
+)
+
+func prepareCommandIDAdmissionLocked(session *DroneSession, commandID string, kind retainedCommandKind, now time.Time) error {
+	expireOperationCommandsLocked(session, now)
+	expireAircraftCommandsLocked(session, now)
+	expireMissionDeploymentsLocked(session, now)
+	conflict := kind != retainedOperationCommand && session.operationCommands[commandID] != nil ||
+		kind != retainedAircraftCommand && session.aircraftCommands[commandID] != nil ||
+		kind != retainedMissionDeployment && session.missionDeployments[commandID] != nil
+	if conflict {
+		return status.Error(codes.AlreadyExists, "command ID was already used by a different command kind")
+	}
+	return nil
+}
+
 // ListActiveDrones snapshots the Relay's currently admitted Agent sessions as
 // drone-status records.
 //
@@ -92,8 +113,9 @@ func (s *Relay) GetDroneStatus(_ context.Context, req *pb.GetDroneStatusRequest)
 // Returns:
 //   - response: contains the correlated Agent acknowledgement.
 //   - error: reports disabled or denied control access, invalid input, command
-//     ID reuse with a different payload, missing/replaced sessions, delivery or
-//     context cancellation, and malformed or mismatched acknowledgements.
+//     ID reuse with a different payload or retained command kind,
+//     missing/replaced sessions, delivery or context cancellation, and
+//     malformed or mismatched acknowledgements.
 func (s *Relay) SetOperationContext(ctx context.Context, req *pb.SetOperationContextRequest) (*pb.SetOperationContextResponse, error) {
 	if err := s.authorizeControlMutation(ctx); err != nil {
 		return nil, err
@@ -157,8 +179,9 @@ func (s *Relay) SetOperationContext(ctx context.Context, req *pb.SetOperationCon
 // Returns:
 //   - response: contains the correlated Agent acknowledgement.
 //   - error: reports disabled or denied control access, invalid input, command
-//     ID reuse with a different payload, missing/replaced sessions, delivery or
-//     context cancellation, and malformed or mismatched acknowledgements.
+//     ID reuse with a different payload or retained command kind,
+//     missing/replaced sessions, delivery or context cancellation, and
+//     malformed or mismatched acknowledgements.
 func (s *Relay) ClearOperationContext(ctx context.Context, req *pb.ClearOperationContextRequest) (*pb.ClearOperationContextResponse, error) {
 	if err := s.authorizeControlMutation(ctx); err != nil {
 		return nil, err
@@ -266,8 +289,8 @@ func (s *Relay) sessionIsCurrent(agentID string, expected *DroneSession) bool {
 // Returns:
 //   - response: contains the Agent's correlated autopilot-level result.
 //   - error: reports disabled or denied control access, invalid input, an
-//     offline/replaced Agent session, stream delivery failure, deadline expiry,
-//     or a malformed Agent result.
+//     offline/replaced Agent session, command-ID payload or kind conflict,
+//     stream delivery failure, deadline expiry, or a malformed Agent result.
 func (s *Relay) SendAircraftCommand(ctx context.Context, req *pb.SendAircraftCommandRequest) (*pb.SendAircraftCommandResponse, error) {
 	if err := s.authorizeControlMutation(ctx); err != nil {
 		return nil, err
@@ -378,10 +401,14 @@ func beginAircraftCommandDelivery(session *DroneSession, command *agentv1.Aircra
 	// aborts its uncertain wait, or precedes admission and receives the command.
 	session.controlStreamMu.RLock()
 	session.pendingMu.Lock()
+	if err := prepareCommandIDAdmissionLocked(session, command.GetCommandId(), retainedAircraftCommand, time.Now()); err != nil {
+		session.pendingMu.Unlock()
+		session.controlStreamMu.RUnlock()
+		return nil, false, err
+	}
 	if session.aircraftCommands == nil {
 		session.aircraftCommands = make(map[string]*aircraftCommandState)
 	}
-	expireAircraftCommandsLocked(session, time.Now())
 	if existing := session.aircraftCommands[command.GetCommandId()]; existing != nil {
 		if existing.fingerprint != fingerprint {
 			session.pendingMu.Unlock()
@@ -496,8 +523,9 @@ func cancelAircraftCommandWaiter(session *DroneSession, commandID string, state 
 
 // deliverOperationCommandToSession retains command fingerprints and terminal
 // outcomes for the session, coalesces exact concurrent retries, and rejects a
-// command ID reused with a different payload. The Agent WAL provides the
-// durable cross-session and cross-process idempotency backstop.
+// command ID reused with a different payload or retained command kind. The
+// Agent WAL provides the durable cross-session and cross-process idempotency
+// backstop.
 func beginOperationCommandDelivery(
 	ctx context.Context,
 	session *DroneSession,
@@ -595,7 +623,9 @@ func beginOperationCommand(
 	if session.operationCommands == nil {
 		session.operationCommands = make(map[string]*operationCommandState)
 	}
-	expireOperationCommandsLocked(session, time.Now())
+	if err := prepareCommandIDAdmissionLocked(session, commandID, retainedOperationCommand, time.Now()); err != nil {
+		return nil, false, err
+	}
 	replacingRetryable := false
 	if existing := session.operationCommands[commandID]; existing != nil {
 		if existing.fingerprint != fingerprint {

--- a/internal/relay/apiserver_test.go
+++ b/internal/relay/apiserver_test.go
@@ -95,7 +95,7 @@ func TestSetOperationContextDeliversToCurrentAgent(t *testing.T) {
 		Command: &agentv1.SetOperationContextCommand{
 			CommandId: "command-1",
 			Context: &agentv1.OperationContext{
-				FlightId: "flight-1", IntentId: "intent-1", IntentVersion: 2,
+				AircraftId: "aircraft-1", FlightId: "flight-1", IntentId: "intent-1", IntentVersion: 2,
 			},
 		},
 	}
@@ -116,7 +116,7 @@ func TestSetOperationContextDeliversToCurrentAgent(t *testing.T) {
 		CommandId: "command-1",
 		Status:    agentv1.OperationContextCommandAck_STATUS_APPLIED,
 		ActiveContext: &agentv1.OperationContext{
-			FlightId: "flight-1", IntentId: "intent-1", IntentVersion: 2,
+			AircraftId: "aircraft-1", FlightId: "flight-1", IntentId: "intent-1", IntentVersion: 2,
 		},
 	})
 	got := <-resultChannel
@@ -125,6 +125,9 @@ func TestSetOperationContextDeliversToCurrentAgent(t *testing.T) {
 	}
 	if got.response.GetResult().GetStatus() != agentv1.OperationContextCommandAck_STATUS_APPLIED {
 		t.Fatalf("SetOperationContext() response = %#v", got.response)
+	}
+	if session.AircraftID != "aircraft-1" {
+		t.Fatalf("session aircraft ID = %q, want aircraft-1", session.AircraftID)
 	}
 
 	// An exact retry returns the retained result without delivering twice.

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -158,9 +158,11 @@ func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*ag
 //
 // A successfully published binding owns Registry liveness until cleanup. A
 // replacement aborts old-binding command waiters and fences uncertain operation
-// context before it can admit telemetry. Operation-context ACKs and aircraft
-// results are handled ahead of telemetry routing and remain bound to the stream
-// that received them. Cleanup removes only this binding, so a superseding stream
+// context before it can admit telemetry. Operation-context ACKs,
+// aircraft-command results, and mission-deployment results are handled ahead of
+// telemetry routing. Each result is correlated by command ID only against the
+// pending request on this exact active binding; evidence from a superseded
+// binding is ignored. Cleanup removes only this binding, so a superseding stream
 // remains active.
 func (r *Relay) TelemetryStream(stream agentv1.AgentGateway_TelemetryStreamServer) error {
 	ctx := stream.Context()

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -127,7 +127,10 @@ func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*ag
 			if r.registryReporter != nil {
 				r.registryReporter.StopAgent(agentID)
 			}
+		} else if retained, ok := r.disconnectedOperationContexts[agentID]; ok {
+			retained.restoreInto(newSession)
 		}
+		delete(r.disconnectedOperationContexts, agentID)
 		r.grpcSessions[agentID] = newSession
 		r.sessionsMu.Unlock()
 		if previous != nil {
@@ -593,35 +596,43 @@ func (session *DroneSession) abortPendingCommandsForStreamReplacement() {
 }
 
 func (session *DroneSession) restoreContextIntoAndAbortPending(replacement *DroneSession) {
+	snapshot := session.snapshotContextAndAbortPending()
+	snapshot.restoreInto(replacement)
+}
+
+func (session *DroneSession) snapshotContextAndAbortPending() operationContextSnapshot {
 	session.pendingMu.Lock()
 	defer session.pendingMu.Unlock()
 	session.sessionMu.RLock()
-	replacement.AircraftID = session.AircraftID
-	replacement.FlightID = session.FlightID
-	replacement.IntentID = session.IntentID
-	replacement.IntentVersion = session.IntentVersion
-	replacement.operationContextUnreconciled = session.operationContextUnreconciled
-	replacement.emptyContextCommandID = session.emptyContextCommandID
+	snapshot := operationContextSnapshot{
+		aircraftID:            session.AircraftID,
+		flightID:              session.FlightID,
+		intentID:              session.IntentID,
+		intentVersion:         session.IntentVersion,
+		unreconciled:          session.operationContextUnreconciled,
+		emptyContextCommandID: session.emptyContextCommandID,
+	}
 	for _, state := range session.operationCommands {
 		if !state.completed && state.delivered {
 			// The retiring Agent may have applied this mutation even though Relay
 			// never received its ACK. The replacement must not inherit the prior
 			// attribution as if the outcome were known.
-			replacement.operationContextUnreconciled = true
+			snapshot.unreconciled = true
 			break
 		}
 	}
-	if replacement.operationContextUnreconciled && replacement.emptyContextCommandID != "" {
-		state := session.operationCommands[replacement.emptyContextCommandID]
+	if snapshot.unreconciled && snapshot.emptyContextCommandID != "" {
+		state := session.operationCommands[snapshot.emptyContextCommandID]
 		if state == nil || state.completed {
 			// A failed or not-yet-admitted attempt has no in-flight outcome to
 			// protect. Its caller may not have run deferred reservation cleanup yet,
 			// so do not copy that transient reservation into the replacement.
-			replacement.emptyContextCommandID = ""
+			snapshot.emptyContextCommandID = ""
 		}
 	}
 	session.sessionMu.RUnlock()
 	session.abortPendingCommandsLocked(time.Now())
+	return snapshot
 }
 
 func (session *DroneSession) requiresOperationContextReconciliation() bool {

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -34,10 +34,13 @@ import (
 // Register authenticates an Agent identity and publishes a fresh logical
 // session generation for its next TelemetryStream. A first session starts with
 // operation context unreconciled when control mutations are enabled. Replacing
-// an existing generation takes that session's ownership lease, copies its last
-// API-authoritative context and reconciliation state, aborts its pending
-// operation, aircraft, and mission commands, stops its Registry liveness, and
-// atomically installs the replacement before releasing the old session. A
+// an existing generation takes that session's ownership lease, aborts its
+// pending operation, aircraft, and mission commands, stops its Registry
+// liveness, and atomically installs the replacement before releasing the old
+// session. Only when Agent authentication is configured does the replacement
+// inherit the prior generation's last API-authoritative context and
+// reconciliation state. Without Agent authentication, the replacement remains
+// unreconciled and must receive an authoritative context replay from the API. A
 // mission whose stream write may have started completes with retained
 // OUTCOME_UNKNOWN evidence; a mission still reserved before admission completes
 // with Aborted and cannot cause a vehicle effect on the replacement.

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -123,7 +123,10 @@ func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*ag
 		}
 		if previous != nil {
 			previous.retired = true
-			previous.restoreContextIntoAndAbortPending(newSession)
+			snapshot := previous.snapshotContextAndAbortPending()
+			if r.agentAuthenticator != nil {
+				snapshot.restoreInto(newSession)
+			}
 			if r.registryReporter != nil {
 				r.registryReporter.StopAgent(agentID)
 			}
@@ -347,14 +350,17 @@ func sendToSessionThroughWrite(ctx context.Context, session *DroneSession, messa
 // was invoked. Once invoked, either a nil or error result is delivery-uncertain:
 // the peer may have applied the message before Relay observed the outcome.
 func sendToSessionWithWritePolicy(ctx context.Context, session *DroneSession, message *agentv1.RelayStreamMessage, waitThroughWrite bool) (bool, error) {
-	return sendToSessionWithWritePolicyAndFinish(ctx, session, message, waitThroughWrite, nil)
+	return sendToSessionWithWritePolicyAndCommit(ctx, session, message, waitThroughWrite, nil)
 }
 
-// sendToSessionWithWritePolicyAndFinish invokes onFinish inside the serialized
-// stream-write task after Send returns but before releasing the binding lock.
-// Callers use it when result admission must remain closed for the entire
-// pre-Send and in-Send interval.
-func sendToSessionWithWritePolicyAndFinish(ctx context.Context, session *DroneSession, message *agentv1.RelayStreamMessage, waitThroughWrite bool, onFinish func()) (bool, error) {
+// sendToSessionWithWritePolicyAndCommit invokes commit immediately before the
+// active binding's Send method. Once commit succeeds, Send is invoked without a
+// later context or state check, so correlated command-level evidence cannot
+// complete the state and suppress the committed delivery.
+func sendToSessionWithWritePolicyAndCommit(ctx context.Context, session *DroneSession, message *agentv1.RelayStreamMessage, waitThroughWrite bool, commit func() bool) (bool, error) {
+	if !waitThroughWrite && commit != nil {
+		return false, status.Error(codes.Internal, "stream delivery commit requires wait-through-write policy")
+	}
 	for {
 		if err := ctx.Err(); err != nil {
 			return false, status.FromContextError(err).Err()
@@ -381,19 +387,17 @@ func sendToSessionWithWritePolicyAndFinish(ctx context.Context, session *DroneSe
 			return false, status.FromContextError(err).Err()
 		}
 		if waitThroughWrite {
-			err := binding.stream.Send(message)
-			if onFinish != nil {
-				onFinish()
+			if commit != nil && !commit() {
+				binding.sendMu.Unlock()
+				return false, status.Error(codes.Canceled, "stream delivery state ended before effect-start commit")
 			}
+			err := binding.stream.Send(message)
 			binding.sendMu.Unlock()
 			return true, err
 		}
 		sent := make(chan error, 1)
 		go func() {
 			err := binding.stream.Send(message)
-			if onFinish != nil {
-				onFinish()
-			}
 			binding.sendMu.Unlock()
 			sent <- err
 		}()
@@ -609,11 +613,6 @@ func (session *DroneSession) abortPendingCommandsForStreamReplacement() {
 		session.operationContextUnreconciled = true
 		session.sessionMu.Unlock()
 	}
-}
-
-func (session *DroneSession) restoreContextIntoAndAbortPending(replacement *DroneSession) {
-	snapshot := session.snapshotContextAndAbortPending()
-	snapshot.restoreInto(replacement)
 }
 
 func (session *DroneSession) snapshotContextAndAbortPending() operationContextSnapshot {

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -39,9 +39,10 @@ import (
 // liveness, and atomically installs the replacement before releasing the old
 // session. Only when Agent authentication is configured does the replacement
 // inherit the prior generation's last API-authoritative context and
-// reconciliation state. Without Agent authentication, the replacement remains
-// unreconciled and must receive an authoritative context replay from the API. A
-// mission whose stream write may have started completes with retained
+// reconciliation state. When control mutations are enabled without Agent
+// authentication, the replacement remains unreconciled and must receive an
+// authoritative context replay from the API. A mission whose stream write may
+// have started completes with retained
 // OUTCOME_UNKNOWN evidence; a mission still reserved before admission completes
 // with Aborted and cannot cause a vehicle effect on the replacement.
 //

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -530,7 +530,7 @@ func (session *DroneSession) handleMissionDeploymentResult(result *agentv1.Missi
 	session.pendingMu.Lock()
 	defer session.pendingMu.Unlock()
 	state := session.missionDeployments[result.GetCommandId()]
-	if state == nil || state.completed {
+	if state == nil || state.completed || state.reserved {
 		return
 	}
 	if err := validateMissionDeploymentResult(state.command, result); err != nil {

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -127,10 +127,9 @@ func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*ag
 			if r.registryReporter != nil {
 				r.registryReporter.StopAgent(agentID)
 			}
-		} else if retained, ok := r.disconnectedOperationContexts[agentID]; ok {
+		} else if retained, ok := r.takeDisconnectedOperationContextLocked(agentID, time.Now()); ok {
 			retained.restoreInto(newSession)
 		}
-		delete(r.disconnectedOperationContexts, agentID)
 		r.grpcSessions[agentID] = newSession
 		r.sessionsMu.Unlock()
 		if previous != nil {

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -81,6 +81,7 @@ func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*ag
 		operationCommands:            make(map[string]*operationCommandState),
 		operationGate:                makeOperationGate(),
 		aircraftCommands:             make(map[string]*aircraftCommandState),
+		missionDeployments:           make(map[string]*missionDeploymentState),
 	}
 
 	// Retire the previous session before publishing its replacement. Do not hold
@@ -227,6 +228,10 @@ func (r *Relay) TelemetryStream(stream agentv1.AgentGateway_TelemetryStreamServe
 		}
 		if commandResult := message.GetAircraftCommandResult(); commandResult != nil {
 			streamSession.handleAircraftCommandResultFrom(streamBinding, commandResult)
+			continue
+		}
+		if result := message.GetMissionDeploymentResult(); result != nil {
+			streamSession.handleMissionDeploymentResultFrom(streamBinding, result)
 			continue
 		}
 		frame := message.GetTelemetryFrame()
@@ -416,10 +421,12 @@ func (session *DroneSession) handleOperationContextCommandAck(ack *agentv1.Opera
 		} else {
 			session.sessionMu.Lock()
 			if state.expected == nil {
+				session.AircraftID = ""
 				session.FlightID = ""
 				session.IntentID = ""
 				session.IntentVersion = 0
 			} else {
+				session.AircraftID = state.expected.AircraftId
 				session.FlightID = state.expected.FlightId
 				session.IntentID = state.expected.IntentId
 				session.IntentVersion = state.expected.IntentVersion
@@ -494,6 +501,44 @@ func (session *DroneSession) handleAircraftCommandResultFrom(binding *telemetryS
 	session.handleAircraftCommandResult(result)
 }
 
+func (session *DroneSession) handleMissionDeploymentResultFrom(binding *telemetryStreamBinding, result *agentv1.MissionDeploymentResult) {
+	if session == nil || binding == nil || result == nil {
+		return
+	}
+	session.controlStreamMu.RLock()
+	defer session.controlStreamMu.RUnlock()
+	session.sessionMu.RLock()
+	isCurrent := session.stream == binding && !binding.closed
+	session.sessionMu.RUnlock()
+	if !isCurrent {
+		return
+	}
+	session.handleMissionDeploymentResult(result)
+}
+
+func (session *DroneSession) handleMissionDeploymentResult(result *agentv1.MissionDeploymentResult) {
+	if session == nil || result == nil {
+		return
+	}
+	session.pendingMu.Lock()
+	defer session.pendingMu.Unlock()
+	state := session.missionDeployments[result.GetCommandId()]
+	if state == nil || state.completed {
+		return
+	}
+	if err := validateMissionDeploymentResult(state.command, result); err != nil {
+		state.err = err
+	} else {
+		state.result = proto.Clone(result).(*agentv1.MissionDeploymentResult)
+	}
+	state.completed = true
+	state.completedAt = time.Now()
+	if state.deliveryCancel != nil {
+		state.deliveryCancel()
+	}
+	close(state.done)
+}
+
 func (session *DroneSession) abortPendingCommands() {
 	session.pendingMu.Lock()
 	defer session.pendingMu.Unlock()
@@ -528,6 +573,9 @@ func (session *DroneSession) abortPendingCommandsForStreamReplacement() {
 		}
 		close(state.done)
 	}
+	for _, state := range session.missionDeployments {
+		completeMissionDeploymentForLostSessionLocked(state, now, "agent stream replaced after mission delivery")
+	}
 	if contextOutcomeUncertain {
 		// The old stream may have applied Set/Clear before its ACK was lost.
 		// Fence telemetry on the replacement until the API replays its current
@@ -543,6 +591,7 @@ func (session *DroneSession) restoreContextIntoAndAbortPending(replacement *Dron
 	session.pendingMu.Lock()
 	defer session.pendingMu.Unlock()
 	session.sessionMu.RLock()
+	replacement.AircraftID = session.AircraftID
 	replacement.FlightID = session.FlightID
 	replacement.IntentID = session.IntentID
 	replacement.IntentVersion = session.IntentVersion
@@ -617,6 +666,9 @@ func (session *DroneSession) abortPendingCommandsLocked(now time.Time) {
 		state.completedAt = now
 		state.deliveryCancel()
 		close(state.done)
+	}
+	for _, state := range session.missionDeployments {
+		completeMissionDeploymentForLostSessionLocked(state, now, "agent session retired while awaiting mission result")
 	}
 }
 

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -36,8 +36,11 @@ import (
 // operation context unreconciled when control mutations are enabled. Replacing
 // an existing generation takes that session's ownership lease, copies its last
 // API-authoritative context and reconciliation state, aborts its pending
-// operation and aircraft commands, stops its Registry liveness, and atomically
-// installs the replacement before releasing the old session.
+// operation, aircraft, and mission commands, stops its Registry liveness, and
+// atomically installs the replacement before releasing the old session. A
+// mission whose stream write may have started completes with retained
+// OUTCOME_UNKNOWN evidence; a mission still reserved before admission completes
+// with Aborted and cannot cause a vehicle effect on the replacement.
 //
 // Parameters:
 //   - ctx: carries Agent authentication and bounds request processing.

--- a/internal/relay/gatewayserver.go
+++ b/internal/relay/gatewayserver.go
@@ -127,8 +127,11 @@ func (r *Relay) Register(ctx context.Context, req *agentv1.RegisterRequest) (*ag
 			if r.registryReporter != nil {
 				r.registryReporter.StopAgent(agentID)
 			}
-		} else if retained, ok := r.takeDisconnectedOperationContextLocked(agentID, time.Now()); ok {
-			retained.restoreInto(newSession)
+		} else if r.agentAuthenticator != nil {
+			retained, ok := r.takeDisconnectedOperationContextLocked(agentID, time.Now())
+			if ok {
+				retained.restoreInto(newSession)
+			}
 		}
 		r.grpcSessions[agentID] = newSession
 		r.sessionsMu.Unlock()
@@ -344,6 +347,14 @@ func sendToSessionThroughWrite(ctx context.Context, session *DroneSession, messa
 // was invoked. Once invoked, either a nil or error result is delivery-uncertain:
 // the peer may have applied the message before Relay observed the outcome.
 func sendToSessionWithWritePolicy(ctx context.Context, session *DroneSession, message *agentv1.RelayStreamMessage, waitThroughWrite bool) (bool, error) {
+	return sendToSessionWithWritePolicyAndFinish(ctx, session, message, waitThroughWrite, nil)
+}
+
+// sendToSessionWithWritePolicyAndFinish invokes onFinish inside the serialized
+// stream-write task after Send returns but before releasing the binding lock.
+// Callers use it when result admission must remain closed for the entire
+// pre-Send and in-Send interval.
+func sendToSessionWithWritePolicyAndFinish(ctx context.Context, session *DroneSession, message *agentv1.RelayStreamMessage, waitThroughWrite bool, onFinish func()) (bool, error) {
 	for {
 		if err := ctx.Err(); err != nil {
 			return false, status.FromContextError(err).Err()
@@ -371,12 +382,18 @@ func sendToSessionWithWritePolicy(ctx context.Context, session *DroneSession, me
 		}
 		if waitThroughWrite {
 			err := binding.stream.Send(message)
+			if onFinish != nil {
+				onFinish()
+			}
 			binding.sendMu.Unlock()
 			return true, err
 		}
 		sent := make(chan error, 1)
 		go func() {
 			err := binding.stream.Send(message)
+			if onFinish != nil {
+				onFinish()
+			}
 			binding.sendMu.Unlock()
 			sent <- err
 		}()
@@ -530,7 +547,7 @@ func (session *DroneSession) handleMissionDeploymentResult(result *agentv1.Missi
 	session.pendingMu.Lock()
 	defer session.pendingMu.Unlock()
 	state := session.missionDeployments[result.GetCommandId()]
-	if state == nil || state.completed || state.reserved {
+	if state == nil || state.completed || !state.resultAdmissionOpen {
 		return
 	}
 	if err := validateMissionDeploymentResult(state.command, result); err != nil {

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -1927,6 +1927,40 @@ func TestRegisterAfterDisconnectFencesUncertainOperationContext(t *testing.T) {
 	}
 }
 
+func TestRegisterAfterDisconnectRestoresAcknowledgedEmptyOperationContext(t *testing.T) {
+	relay := relayWithSinks(mock.NewMockSink())
+	relay.controlAuthorizer = func(context.Context) error { return nil }
+	relay.agentAuthenticator = func(context.Context, string) error { return nil }
+	relay.grpcSessions = make(map[string]*DroneSession)
+	const agentID = "agent-1"
+	binding := &telemetryStreamBinding{generation: 1}
+	old := &DroneSession{
+		agentID: agentID, SessionID: "old-session", stream: binding, streamGeneration: 1,
+		pending:            make(map[string]chan *agentv1.OperationContextCommandAck),
+		operationCommands:  make(map[string]*operationCommandState),
+		aircraftCommands:   make(map[string]*aircraftCommandState),
+		missionDeployments: make(map[string]*missionDeploymentState),
+	}
+	relay.grpcSessions[agentID] = old
+
+	relay.deleteStream(agentID, old, binding)
+	if _, retained := relay.disconnectedOperationContexts[agentID]; !retained {
+		t.Fatal("authenticated disconnect discarded acknowledged empty operation context")
+	}
+	if _, err := relay.Register(context.Background(), &agentv1.RegisterRequest{AgentId: agentID}); err != nil {
+		t.Fatal(err)
+	}
+	relay.sessionsMu.RLock()
+	replacement := relay.grpcSessions[agentID]
+	relay.sessionsMu.RUnlock()
+	if replacement.requiresOperationContextReconciliation() {
+		t.Fatal("authenticated reconnect lost acknowledged empty operation context")
+	}
+	if got := droneStatus(replacement); got.GetFlightId() != "" || got.GetIntentId() != "" || got.GetIntentVersion() != 0 {
+		t.Fatalf("restored empty context = %#v", got)
+	}
+}
+
 func TestRegisterAfterDisconnectDoesNotRestoreContextWithoutAgentAuthentication(t *testing.T) {
 	relay := relayWithSinks(mock.NewMockSink())
 	relay.controlAuthorizer = func(context.Context) error { return nil }
@@ -1970,19 +2004,14 @@ func TestDisconnectedOperationContextCacheIsBoundedAndExpiring(t *testing.T) {
 		aircraftID: "aircraft-1", flightID: "flight-1", intentID: "intent-1", intentVersion: 7,
 	}
 
-	t.Run("empty reconciled context is omitted", func(t *testing.T) {
+	t.Run("empty reconciled context retains authoritative presence", func(t *testing.T) {
 		relay := &Relay{}
 		relay.retainDisconnectedOperationContextLocked("agent-empty", operationContextSnapshot{}, base)
-		if len(relay.disconnectedOperationContexts) != 0 {
-			t.Fatalf("empty cache size = %d, want 0", len(relay.disconnectedOperationContexts))
-		}
-		relay.retainDisconnectedOperationContextLocked(
-			"agent-unreconciled",
-			operationContextSnapshot{unreconciled: true},
-			base,
-		)
 		if len(relay.disconnectedOperationContexts) != 1 {
-			t.Fatal("empty but unreconciled context was discarded")
+			t.Fatalf("empty cache size = %d, want 1", len(relay.disconnectedOperationContexts))
+		}
+		if restored, ok := relay.takeDisconnectedOperationContextLocked("agent-empty", base); !ok || restored != (operationContextSnapshot{}) {
+			t.Fatalf("empty authoritative context = (%+v, %t), want retained empty snapshot", restored, ok)
 		}
 	})
 

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -873,6 +873,7 @@ type mockTelemetryStream struct {
 	sendStarted chan struct{}
 	sendBlock   chan struct{}
 	sendErr     error
+	sendHook    func(*agentv1.RelayStreamMessage)
 }
 
 func (m *mockTelemetryStream) Context() context.Context {
@@ -894,6 +895,9 @@ func (m *mockTelemetryStream) Recv() (*agentv1.AgentStreamMessage, error) {
 }
 
 func (m *mockTelemetryStream) Send(ack *agentv1.RelayStreamMessage) error {
+	if m.sendHook != nil {
+		m.sendHook(ack)
+	}
 	if m.sendStarted != nil {
 		select {
 		case m.sendStarted <- struct{}{}:
@@ -1613,6 +1617,7 @@ func TestTelemetryStream_RejectsOldStreamAfterActiveReplacementCloses(t *testing
 
 func TestTelemetryStream_CommandACKStaysBoundToReceivingSession(t *testing.T) {
 	relay := relayWithSinks(mock.NewMockSink())
+	relay.agentAuthenticator = func(context.Context, string) error { return nil }
 	relay.grpcSessions = make(map[string]*DroneSession)
 	agentID := "reconnecting-agent"
 	oldPending := make(chan *agentv1.OperationContextCommandAck, 1)
@@ -1738,6 +1743,7 @@ func TestTelemetryStream_CommandACKStaysBoundToReceivingSession(t *testing.T) {
 
 func TestRegisterReplacementRestoresAcknowledgedOperationContext(t *testing.T) {
 	relay := relayWithSinks(mock.NewMockSink())
+	relay.agentAuthenticator = func(context.Context, string) error { return nil }
 	relay.grpcSessions = make(map[string]*DroneSession)
 	old := &DroneSession{
 		agentID: "agent-1", SessionID: "old-session",
@@ -1763,6 +1769,51 @@ func TestRegisterReplacementRestoresAcknowledgedOperationContext(t *testing.T) {
 	}
 	if !replacement.reserveEmptyContextReconciliation("reconcile-empty") || replacement.reserveEmptyContextReconciliation("different-empty") {
 		t.Fatal("same-process replacement lost the retained empty-context command identity")
+	}
+}
+
+func TestRegisterLiveReplacementDoesNotTransferContextWithoutAgentAuthentication(t *testing.T) {
+	relay := relayWithSinks(mock.NewMockSink())
+	relay.controlAuthorizer = func(context.Context) error { return nil }
+	relay.grpcSessions = make(map[string]*DroneSession)
+	state := &operationCommandState{done: make(chan struct{}), delivered: true}
+	old := &DroneSession{
+		agentID: "agent-1", SessionID: "old-session",
+		AircraftID: "aircraft-1", FlightID: "flight-1", IntentID: "intent-1", IntentVersion: 7,
+		pending: map[string]chan *agentv1.OperationContextCommandAck{
+			"pending-command": make(chan *agentv1.OperationContextCommandAck, 1),
+		},
+		operationCommands:  map[string]*operationCommandState{"pending-command": state},
+		aircraftCommands:   make(map[string]*aircraftCommandState),
+		missionDeployments: make(map[string]*missionDeploymentState),
+	}
+	relay.grpcSessions[old.agentID] = old
+
+	if _, err := relay.Register(context.Background(), &agentv1.RegisterRequest{AgentId: old.agentID}); err != nil {
+		t.Fatal(err)
+	}
+	relay.sessionsMu.RLock()
+	replacement := relay.grpcSessions[old.agentID]
+	relay.sessionsMu.RUnlock()
+	if replacement == old || !old.retired {
+		t.Fatal("authentication-free registration did not retire the claimed live session")
+	}
+	select {
+	case <-state.done:
+		if status.Code(state.err) != codes.Aborted {
+			t.Fatalf("retired pending command error = %v, want Aborted", state.err)
+		}
+	default:
+		t.Fatal("authentication-free replacement did not abort old pending commands")
+	}
+	replacement.sessionMu.RLock()
+	aircraftID, flightID, intentID, intentVersion := replacement.AircraftID, replacement.FlightID, replacement.IntentID, replacement.IntentVersion
+	replacement.sessionMu.RUnlock()
+	if aircraftID != "" || flightID != "" || intentID != "" || intentVersion != 0 {
+		t.Fatalf("authentication-free live takeover inherited context: aircraft=%q flight=%q intent=%q v%d", aircraftID, flightID, intentID, intentVersion)
+	}
+	if !replacement.requiresOperationContextReconciliation() {
+		t.Fatal("authentication-free live takeover bypassed API context reconciliation")
 	}
 }
 
@@ -1969,6 +2020,7 @@ func TestDisconnectedOperationContextCacheIsBoundedAndExpiring(t *testing.T) {
 
 func TestRegisterReplacementDropsCompletedEmptyReconciliationReservation(t *testing.T) {
 	relay := relayWithSinks(mock.NewMockSink())
+	relay.agentAuthenticator = func(context.Context, string) error { return nil }
 	relay.grpcSessions = make(map[string]*DroneSession)
 	old := &DroneSession{
 		agentID: "agent-1", SessionID: "old-session",

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -1770,6 +1770,7 @@ func TestRegisterAfterDisconnectRestoresAcknowledgedOperationContext(t *testing.
 	mockSink := mock.NewMockSink()
 	relay := relayWithSinks(mockSink)
 	relay.controlAuthorizer = func(context.Context) error { return nil }
+	relay.agentAuthenticator = func(context.Context, string) error { return nil }
 	relay.grpcSessions = make(map[string]*DroneSession)
 	const agentID = "agent-1"
 	oldBinding := &telemetryStreamBinding{generation: 1}
@@ -1838,6 +1839,7 @@ func TestRegisterAfterDisconnectRestoresAcknowledgedOperationContext(t *testing.
 func TestRegisterAfterDisconnectFencesUncertainOperationContext(t *testing.T) {
 	relay := relayWithSinks(mock.NewMockSink())
 	relay.controlAuthorizer = func(context.Context) error { return nil }
+	relay.agentAuthenticator = func(context.Context, string) error { return nil }
 	relay.grpcSessions = make(map[string]*DroneSession)
 	const agentID = "agent-1"
 	binding := &telemetryStreamBinding{generation: 1}
@@ -1871,6 +1873,43 @@ func TestRegisterAfterDisconnectFencesUncertainOperationContext(t *testing.T) {
 	relay.sessionsMu.RUnlock()
 	if !replacement.requiresOperationContextReconciliation() {
 		t.Fatal("reconnect trusted context after a delivered mutation lost its ACK")
+	}
+}
+
+func TestRegisterAfterDisconnectDoesNotRestoreContextWithoutAgentAuthentication(t *testing.T) {
+	relay := relayWithSinks(mock.NewMockSink())
+	relay.controlAuthorizer = func(context.Context) error { return nil }
+	relay.grpcSessions = make(map[string]*DroneSession)
+	const agentID = "agent-1"
+	binding := &telemetryStreamBinding{generation: 1}
+	old := &DroneSession{
+		agentID: agentID, SessionID: "old-session", stream: binding, streamGeneration: 1,
+		AircraftID: "aircraft-1", FlightID: "flight-1", IntentID: "intent-1", IntentVersion: 7,
+		pending:            make(map[string]chan *agentv1.OperationContextCommandAck),
+		operationCommands:  make(map[string]*operationCommandState),
+		aircraftCommands:   make(map[string]*aircraftCommandState),
+		missionDeployments: make(map[string]*missionDeploymentState),
+	}
+	relay.grpcSessions[agentID] = old
+
+	relay.deleteStream(agentID, old, binding)
+	if len(relay.disconnectedOperationContexts) != 0 {
+		t.Fatal("authentication-free disconnect retained transferable operation context")
+	}
+	if _, err := relay.Register(context.Background(), &agentv1.RegisterRequest{AgentId: agentID}); err != nil {
+		t.Fatal(err)
+	}
+	relay.sessionsMu.RLock()
+	replacement := relay.grpcSessions[agentID]
+	relay.sessionsMu.RUnlock()
+	replacement.sessionMu.RLock()
+	aircraftID, flightID, intentID, intentVersion := replacement.AircraftID, replacement.FlightID, replacement.IntentID, replacement.IntentVersion
+	replacement.sessionMu.RUnlock()
+	if aircraftID != "" || flightID != "" || intentID != "" || intentVersion != 0 {
+		t.Fatalf("authentication-free reconnect inherited context: aircraft=%q flight=%q intent=%q v%d", aircraftID, flightID, intentID, intentVersion)
+	}
+	if !replacement.requiresOperationContextReconciliation() {
+		t.Fatal("authentication-free reconnect bypassed API context reconciliation")
 	}
 }
 

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -1765,6 +1765,114 @@ func TestRegisterReplacementRestoresAcknowledgedOperationContext(t *testing.T) {
 	}
 }
 
+func TestRegisterAfterDisconnectRestoresAcknowledgedOperationContext(t *testing.T) {
+	mockSink := mock.NewMockSink()
+	relay := relayWithSinks(mockSink)
+	relay.controlAuthorizer = func(context.Context) error { return nil }
+	relay.grpcSessions = make(map[string]*DroneSession)
+	const agentID = "agent-1"
+	oldBinding := &telemetryStreamBinding{generation: 1}
+	old := &DroneSession{
+		agentID: agentID, SessionID: "old-session", stream: oldBinding, streamGeneration: 1,
+		AircraftID: "aircraft-1", FlightID: "flight-1", IntentID: "intent-1", IntentVersion: 7,
+		pending:            make(map[string]chan *agentv1.OperationContextCommandAck),
+		operationCommands:  make(map[string]*operationCommandState),
+		aircraftCommands:   make(map[string]*aircraftCommandState),
+		missionDeployments: make(map[string]*missionDeploymentState),
+	}
+	relay.grpcSessions[agentID] = old
+
+	relay.deleteStream(agentID, old, oldBinding)
+	relay.sessionsMu.RLock()
+	_, connected := relay.grpcSessions[agentID]
+	relay.sessionsMu.RUnlock()
+	if connected || !old.retired || !oldBinding.closed {
+		t.Fatalf("disconnect state: connected=%t retired=%t binding_closed=%t", connected, old.retired, oldBinding.closed)
+	}
+
+	registration, err := relay.Register(context.Background(), &agentv1.RegisterRequest{AgentId: agentID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	relay.sessionsMu.RLock()
+	replacement := relay.grpcSessions[agentID]
+	relay.sessionsMu.RUnlock()
+	if replacement == old {
+		t.Fatal("reconnect did not create a fresh session")
+	}
+	replacement.sessionMu.RLock()
+	aircraftID := replacement.AircraftID
+	replacement.sessionMu.RUnlock()
+	if got := droneStatus(replacement); aircraftID != "aircraft-1" || got.GetFlightId() != "flight-1" ||
+		got.GetIntentId() != "intent-1" || got.GetIntentVersion() != 7 {
+		t.Fatalf("reconnected context = aircraft %q, status %#v", aircraftID, got)
+	}
+	if replacement.requiresOperationContextReconciliation() {
+		t.Fatal("authenticated same-Relay reconnect lost reconciled operation context")
+	}
+
+	stream, cancel := newAgentTelemetryStream(agentID, registration.GetSessionId())
+	defer cancel()
+	streamErr := make(chan error, 1)
+	go func() { streamErr <- relay.TelemetryStream(stream) }()
+	stream.recvChan <- telemetryStreamMessage(&agentv1.TelemetryFrame{
+		AgentId: agentID, SessionId: registration.GetSessionId(), Seq: 22415,
+		MsgName: "Heartbeat", WalId: testWALGenerationID, SentAtUnixNs: time.Now().UnixNano(),
+	})
+	message := <-stream.sentAckChan
+	if ack := message.GetTelemetryAck(); ack == nil || ack.GetStatus() != agentv1.TelemetryAck_STATUS_OK {
+		t.Fatalf("replayed telemetry ACK = %#v, want OK", ack)
+	}
+	messages := mockSink.GetMessages()
+	if len(messages) != 1 || messages[0].FlightID != "flight-1" || messages[0].IntentID != "intent-1" ||
+		messages[0].IntentVersion != 7 {
+		t.Fatalf("replayed telemetry attribution = %#v", messages)
+	}
+	close(stream.recvChan)
+	if err := <-streamErr; err != nil {
+		t.Fatalf("TelemetryStream() error = %v", err)
+	}
+}
+
+func TestRegisterAfterDisconnectFencesUncertainOperationContext(t *testing.T) {
+	relay := relayWithSinks(mock.NewMockSink())
+	relay.controlAuthorizer = func(context.Context) error { return nil }
+	relay.grpcSessions = make(map[string]*DroneSession)
+	const agentID = "agent-1"
+	binding := &telemetryStreamBinding{generation: 1}
+	state := &operationCommandState{delivered: true, done: make(chan struct{})}
+	old := &DroneSession{
+		agentID: agentID, SessionID: "old-session", stream: binding, streamGeneration: 1,
+		AircraftID: "aircraft-1", FlightID: "flight-1", IntentID: "intent-1", IntentVersion: 7,
+		pending: map[string]chan *agentv1.OperationContextCommandAck{
+			"context-command": make(chan *agentv1.OperationContextCommandAck, 1),
+		},
+		operationCommands:  map[string]*operationCommandState{"context-command": state},
+		aircraftCommands:   make(map[string]*aircraftCommandState),
+		missionDeployments: make(map[string]*missionDeploymentState),
+	}
+	relay.grpcSessions[agentID] = old
+
+	relay.deleteStream(agentID, old, binding)
+	select {
+	case <-state.done:
+		if status.Code(state.err) != codes.Aborted {
+			t.Fatalf("disconnected operation error = %v, want Aborted", state.err)
+		}
+	default:
+		t.Fatal("disconnect did not abort the pending operation command")
+	}
+	if _, err := relay.Register(context.Background(), &agentv1.RegisterRequest{AgentId: agentID}); err != nil {
+		t.Fatal(err)
+	}
+	relay.sessionsMu.RLock()
+	replacement := relay.grpcSessions[agentID]
+	relay.sessionsMu.RUnlock()
+	if !replacement.requiresOperationContextReconciliation() {
+		t.Fatal("reconnect trusted context after a delivered mutation lost its ACK")
+	}
+}
+
 func TestRegisterReplacementDropsCompletedEmptyReconciliationReservation(t *testing.T) {
 	relay := relayWithSinks(mock.NewMockSink())
 	relay.grpcSessions = make(map[string]*DroneSession)

--- a/internal/relay/gatewayserver_test.go
+++ b/internal/relay/gatewayserver_test.go
@@ -14,6 +14,7 @@ package relay
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -1871,6 +1872,60 @@ func TestRegisterAfterDisconnectFencesUncertainOperationContext(t *testing.T) {
 	if !replacement.requiresOperationContextReconciliation() {
 		t.Fatal("reconnect trusted context after a delivered mutation lost its ACK")
 	}
+}
+
+func TestDisconnectedOperationContextCacheIsBoundedAndExpiring(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	valuable := operationContextSnapshot{
+		aircraftID: "aircraft-1", flightID: "flight-1", intentID: "intent-1", intentVersion: 7,
+	}
+
+	t.Run("empty reconciled context is omitted", func(t *testing.T) {
+		relay := &Relay{}
+		relay.retainDisconnectedOperationContextLocked("agent-empty", operationContextSnapshot{}, base)
+		if len(relay.disconnectedOperationContexts) != 0 {
+			t.Fatalf("empty cache size = %d, want 0", len(relay.disconnectedOperationContexts))
+		}
+		relay.retainDisconnectedOperationContextLocked(
+			"agent-unreconciled",
+			operationContextSnapshot{unreconciled: true},
+			base,
+		)
+		if len(relay.disconnectedOperationContexts) != 1 {
+			t.Fatal("empty but unreconciled context was discarded")
+		}
+	})
+
+	t.Run("entry expires", func(t *testing.T) {
+		relay := &Relay{}
+		relay.retainDisconnectedOperationContextLocked("agent-1", valuable, base)
+		if _, ok := relay.takeDisconnectedOperationContextLocked(
+			"agent-1",
+			base.Add(disconnectedOperationContextTTL),
+		); ok {
+			t.Fatal("entry remained available at its expiration boundary")
+		}
+		if len(relay.disconnectedOperationContexts) != 0 {
+			t.Fatal("expired entry was not removed when consumed")
+		}
+	})
+
+	t.Run("oldest entry is deterministically evicted at capacity", func(t *testing.T) {
+		relay := &Relay{}
+		for i := 0; i < maxDisconnectedOperationContextCount; i++ {
+			relay.retainDisconnectedOperationContextLocked(fmt.Sprintf("agent-%04d", i), valuable, base)
+		}
+		relay.retainDisconnectedOperationContextLocked("agent-extra", valuable, base)
+		if got := len(relay.disconnectedOperationContexts); got != maxDisconnectedOperationContextCount {
+			t.Fatalf("cache size = %d, want %d", got, maxDisconnectedOperationContextCount)
+		}
+		if _, ok := relay.disconnectedOperationContexts["agent-0000"]; ok {
+			t.Fatal("lexically first equally-old entry was not evicted")
+		}
+		if _, ok := relay.disconnectedOperationContexts["agent-extra"]; !ok {
+			t.Fatal("new entry was not retained at capacity")
+		}
+	})
 }
 
 func TestRegisterReplacementDropsCompletedEmptyReconciliationReservation(t *testing.T) {

--- a/internal/relay/mission_deployment.go
+++ b/internal/relay/mission_deployment.go
@@ -1,0 +1,478 @@
+/*
+Copyright 2026 The Aero Arc Relay Authors.
+
+Licensed under the Mozilla Public License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://mozilla.org/MPL/2.0/.
+*/
+
+package relay
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"math"
+	"strings"
+	"time"
+
+	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
+	pb "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
+	"github.com/bluenviron/gomavlib/v2/pkg/dialects/common"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	missionPlanSchemaVersion = 1
+	maxMissionItems          = 200
+	maxMissionDeploymentWait = 2 * time.Minute
+	maxMissionCommandWindow  = 5 * time.Minute
+	maxMissionClockSkew      = 30 * time.Second
+)
+
+func isSupportedMissionFrame(value uint32) bool {
+	switch value {
+	case uint32(common.MAV_FRAME_GLOBAL),
+		uint32(common.MAV_FRAME_GLOBAL_RELATIVE_ALT),
+		uint32(common.MAV_FRAME_GLOBAL_INT),
+		uint32(common.MAV_FRAME_GLOBAL_RELATIVE_ALT_INT),
+		uint32(common.MAV_FRAME_GLOBAL_TERRAIN_ALT),
+		uint32(common.MAV_FRAME_GLOBAL_TERRAIN_ALT_INT):
+		return true
+	default:
+		return false
+	}
+}
+
+func isSupportedMissionCommand(value uint32) bool {
+	switch value {
+	case uint32(common.MAV_CMD_NAV_WAYPOINT),
+		uint32(common.MAV_CMD_NAV_LOITER_UNLIM),
+		uint32(common.MAV_CMD_NAV_LOITER_TURNS),
+		uint32(common.MAV_CMD_NAV_LOITER_TIME),
+		uint32(common.MAV_CMD_NAV_RETURN_TO_LAUNCH),
+		uint32(common.MAV_CMD_NAV_LAND),
+		uint32(common.MAV_CMD_NAV_TAKEOFF):
+		return true
+	default:
+		return false
+	}
+}
+
+// DeployMission authenticates a control-plane caller and delivers one bounded,
+// immutable mission to the exact Agent session active at admission. It refuses
+// delivery unless the configured Agent mapping and reconciled operation context
+// exactly match the mission binding. Exact retries coalesce; a command ID may
+// never identify a different payload.
+func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest) (*pb.DeployMissionResponse, error) {
+	if err := s.authorizeControlMutation(ctx); err != nil {
+		return nil, err
+	}
+	agentID := strings.TrimSpace(req.GetAgentId())
+	command := req.GetCommand()
+	if agentID == "" || command == nil {
+		return nil, status.Error(codes.InvalidArgument, "agent_id and command are required")
+	}
+	if err := validateDeployMissionCommand(command); err != nil {
+		return nil, err
+	}
+	if s.config == nil {
+		return nil, status.Error(codes.FailedPrecondition, "relay Agent mapping is not configured")
+	}
+	mapping, mapped := s.config.Telemetry.AgentMappings[agentID]
+	if !mapped || strings.TrimSpace(mapping.OperatorID) == "" || strings.TrimSpace(mapping.AircraftID) == "" {
+		return nil, status.Error(codes.FailedPrecondition, "relay Agent mapping is not configured")
+	}
+	binding := command.GetBinding()
+	if mapping.OperatorID != binding.GetOperatorId() || mapping.AircraftID != binding.GetAircraftId() {
+		return nil, status.Error(codes.FailedPrecondition, "mission binding does not match configured Agent mapping")
+	}
+
+	s.sessionsMu.RLock()
+	session := s.grpcSessions[agentID]
+	s.sessionsMu.RUnlock()
+	if session == nil {
+		return nil, status.Error(codes.NotFound, "agent is not connected")
+	}
+	release, err := acquireOperationCommandSlot(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	session.ownershipMu.RLock()
+	s.sessionsMu.RLock()
+	current := s.grpcSessions[agentID] == session && !session.retired
+	s.sessionsMu.RUnlock()
+	if !current {
+		session.ownershipMu.RUnlock()
+		return nil, status.Error(codes.NotFound, "agent session is no longer active")
+	}
+	session.sessionMu.RLock()
+	connected := session.stream != nil
+	sessionID := session.SessionID
+	unreconciled := session.operationContextUnreconciled
+	contextMatches := session.AircraftID != "" && session.AircraftID == binding.GetAircraftId() &&
+		session.FlightID == binding.GetFlightId() &&
+		session.IntentID == binding.GetIntentId() && session.IntentVersion == binding.GetIntentVersion()
+	session.sessionMu.RUnlock()
+	if !connected {
+		session.ownershipMu.RUnlock()
+		return nil, status.Error(codes.NotFound, "agent stream is not connected")
+	}
+	if unreconciled {
+		session.ownershipMu.RUnlock()
+		return nil, status.Error(codes.FailedPrecondition, "operation context must be reconciled before mission deployment")
+	}
+	if !contextMatches {
+		session.ownershipMu.RUnlock()
+		return nil, status.Error(codes.FailedPrecondition, "mission binding does not match the reconciled Agent operation context")
+	}
+
+	startedAt := time.Now()
+	state, owner, err := beginMissionDeployment(session, command)
+	if err != nil {
+		session.ownershipMu.RUnlock()
+		relayMissionDeploymentsTotal.WithLabelValues("delivery_failed").Inc()
+		return nil, err
+	}
+	if !owner {
+		session.ownershipMu.RUnlock()
+	} else {
+		slog.LogAttrs(ctx, slog.LevelInfo, "mission_deployment_started",
+			slog.String("command_id", command.GetCommandId()),
+			slog.String("deployment_id", binding.GetDeploymentId()),
+			slog.String("mission_id", binding.GetMissionId()),
+			slog.String("aircraft_id", binding.GetAircraftId()),
+			slog.String("flight_id", binding.GetFlightId()),
+			slog.String("intent_id", binding.GetIntentId()),
+			slog.Uint64("intent_version", uint64(binding.GetIntentVersion())),
+			slog.String("agent_id", agentID),
+			slog.String("session_id", sessionID),
+		)
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, maxMissionDeploymentWait)
+	defer cancel()
+	select {
+	case <-state.done:
+		result, err := takeMissionDeploymentResult(session, state)
+		if err != nil {
+			relayMissionDeploymentsTotal.WithLabelValues("delivery_failed").Inc()
+			return nil, err
+		}
+		if result == nil {
+			relayMissionDeploymentsTotal.WithLabelValues("delivery_failed").Inc()
+			return nil, status.Error(codes.Internal, "agent returned an empty mission deployment result")
+		}
+		duration := time.Since(startedAt)
+		relayMissionDeploymentsTotal.WithLabelValues(result.GetStatus().String()).Inc()
+		relayMissionDeploymentDuration.Observe(duration.Seconds())
+		slog.LogAttrs(ctx, slog.LevelInfo, "mission_deployment_completed",
+			slog.String("command_id", command.GetCommandId()),
+			slog.String("deployment_id", binding.GetDeploymentId()),
+			slog.String("agent_id", agentID),
+			slog.String("session_id", sessionID),
+			slog.String("result", result.GetStatus().String()),
+			slog.Duration("duration", duration),
+		)
+		return &pb.DeployMissionResponse{Result: result}, nil
+	case <-waitCtx.Done():
+		requestErr := status.FromContextError(waitCtx.Err()).Err()
+		cancelMissionDeploymentWaiter(session, command.GetCommandId(), state)
+		relayMissionDeploymentsTotal.WithLabelValues("wait_ended").Inc()
+		return nil, requestErr
+	}
+}
+
+func validateDeployMissionCommand(command *agentv1.DeployMissionCommand) error {
+	if command == nil || command.GetBinding() == nil || command.GetPlan() == nil {
+		return status.Error(codes.InvalidArgument, "command, binding, and plan are required")
+	}
+	if len(command.ProtoReflect().GetUnknown()) != 0 || len(command.GetBinding().ProtoReflect().GetUnknown()) != 0 || len(command.GetPlan().ProtoReflect().GetUnknown()) != 0 {
+		return status.Error(codes.InvalidArgument, "mission command contains unknown fields")
+	}
+	if strings.TrimSpace(command.GetCommandId()) == "" || command.GetCommandId() != strings.TrimSpace(command.GetCommandId()) {
+		return status.Error(codes.InvalidArgument, "command_id must be non-empty and canonical")
+	}
+	b := command.GetBinding()
+	values := []string{b.GetMissionId(), b.GetMissionDigest(), b.GetDeploymentId(), b.GetOperatorId(), b.GetAircraftId(), b.GetFlightId(), b.GetIntentId()}
+	for _, value := range values {
+		if value == "" || value != strings.TrimSpace(value) {
+			return status.Error(codes.InvalidArgument, "all mission binding identifiers must be non-empty and canonical")
+		}
+	}
+	if b.GetMissionVersion() == 0 || b.GetIntentVersion() == 0 {
+		return status.Error(codes.InvalidArgument, "mission_version and intent_version must be positive")
+	}
+	if len(b.GetMissionDigest()) != sha256.Size*2 || strings.ToLower(b.GetMissionDigest()) != b.GetMissionDigest() {
+		return status.Error(codes.InvalidArgument, "mission_digest must be lowercase hexadecimal SHA-256")
+	}
+	if _, err := hex.DecodeString(b.GetMissionDigest()); err != nil {
+		return status.Error(codes.InvalidArgument, "mission_digest must be lowercase hexadecimal SHA-256")
+	}
+	if command.GetIssuedAtUnixMs() <= 0 || command.GetExpiresAtUnixMs() <= command.GetIssuedAtUnixMs() {
+		return status.Error(codes.InvalidArgument, "mission command timestamps are invalid")
+	}
+	plan := command.GetPlan()
+	if plan.GetSchemaVersion() != missionPlanSchemaVersion {
+		return status.Errorf(codes.InvalidArgument, "unsupported mission schema version %d", plan.GetSchemaVersion())
+	}
+	if len(plan.GetItems()) == 0 || len(plan.GetItems()) > maxMissionItems {
+		return status.Errorf(codes.InvalidArgument, "mission plan must contain 1 to %d items", maxMissionItems)
+	}
+	for i, item := range plan.GetItems() {
+		if item == nil || len(item.ProtoReflect().GetUnknown()) != 0 {
+			return status.Errorf(codes.InvalidArgument, "mission item %d is nil or contains unknown fields", i)
+		}
+		if item.GetSequence() != uint32(i) {
+			return status.Errorf(codes.InvalidArgument, "mission item %d has non-contiguous sequence", i)
+		}
+		if !isSupportedMissionFrame(item.GetFrame()) {
+			return status.Errorf(codes.InvalidArgument, "mission item %d uses unsupported frame %d", i, item.GetFrame())
+		}
+		if !isSupportedMissionCommand(item.GetCommand()) {
+			return status.Errorf(codes.InvalidArgument, "mission item %d uses unsupported command %d", i, item.GetCommand())
+		}
+		if item.GetLatitudeE7() < -900000000 || item.GetLatitudeE7() > 900000000 || item.GetLongitudeE7() < -1800000000 || item.GetLongitudeE7() > 1800000000 {
+			return status.Errorf(codes.InvalidArgument, "mission item %d has invalid coordinates", i)
+		}
+		values := []float64{item.GetParam1(), item.GetParam2(), item.GetParam3(), item.GetParam4(), item.GetAltitudeM()}
+		for _, value := range values {
+			if math.IsNaN(value) || math.IsInf(value, 0) {
+				return status.Errorf(codes.InvalidArgument, "mission item %d contains a non-finite value", i)
+			}
+		}
+	}
+	digest, err := missionPlanDigest(plan)
+	if err != nil {
+		return status.Errorf(codes.Internal, "canonicalize mission plan: %v", err)
+	}
+	if digest != b.GetMissionDigest() {
+		return status.Error(codes.InvalidArgument, "mission_digest does not match the canonical plan")
+	}
+	return nil
+}
+
+func beginMissionDeployment(session *DroneSession, command *agentv1.DeployMissionCommand) (*missionDeploymentState, bool, error) {
+	encoded, err := proto.MarshalOptions{Deterministic: true}.Marshal(command)
+	if err != nil {
+		return nil, false, status.Errorf(codes.Internal, "fingerprint mission command: %v", err)
+	}
+	digest := sha256.Sum256(encoded)
+	fingerprint := hex.EncodeToString(digest[:])
+
+	session.controlStreamMu.RLock()
+	session.pendingMu.Lock()
+	if session.missionDeployments == nil {
+		session.missionDeployments = make(map[string]*missionDeploymentState)
+	}
+	expireMissionDeploymentsLocked(session, time.Now())
+	if existing := session.missionDeployments[command.GetCommandId()]; existing != nil {
+		if existing.fingerprint != fingerprint {
+			session.pendingMu.Unlock()
+			session.controlStreamMu.RUnlock()
+			return nil, false, status.Error(codes.AlreadyExists, "mission command ID was already used with a different payload")
+		}
+		existing.waiters++
+		session.pendingMu.Unlock()
+		session.controlStreamMu.RUnlock()
+		return existing, false, nil
+	}
+	now := time.Now()
+	if now.UnixMilli() >= command.GetExpiresAtUnixMs() {
+		session.pendingMu.Unlock()
+		session.controlStreamMu.RUnlock()
+		return nil, false, status.Error(codes.DeadlineExceeded, "mission command has expired")
+	}
+	if command.GetIssuedAtUnixMs() > now.Add(maxMissionClockSkew).UnixMilli() {
+		session.pendingMu.Unlock()
+		session.controlStreamMu.RUnlock()
+		return nil, false, status.Error(codes.InvalidArgument, "mission command issue time is too far in the future")
+	}
+	if command.GetExpiresAtUnixMs()-command.GetIssuedAtUnixMs() > maxMissionCommandWindow.Milliseconds() {
+		session.pendingMu.Unlock()
+		session.controlStreamMu.RUnlock()
+		return nil, false, status.Error(codes.InvalidArgument, "mission command validity window is too long")
+	}
+	makeMissionDeploymentRoomLocked(session)
+	if len(session.missionDeployments) >= maxOperationCommands {
+		session.pendingMu.Unlock()
+		session.controlStreamMu.RUnlock()
+		return nil, false, status.Error(codes.ResourceExhausted, "mission deployment retention is full")
+	}
+	deliveryCtx, deliveryCancel := context.WithCancel(context.Background())
+	cloned := proto.Clone(command).(*agentv1.DeployMissionCommand)
+	state := &missionDeploymentState{
+		fingerprint: fingerprint, command: cloned, done: make(chan struct{}),
+		deliveryCancel: deliveryCancel, waiters: 1,
+	}
+	session.missionDeployments[command.GetCommandId()] = state
+	session.pendingMu.Unlock()
+	go func() {
+		defer session.ownershipMu.RUnlock()
+		defer session.controlStreamMu.RUnlock()
+		attempted, sendErr := sendToSessionWithWritePolicy(deliveryCtx, session, &agentv1.RelayStreamMessage{
+			Payload: &agentv1.RelayStreamMessage_DeployMission{DeployMission: cloned},
+		}, true)
+		session.pendingMu.Lock()
+		if session.missionDeployments[cloned.GetCommandId()] == state && !state.completed {
+			// Any invoked Send is outcome-uncertain: the peer can apply the
+			// message even when Relay observes a transport error.
+			state.delivered = attempted
+		}
+		session.pendingMu.Unlock()
+		if sendErr != nil {
+			if attempted {
+				finishMissionDeployment(session, cloned.GetCommandId(), state, uncertainMissionDeploymentResult(cloned, time.Now(), "mission stream write failed after delivery began"), nil)
+			} else {
+				finishMissionDeployment(session, cloned.GetCommandId(), state, nil, sendErr)
+			}
+		}
+	}()
+	return state, true, nil
+}
+
+func validateMissionDeploymentResult(command *agentv1.DeployMissionCommand, result *agentv1.MissionDeploymentResult) error {
+	if command == nil || result == nil || result.GetCommandId() != command.GetCommandId() || !proto.Equal(result.GetBinding(), command.GetBinding()) {
+		return status.Error(codes.Internal, "agent returned a mismatched mission deployment result")
+	}
+	if len(result.ProtoReflect().GetUnknown()) != 0 || result.GetBinding() == nil || len(result.GetBinding().ProtoReflect().GetUnknown()) != 0 {
+		return status.Error(codes.Internal, "agent returned an invalid mission deployment result")
+	}
+	switch result.GetStatus() {
+	case agentv1.MissionDeploymentResult_STATUS_APPLIED,
+		agentv1.MissionDeploymentResult_STATUS_ALREADY_APPLIED,
+		agentv1.MissionDeploymentResult_STATUS_REJECTED,
+		agentv1.MissionDeploymentResult_STATUS_TEMPORARY_ERROR,
+		agentv1.MissionDeploymentResult_STATUS_OUTCOME_UNKNOWN,
+		agentv1.MissionDeploymentResult_STATUS_BINDING_MISMATCH,
+		agentv1.MissionDeploymentResult_STATUS_ONBOARD_MISSION_MISMATCH:
+	default:
+		return status.Error(codes.Internal, "agent returned an invalid mission deployment status")
+	}
+	if result.GetCompletedAtUnixMs() <= 0 {
+		return status.Error(codes.Internal, "agent returned a mission result without completion time")
+	}
+	if result.GetStatus() == agentv1.MissionDeploymentResult_STATUS_APPLIED || result.GetStatus() == agentv1.MissionDeploymentResult_STATUS_ALREADY_APPLIED {
+		if result.GetOnboardMissionDigest() != command.GetBinding().GetMissionDigest() || int(result.GetUploadedItemCount()) != len(command.GetPlan().GetItems()) {
+			return status.Error(codes.Internal, "agent success result does not prove the expected onboard mission")
+		}
+	}
+	return nil
+}
+
+func finishMissionDeployment(session *DroneSession, commandID string, state *missionDeploymentState, result *agentv1.MissionDeploymentResult, err error) {
+	session.pendingMu.Lock()
+	defer session.pendingMu.Unlock()
+	if session.missionDeployments[commandID] != state || state.completed {
+		return
+	}
+	if result != nil {
+		state.result = proto.Clone(result).(*agentv1.MissionDeploymentResult)
+	}
+	state.err = err
+	state.completed = true
+	state.completedAt = time.Now()
+	state.deliveryCancel()
+	close(state.done)
+}
+
+func completeMissionDeploymentForLostSessionLocked(state *missionDeploymentState, now time.Time, reason string) {
+	if state == nil || state.completed {
+		return
+	}
+	if state.delivered {
+		state.result = uncertainMissionDeploymentResult(state.command, now, reason)
+	} else {
+		state.err = status.Error(codes.Aborted, reason+" before confirmed delivery")
+	}
+	state.completed = true
+	state.completedAt = now
+	if state.deliveryCancel != nil {
+		state.deliveryCancel()
+	}
+	close(state.done)
+}
+
+func uncertainMissionDeploymentResult(command *agentv1.DeployMissionCommand, now time.Time, reason string) *agentv1.MissionDeploymentResult {
+	return &agentv1.MissionDeploymentResult{
+		CommandId: command.GetCommandId(), Binding: proto.Clone(command.GetBinding()).(*agentv1.MissionBinding),
+		Status: agentv1.MissionDeploymentResult_STATUS_OUTCOME_UNKNOWN, Message: reason, CompletedAtUnixMs: now.UnixMilli(),
+	}
+}
+
+func takeMissionDeploymentResult(session *DroneSession, state *missionDeploymentState) (*agentv1.MissionDeploymentResult, error) {
+	session.pendingMu.Lock()
+	defer session.pendingMu.Unlock()
+	if state.waiters > 0 {
+		state.waiters--
+	}
+	if state.result == nil {
+		return nil, state.err
+	}
+	return proto.Clone(state.result).(*agentv1.MissionDeploymentResult), state.err
+}
+
+func cancelMissionDeploymentWaiter(session *DroneSession, commandID string, state *missionDeploymentState) {
+	session.pendingMu.Lock()
+	defer session.pendingMu.Unlock()
+	if session.missionDeployments[commandID] != state {
+		return
+	}
+	if state.waiters > 0 {
+		state.waiters--
+	}
+	if state.waiters != 0 || state.completed {
+		return
+	}
+	// Admission and stream delivery run independently of an individual waiter.
+	// Conservatively retain uncertainty even if cancellation wins just before
+	// the delivery task records Send as started; this prevents a retry from
+	// duplicating a command that may already be crossing the stream.
+	state.result = uncertainMissionDeploymentResult(state.command, time.Now(), "mission result wait ended after command admission")
+	state.completed = true
+	state.completedAt = time.Now()
+	state.deliveryCancel()
+	close(state.done)
+}
+
+func expireMissionDeploymentsLocked(session *DroneSession, now time.Time) {
+	for commandID, state := range session.missionDeployments {
+		if state.completed && now.Sub(state.completedAt) >= operationCommandRetention {
+			delete(session.missionDeployments, commandID)
+		}
+	}
+}
+
+func makeMissionDeploymentRoomLocked(session *DroneSession) {
+	for len(session.missionDeployments) >= maxOperationCommands {
+		var oldestID string
+		var oldest time.Time
+		for commandID, state := range session.missionDeployments {
+			if !state.completed {
+				continue
+			}
+			if oldestID == "" || state.completedAt.Before(oldest) {
+				oldestID, oldest = commandID, state.completedAt
+			}
+		}
+		if oldestID == "" {
+			return
+		}
+		delete(session.missionDeployments, oldestID)
+	}
+}
+
+func missionPlanDigest(plan *agentv1.MissionPlan) (string, error) {
+	encoded, err := proto.MarshalOptions{Deterministic: true}.Marshal(plan)
+	if err != nil {
+		return "", fmt.Errorf("marshal mission plan: %w", err)
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:]), nil
+}

--- a/internal/relay/mission_deployment.go
+++ b/internal/relay/mission_deployment.go
@@ -57,8 +57,9 @@ func isPositiveZero(value float64) bool {
 // immutable mission to the exact Agent session active at admission. It refuses
 // delivery unless the configured Agent mapping and reconciled operation context
 // exactly match the mission binding. Concurrent exact attempts coalesce,
-// terminal results replay, and retryable Agent outcomes may start one new
-// delivery on the original stream binding. A command ID may never identify a
+// terminal results replay even after operation context advances, and retryable
+// Agent outcomes may start one new delivery on the original stream binding only
+// while the exact context still matches. A command ID may never identify a
 // different payload. Relay forwards an expired command because its in-memory
 // retention may have been lost during restart; only an Agent with a matching
 // durable uncertain record may reconcile it by readback. The Agent must reject
@@ -127,34 +128,48 @@ func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest)
 	session.sessionMu.RLock()
 	connected := session.stream != nil
 	sessionID := session.SessionID
-	unreconciled := session.operationContextUnreconciled
-	contextMatches := session.AircraftID != "" && session.AircraftID == binding.GetAircraftId() &&
-		session.FlightID == binding.GetFlightId() &&
-		session.IntentID == binding.GetIntentId() && session.IntentVersion == binding.GetIntentVersion()
 	session.sessionMu.RUnlock()
 	if !connected {
 		session.ownershipMu.RUnlock()
 		return nil, status.Error(codes.NotFound, "agent stream is not connected")
 	}
-	if unreconciled {
-		session.ownershipMu.RUnlock()
-		return nil, status.Error(codes.FailedPrecondition, "operation context must be reconciled before mission deployment")
-	}
-	if !contextMatches {
-		session.ownershipMu.RUnlock()
-		return nil, status.Error(codes.FailedPrecondition, "mission binding does not match the reconciled Agent operation context")
-	}
 
 	startedAt := time.Now()
-	state, owner, err := beginMissionDeployment(session, command)
+	state, attached, err := attachMissionDeployment(session, command)
 	if err != nil {
 		session.ownershipMu.RUnlock()
 		relayMissionDeploymentsTotal.WithLabelValues("delivery_failed").Inc()
 		return nil, err
 	}
-	if !owner {
+	owner := false
+	if attached {
 		session.ownershipMu.RUnlock()
 	} else {
+		session.sessionMu.RLock()
+		unreconciled := session.operationContextUnreconciled
+		contextMatches := session.AircraftID != "" && session.AircraftID == binding.GetAircraftId() &&
+			session.FlightID == binding.GetFlightId() &&
+			session.IntentID == binding.GetIntentId() && session.IntentVersion == binding.GetIntentVersion()
+		session.sessionMu.RUnlock()
+		if unreconciled {
+			session.ownershipMu.RUnlock()
+			return nil, status.Error(codes.FailedPrecondition, "operation context must be reconciled before mission deployment")
+		}
+		if !contextMatches {
+			session.ownershipMu.RUnlock()
+			return nil, status.Error(codes.FailedPrecondition, "mission binding does not match the reconciled Agent operation context")
+		}
+		state, owner, err = beginMissionDeployment(session, command)
+		if err != nil {
+			session.ownershipMu.RUnlock()
+			relayMissionDeploymentsTotal.WithLabelValues("delivery_failed").Inc()
+			return nil, err
+		}
+		if !owner {
+			session.ownershipMu.RUnlock()
+		}
+	}
+	if owner {
 		slog.LogAttrs(ctx, slog.LevelInfo, "mission_deployment_started",
 			slog.String("command_id", command.GetCommandId()),
 			slog.String("deployment_id", binding.GetDeploymentId()),
@@ -199,6 +214,51 @@ func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest)
 		relayMissionDeploymentsTotal.WithLabelValues("wait_ended").Inc()
 		return nil, requestErr
 	}
+}
+
+func missionDeploymentFingerprint(command *agentv1.DeployMissionCommand) (string, error) {
+	encoded, err := proto.MarshalOptions{Deterministic: true}.Marshal(command)
+	if err != nil {
+		return "", status.Errorf(codes.Internal, "fingerprint mission command: %v", err)
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+// attachMissionDeployment attaches to an existing attempt when doing so cannot
+// initiate a new stream delivery. This makes retained terminal evidence and an
+// already-running attempt replayable after operation context advances, while a
+// retryable result on the current stream still passes the active-context fence
+// before beginMissionDeployment replaces it.
+func attachMissionDeployment(session *DroneSession, command *agentv1.DeployMissionCommand) (*missionDeploymentState, bool, error) {
+	fingerprint, err := missionDeploymentFingerprint(command)
+	if err != nil {
+		return nil, false, err
+	}
+
+	session.controlStreamMu.RLock()
+	defer session.controlStreamMu.RUnlock()
+	session.pendingMu.Lock()
+	defer session.pendingMu.Unlock()
+	if session.missionDeployments == nil {
+		return nil, false, nil
+	}
+	expireMissionDeploymentsLocked(session, time.Now())
+	existing := session.missionDeployments[command.GetCommandId()]
+	if existing == nil {
+		return nil, false, nil
+	}
+	if existing.fingerprint != fingerprint {
+		return nil, false, status.Error(codes.AlreadyExists, "mission command ID was already used with a different payload")
+	}
+	session.sessionMu.RLock()
+	currentStream := session.stream
+	session.sessionMu.RUnlock()
+	if existing.completed && retryableMissionDeployment(existing) && existing.deliveryStream == currentStream {
+		return nil, false, nil
+	}
+	existing.waiters++
+	return existing, true, nil
 }
 
 func validateDeployMissionCommand(command *agentv1.DeployMissionCommand) error {
@@ -298,12 +358,10 @@ func validateDeployMissionCommand(command *agentv1.DeployMissionCommand) error {
 }
 
 func beginMissionDeployment(session *DroneSession, command *agentv1.DeployMissionCommand) (*missionDeploymentState, bool, error) {
-	encoded, err := proto.MarshalOptions{Deterministic: true}.Marshal(command)
+	fingerprint, err := missionDeploymentFingerprint(command)
 	if err != nil {
-		return nil, false, status.Errorf(codes.Internal, "fingerprint mission command: %v", err)
+		return nil, false, err
 	}
-	digest := sha256.Sum256(encoded)
-	fingerprint := hex.EncodeToString(digest[:])
 
 	session.controlStreamMu.RLock()
 	session.pendingMu.Lock()

--- a/internal/relay/mission_deployment.go
+++ b/internal/relay/mission_deployment.go
@@ -118,7 +118,7 @@ func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest)
 	if err != nil {
 		return nil, err
 	}
-	state, attached, reservationOwner, err := attachMissionDeployment(session, command)
+	state, attached, reservationOwner, err := attachMissionDeployment(waitCtx, session, command)
 	if err != nil {
 		session.ownershipMu.RUnlock()
 		relayMissionDeploymentsTotal.WithLabelValues("delivery_failed").Inc()
@@ -127,6 +127,9 @@ func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest)
 	owner := false
 	if attached {
 		session.ownershipMu.RUnlock()
+	} else if reservationOwner {
+		session.ownershipMu.RUnlock()
+		s.startMissionDeploymentReservation(agentID, session, state)
 	} else {
 		// Exact retries of running or retained deployments never contend for the
 		// cross-operation gate. Only a request that may initiate a stream write
@@ -135,9 +138,6 @@ func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest)
 		session.ownershipMu.RUnlock()
 		release, acquireErr := acquireOperationCommandSlot(waitCtx, session)
 		if acquireErr != nil {
-			if reservationOwner {
-				failMissionDeploymentReservation(session, command.GetCommandId(), state, acquireErr)
-			}
 			return nil, acquireErr
 		}
 		gateRelease := release
@@ -149,32 +149,28 @@ func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest)
 
 		sessionID, err = s.lockCurrentMissionSession(agentID, session)
 		if err != nil {
-			if reservationOwner {
-				failMissionDeploymentReservation(session, command.GetCommandId(), state, err)
-			}
 			return nil, err
 		}
-		if reservationOwner && missionDeploymentCompleted(session, state) {
+		// Another caller may have admitted this exact deployment while this
+		// request waited for the gate. Reattach instead of redelivering it.
+		state, attached, reservationOwner, err = attachMissionDeployment(waitCtx, session, command)
+		if err != nil {
+			session.ownershipMu.RUnlock()
+			relayMissionDeploymentsTotal.WithLabelValues("delivery_failed").Inc()
+			return nil, err
+		}
+		if attached {
 			session.ownershipMu.RUnlock()
 			gateRelease()
 			gateRelease = nil
+			goto waitForMissionResult
+		}
+		if reservationOwner {
+			session.ownershipMu.RUnlock()
+			gateRelease()
+			gateRelease = nil
+			s.startMissionDeploymentReservation(agentID, session, state)
 		} else {
-			if !reservationOwner {
-				// Another caller may have admitted this exact deployment while this
-				// request waited for the gate. Reattach instead of redelivering it.
-				state, attached, reservationOwner, err = attachMissionDeployment(session, command)
-				if err != nil {
-					session.ownershipMu.RUnlock()
-					relayMissionDeploymentsTotal.WithLabelValues("delivery_failed").Inc()
-					return nil, err
-				}
-				if attached {
-					session.ownershipMu.RUnlock()
-					gateRelease()
-					gateRelease = nil
-					goto waitForMissionResult
-				}
-			}
 			session.sessionMu.RLock()
 			unreconciled := session.operationContextUnreconciled
 			contextMatches := session.AircraftID != "" && session.AircraftID == binding.GetAircraftId() &&
@@ -183,30 +179,15 @@ func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest)
 			session.sessionMu.RUnlock()
 			if unreconciled {
 				session.ownershipMu.RUnlock()
-				preconditionErr := status.Error(codes.FailedPrecondition, "operation context must be reconciled before mission deployment")
-				if reservationOwner && !failMissionDeploymentReservation(session, command.GetCommandId(), state, preconditionErr) {
-					gateRelease()
-					gateRelease = nil
-					goto waitForMissionResult
-				}
-				return nil, preconditionErr
+				return nil, status.Error(codes.FailedPrecondition, "operation context must be reconciled before mission deployment")
 			}
 			if !contextMatches {
 				session.ownershipMu.RUnlock()
-				preconditionErr := status.Error(codes.FailedPrecondition, "mission binding does not match the reconciled Agent operation context")
-				if reservationOwner && !failMissionDeploymentReservation(session, command.GetCommandId(), state, preconditionErr) {
-					gateRelease()
-					gateRelease = nil
-					goto waitForMissionResult
-				}
-				return nil, preconditionErr
+				return nil, status.Error(codes.FailedPrecondition, "mission binding does not match the reconciled Agent operation context")
 			}
-			state, owner, err = beginMissionDeployment(waitCtx, session, command, state)
+			state, owner, err = beginMissionDeployment(waitCtx, session, command, nil)
 			if err != nil {
 				session.ownershipMu.RUnlock()
-				if reservationOwner {
-					failMissionDeploymentReservation(session, command.GetCommandId(), state, err)
-				}
 				relayMissionDeploymentsTotal.WithLabelValues("delivery_failed").Inc()
 				return nil, err
 			}
@@ -262,6 +243,68 @@ waitForMissionResult:
 	}
 }
 
+func (s *Relay) startMissionDeploymentReservation(agentID string, session *DroneSession, state *missionDeploymentState) {
+	go func() {
+		ctx := state.admission.ctx
+		defer state.admission.cancel()
+		release, err := acquireOperationCommandSlot(ctx, session)
+		if err != nil {
+			failMissionDeploymentReservation(session, state.command.GetCommandId(), state, err)
+			return
+		}
+		defer release()
+
+		sessionID, err := s.lockCurrentMissionSession(agentID, session)
+		if err != nil {
+			failMissionDeploymentReservation(session, state.command.GetCommandId(), state, err)
+			return
+		}
+		if missionDeploymentCompleted(session, state) {
+			session.ownershipMu.RUnlock()
+			return
+		}
+		binding := state.command.GetBinding()
+		session.sessionMu.RLock()
+		unreconciled := session.operationContextUnreconciled
+		contextMatches := session.AircraftID != "" && session.AircraftID == binding.GetAircraftId() &&
+			session.FlightID == binding.GetFlightId() &&
+			session.IntentID == binding.GetIntentId() && session.IntentVersion == binding.GetIntentVersion()
+		session.sessionMu.RUnlock()
+		if unreconciled || !contextMatches {
+			session.ownershipMu.RUnlock()
+			failMissionDeploymentReservation(session, state.command.GetCommandId(), state,
+				status.Error(codes.FailedPrecondition, "mission binding does not match the reconciled Agent operation context"))
+			return
+		}
+		command := proto.Clone(state.command).(*agentv1.DeployMissionCommand)
+		_, owner, err := beginMissionDeployment(ctx, session, command, state)
+		if err != nil {
+			session.ownershipMu.RUnlock()
+			failMissionDeploymentReservation(session, command.GetCommandId(), state, err)
+			return
+		}
+		if !owner {
+			session.ownershipMu.RUnlock()
+			return
+		}
+		slog.LogAttrs(ctx, slog.LevelInfo, "mission_deployment_started",
+			slog.String("command_id", command.GetCommandId()),
+			slog.String("deployment_id", binding.GetDeploymentId()),
+			slog.String("mission_id", binding.GetMissionId()),
+			slog.String("aircraft_id", binding.GetAircraftId()),
+			slog.String("flight_id", binding.GetFlightId()),
+			slog.String("intent_id", binding.GetIntentId()),
+			slog.Uint64("intent_version", uint64(binding.GetIntentVersion())),
+			slog.String("agent_id", agentID),
+			slog.String("session_id", sessionID),
+		)
+		select {
+		case <-state.done:
+		case <-ctx.Done():
+		}
+	}()
+}
+
 // lockCurrentMissionSession pins session as the active, connected session for
 // agentID. On success the caller owns session.ownershipMu's read lease and must
 // release it, or transfer it to an admitted asynchronous delivery.
@@ -300,7 +343,7 @@ func missionDeploymentFingerprint(command *agentv1.DeployMissionCommand) (string
 // This keeps retained evidence and running attempts replayable after operation
 // context advances while every new delivery still passes the active-context
 // fence before beginMissionDeployment activates its reservation.
-func attachMissionDeployment(session *DroneSession, command *agentv1.DeployMissionCommand) (*missionDeploymentState, bool, bool, error) {
+func attachMissionDeployment(waitCtx context.Context, session *DroneSession, command *agentv1.DeployMissionCommand) (*missionDeploymentState, bool, bool, error) {
 	fingerprint, err := missionDeploymentFingerprint(command)
 	if err != nil {
 		return nil, false, false, err
@@ -332,12 +375,54 @@ func attachMissionDeployment(session *DroneSession, command *agentv1.DeployMissi
 		reserved := &missionDeploymentState{
 			fingerprint: fingerprint, command: cloned, deliveryStream: currentStream,
 			done: make(chan struct{}), waiters: 1, reserved: true,
+			admission: newMissionAdmission(waitCtx),
 		}
 		session.missionDeployments[command.GetCommandId()] = reserved
 		return reserved, false, true, nil
 	}
+	if existing.reserved && existing.admission != nil {
+		existing.admission.add(waitCtx)
+	}
 	existing.waiters++
 	return existing, true, false, nil
+}
+
+func newMissionAdmission(waiterCtx context.Context) *missionAdmission {
+	ctx, cancel := context.WithTimeout(context.Background(), maxMissionDeploymentWait)
+	admission := &missionAdmission{ctx: ctx, cancel: cancel}
+	admission.add(waiterCtx)
+	return admission
+}
+
+func (a *missionAdmission) add(waiterCtx context.Context) bool {
+	a.mu.Lock()
+	if a.closed || a.ctx.Err() != nil || waiterCtx.Err() != nil {
+		a.mu.Unlock()
+		return false
+	}
+	a.active++
+	a.mu.Unlock()
+	go func() {
+		select {
+		case <-waiterCtx.Done():
+			a.remove()
+		case <-a.ctx.Done():
+		}
+	}()
+	return true
+}
+
+func (a *missionAdmission) remove() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.closed || a.active == 0 {
+		return
+	}
+	a.active--
+	if a.active == 0 {
+		a.closed = true
+		a.cancel()
+	}
 }
 
 func missionDeploymentCompleted(session *DroneSession, state *missionDeploymentState) bool {
@@ -356,6 +441,7 @@ func failMissionDeploymentReservation(session *DroneSession, commandID string, s
 	state.admissionFailed = true
 	state.completed = true
 	state.completedAt = time.Now()
+	state.admission.cancel()
 	close(state.done)
 	return true
 }
@@ -642,6 +728,9 @@ func completeMissionDeploymentForLostSessionLocked(state *missionDeploymentState
 	}
 	state.completed = true
 	state.completedAt = now
+	if state.admission != nil {
+		state.admission.cancel()
+	}
 	if state.deliveryCancel != nil {
 		state.deliveryCancel()
 	}
@@ -677,6 +766,15 @@ func cancelMissionDeploymentWaiter(session *DroneSession, commandID string, stat
 		state.waiters--
 	}
 	if state.waiters != 0 || state.completed {
+		return
+	}
+	if state.reserved {
+		state.err = status.Error(codes.Canceled, "all mission retry waiters ended before admission")
+		state.admissionFailed = true
+		state.completed = true
+		state.completedAt = time.Now()
+		state.admission.cancel()
+		close(state.done)
 		return
 	}
 	// Admission and stream delivery run independently of an individual waiter.

--- a/internal/relay/mission_deployment.go
+++ b/internal/relay/mission_deployment.go
@@ -118,7 +118,7 @@ func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest)
 	if err != nil {
 		return nil, err
 	}
-	state, attached, err := attachMissionDeployment(session, command)
+	state, attached, reservationOwner, err := attachMissionDeployment(session, command)
 	if err != nil {
 		session.ownershipMu.RUnlock()
 		relayMissionDeploymentsTotal.WithLabelValues("delivery_failed").Inc()
@@ -135,6 +135,9 @@ func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest)
 		session.ownershipMu.RUnlock()
 		release, acquireErr := acquireOperationCommandSlot(waitCtx, session)
 		if acquireErr != nil {
+			if reservationOwner {
+				failMissionDeploymentReservation(session, command.GetCommandId(), state, acquireErr)
+			}
 			return nil, acquireErr
 		}
 		gateRelease := release
@@ -146,21 +149,32 @@ func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest)
 
 		sessionID, err = s.lockCurrentMissionSession(agentID, session)
 		if err != nil {
+			if reservationOwner {
+				failMissionDeploymentReservation(session, command.GetCommandId(), state, err)
+			}
 			return nil, err
 		}
-		// Another caller may have admitted this exact deployment while this
-		// request waited for the gate. Reattach instead of redelivering it.
-		state, attached, err = attachMissionDeployment(session, command)
-		if err != nil {
-			session.ownershipMu.RUnlock()
-			relayMissionDeploymentsTotal.WithLabelValues("delivery_failed").Inc()
-			return nil, err
-		}
-		if attached {
+		if reservationOwner && missionDeploymentCompleted(session, state) {
 			session.ownershipMu.RUnlock()
 			gateRelease()
 			gateRelease = nil
 		} else {
+			if !reservationOwner {
+				// Another caller may have admitted this exact deployment while this
+				// request waited for the gate. Reattach instead of redelivering it.
+				state, attached, reservationOwner, err = attachMissionDeployment(session, command)
+				if err != nil {
+					session.ownershipMu.RUnlock()
+					relayMissionDeploymentsTotal.WithLabelValues("delivery_failed").Inc()
+					return nil, err
+				}
+				if attached {
+					session.ownershipMu.RUnlock()
+					gateRelease()
+					gateRelease = nil
+					goto waitForMissionResult
+				}
+			}
 			session.sessionMu.RLock()
 			unreconciled := session.operationContextUnreconciled
 			contextMatches := session.AircraftID != "" && session.AircraftID == binding.GetAircraftId() &&
@@ -169,15 +183,30 @@ func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest)
 			session.sessionMu.RUnlock()
 			if unreconciled {
 				session.ownershipMu.RUnlock()
-				return nil, status.Error(codes.FailedPrecondition, "operation context must be reconciled before mission deployment")
+				preconditionErr := status.Error(codes.FailedPrecondition, "operation context must be reconciled before mission deployment")
+				if reservationOwner && !failMissionDeploymentReservation(session, command.GetCommandId(), state, preconditionErr) {
+					gateRelease()
+					gateRelease = nil
+					goto waitForMissionResult
+				}
+				return nil, preconditionErr
 			}
 			if !contextMatches {
 				session.ownershipMu.RUnlock()
-				return nil, status.Error(codes.FailedPrecondition, "mission binding does not match the reconciled Agent operation context")
+				preconditionErr := status.Error(codes.FailedPrecondition, "mission binding does not match the reconciled Agent operation context")
+				if reservationOwner && !failMissionDeploymentReservation(session, command.GetCommandId(), state, preconditionErr) {
+					gateRelease()
+					gateRelease = nil
+					goto waitForMissionResult
+				}
+				return nil, preconditionErr
 			}
-			state, owner, err = beginMissionDeployment(waitCtx, session, command)
+			state, owner, err = beginMissionDeployment(waitCtx, session, command, state)
 			if err != nil {
 				session.ownershipMu.RUnlock()
+				if reservationOwner {
+					failMissionDeploymentReservation(session, command.GetCommandId(), state, err)
+				}
 				relayMissionDeploymentsTotal.WithLabelValues("delivery_failed").Inc()
 				return nil, err
 			}
@@ -186,6 +215,8 @@ func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest)
 			}
 		}
 	}
+
+waitForMissionResult:
 	if owner {
 		slog.LogAttrs(ctx, slog.LevelInfo, "mission_deployment_started",
 			slog.String("command_id", command.GetCommandId()),
@@ -264,14 +295,15 @@ func missionDeploymentFingerprint(command *agentv1.DeployMissionCommand) (string
 }
 
 // attachMissionDeployment attaches to an existing attempt when doing so cannot
-// initiate a new stream delivery. This makes retained terminal evidence and an
-// already-running attempt replayable after operation context advances, while a
-// retryable result on the current stream still passes the active-context fence
-// before beginMissionDeployment replaces it.
-func attachMissionDeployment(session *DroneSession, command *agentv1.DeployMissionCommand) (*missionDeploymentState, bool, error) {
+// initiate a new stream delivery. For a retryable result on the current stream,
+// it instead reserves one shared pending generation before gate contention.
+// This keeps retained evidence and running attempts replayable after operation
+// context advances while every new delivery still passes the active-context
+// fence before beginMissionDeployment activates its reservation.
+func attachMissionDeployment(session *DroneSession, command *agentv1.DeployMissionCommand) (*missionDeploymentState, bool, bool, error) {
 	fingerprint, err := missionDeploymentFingerprint(command)
 	if err != nil {
-		return nil, false, err
+		return nil, false, false, err
 	}
 
 	session.controlStreamMu.RLock()
@@ -279,23 +311,53 @@ func attachMissionDeployment(session *DroneSession, command *agentv1.DeployMissi
 	session.pendingMu.Lock()
 	defer session.pendingMu.Unlock()
 	if err := prepareCommandIDAdmissionLocked(session, command.GetCommandId(), retainedMissionDeployment, time.Now()); err != nil {
-		return nil, false, err
+		return nil, false, false, err
 	}
 	existing := session.missionDeployments[command.GetCommandId()]
 	if existing == nil {
-		return nil, false, nil
+		return nil, false, false, nil
 	}
 	if existing.fingerprint != fingerprint {
-		return nil, false, status.Error(codes.AlreadyExists, "mission command ID was already used with a different payload")
+		return nil, false, false, status.Error(codes.AlreadyExists, "mission command ID was already used with a different payload")
 	}
 	session.sessionMu.RLock()
 	currentStream := session.stream
 	session.sessionMu.RUnlock()
-	if existing.completed && retryableMissionDeployment(existing) && existing.deliveryStream == currentStream {
-		return nil, false, nil
+	if existing.completed && retryableMissionDeployment(existing) &&
+		(existing.admissionFailed || existing.deliveryStream == currentStream) {
+		// Reserve the next delivery generation before callers contend for the
+		// cross-operation gate. Concurrent exact retries attach to this shared
+		// state even if the next Agent result arrives before the gate is released.
+		cloned := proto.Clone(command).(*agentv1.DeployMissionCommand)
+		reserved := &missionDeploymentState{
+			fingerprint: fingerprint, command: cloned, deliveryStream: currentStream,
+			done: make(chan struct{}), waiters: 1, reserved: true,
+		}
+		session.missionDeployments[command.GetCommandId()] = reserved
+		return reserved, false, true, nil
 	}
 	existing.waiters++
-	return existing, true, nil
+	return existing, true, false, nil
+}
+
+func missionDeploymentCompleted(session *DroneSession, state *missionDeploymentState) bool {
+	session.pendingMu.Lock()
+	defer session.pendingMu.Unlock()
+	return state.completed
+}
+
+func failMissionDeploymentReservation(session *DroneSession, commandID string, state *missionDeploymentState, err error) bool {
+	session.pendingMu.Lock()
+	defer session.pendingMu.Unlock()
+	if session.missionDeployments[commandID] != state || state.completed || !state.reserved {
+		return false
+	}
+	state.err = err
+	state.admissionFailed = true
+	state.completed = true
+	state.completedAt = time.Now()
+	close(state.done)
+	return true
 }
 
 func validateDeployMissionCommand(command *agentv1.DeployMissionCommand) error {
@@ -394,7 +456,7 @@ func validateDeployMissionCommand(command *agentv1.DeployMissionCommand) error {
 	return nil
 }
 
-func beginMissionDeployment(ctx context.Context, session *DroneSession, command *agentv1.DeployMissionCommand) (*missionDeploymentState, bool, error) {
+func beginMissionDeployment(ctx context.Context, session *DroneSession, command *agentv1.DeployMissionCommand, reservation *missionDeploymentState) (*missionDeploymentState, bool, error) {
 	fingerprint, err := missionDeploymentFingerprint(command)
 	if err != nil {
 		return nil, false, err
@@ -419,7 +481,10 @@ func beginMissionDeployment(ctx context.Context, session *DroneSession, command 
 			session.controlStreamMu.RUnlock()
 			return nil, false, status.Error(codes.AlreadyExists, "mission command ID was already used with a different payload")
 		}
-		if !existing.completed || !retryableMissionDeployment(existing) || existing.deliveryStream != currentStream {
+		if existing == reservation && existing.reserved && !existing.completed {
+			// The caller owns this pre-gate delivery reservation. Activate the same
+			// state so every concurrent waiter observes this generation's result.
+		} else if !existing.completed || !retryableMissionDeployment(existing) || existing.deliveryStream != currentStream {
 			existing.waiters++
 			session.pendingMu.Unlock()
 			session.controlStreamMu.RUnlock()
@@ -458,9 +523,18 @@ func beginMissionDeployment(ctx context.Context, session *DroneSession, command 
 	}
 	deliveryCtx, deliveryCancel := context.WithCancel(context.Background())
 	cloned := proto.Clone(command).(*agentv1.DeployMissionCommand)
-	state := &missionDeploymentState{
-		fingerprint: fingerprint, command: cloned, deliveryStream: currentStream, done: make(chan struct{}),
-		deliveryCancel: deliveryCancel, waiters: 1,
+	state := reservation
+	if state == nil {
+		state = &missionDeploymentState{
+			fingerprint: fingerprint, command: cloned, deliveryStream: currentStream, done: make(chan struct{}),
+			deliveryCancel: deliveryCancel, waiters: 1,
+		}
+	} else {
+		state.command = cloned
+		state.deliveryStream = currentStream
+		state.deliveryCancel = deliveryCancel
+		state.reserved = false
+		state.admissionFailed = false
 	}
 	session.missionDeployments[command.GetCommandId()] = state
 	session.pendingMu.Unlock()
@@ -489,7 +563,13 @@ func beginMissionDeployment(ctx context.Context, session *DroneSession, command 
 }
 
 func retryableMissionDeployment(state *missionDeploymentState) bool {
-	if state == nil || !state.completed || state.err != nil || state.result == nil {
+	if state == nil || !state.completed {
+		return false
+	}
+	if state.admissionFailed {
+		return true
+	}
+	if state.err != nil || state.result == nil {
 		return false
 	}
 	switch state.result.GetStatus() {
@@ -542,7 +622,9 @@ func finishMissionDeployment(session *DroneSession, commandID string, state *mis
 	state.err = err
 	state.completed = true
 	state.completedAt = time.Now()
-	state.deliveryCancel()
+	if state.deliveryCancel != nil {
+		state.deliveryCancel()
+	}
 	close(state.done)
 }
 
@@ -550,7 +632,10 @@ func completeMissionDeploymentForLostSessionLocked(state *missionDeploymentState
 	if state == nil || state.completed {
 		return
 	}
-	if state.delivered {
+	if state.reserved {
+		state.err = status.Error(codes.Aborted, reason+" before mission admission")
+		state.admissionFailed = true
+	} else if state.delivered {
 		state.result = uncertainMissionDeploymentResult(state.command, now, reason)
 	} else {
 		state.err = status.Error(codes.Aborted, reason+" before confirmed delivery")
@@ -601,7 +686,9 @@ func cancelMissionDeploymentWaiter(session *DroneSession, commandID string, stat
 	state.result = uncertainMissionDeploymentResult(state.command, time.Now(), "mission result wait ended after command admission")
 	state.completed = true
 	state.completedAt = time.Now()
-	state.deliveryCancel()
+	if state.deliveryCancel != nil {
+		state.deliveryCancel()
+	}
 	close(state.done)
 }
 

--- a/internal/relay/mission_deployment.go
+++ b/internal/relay/mission_deployment.go
@@ -668,14 +668,16 @@ func beginMissionDeployment(ctx context.Context, session *DroneSession, command 
 	go func() {
 		defer session.ownershipMu.RUnlock()
 		defer session.controlStreamMu.RUnlock()
-		attempted, sendErr := sendToSessionWithWritePolicyAndFinish(deliveryCtx, session, &agentv1.RelayStreamMessage{
+		attempted, sendErr := sendToSessionWithWritePolicyAndCommit(deliveryCtx, session, &agentv1.RelayStreamMessage{
 			Payload: &agentv1.RelayStreamMessage_DeployMission{DeployMission: cloned},
-		}, true, func() {
+		}, true, func() bool {
 			session.pendingMu.Lock()
-			if session.missionDeployments[cloned.GetCommandId()] == state && !state.completed {
-				state.resultAdmissionOpen = true
+			defer session.pendingMu.Unlock()
+			if session.missionDeployments[cloned.GetCommandId()] != state || state.completed {
+				return false
 			}
-			session.pendingMu.Unlock()
+			state.resultAdmissionOpen = true
+			return true
 		})
 		session.pendingMu.Lock()
 		if session.missionDeployments[cloned.GetCommandId()] == state && !state.completed {

--- a/internal/relay/mission_deployment.go
+++ b/internal/relay/mission_deployment.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"log/slog"
 	"math"
 	"strings"
@@ -20,6 +19,7 @@ import (
 
 	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
 	pb "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
+	"github.com/aero-arc/aero-arc-protos/missiondigest"
 	"github.com/bluenviron/gomavlib/v2/pkg/dialects/common"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -524,10 +524,5 @@ func makeMissionDeploymentRoomLocked(session *DroneSession) {
 }
 
 func missionPlanDigest(plan *agentv1.MissionPlan) (string, error) {
-	encoded, err := proto.MarshalOptions{Deterministic: true}.Marshal(plan)
-	if err != nil {
-		return "", fmt.Errorf("marshal mission plan: %w", err)
-	}
-	digest := sha256.Sum256(encoded)
-	return hex.EncodeToString(digest[:]), nil
+	return missiondigest.Digest(plan)
 }

--- a/internal/relay/mission_deployment.go
+++ b/internal/relay/mission_deployment.go
@@ -113,30 +113,11 @@ func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest)
 	}
 	waitCtx, cancel := context.WithTimeout(ctx, maxMissionDeploymentWait)
 	defer cancel()
-	release, err := acquireOperationCommandSlot(waitCtx, session)
+	startedAt := time.Now()
+	sessionID, err := s.lockCurrentMissionSession(agentID, session)
 	if err != nil {
 		return nil, err
 	}
-	defer release()
-
-	session.ownershipMu.RLock()
-	s.sessionsMu.RLock()
-	current := s.grpcSessions[agentID] == session && !session.retired
-	s.sessionsMu.RUnlock()
-	if !current {
-		session.ownershipMu.RUnlock()
-		return nil, status.Error(codes.NotFound, "agent session is no longer active")
-	}
-	session.sessionMu.RLock()
-	connected := session.stream != nil
-	sessionID := session.SessionID
-	session.sessionMu.RUnlock()
-	if !connected {
-		session.ownershipMu.RUnlock()
-		return nil, status.Error(codes.NotFound, "agent stream is not connected")
-	}
-
-	startedAt := time.Now()
 	state, attached, err := attachMissionDeployment(session, command)
 	if err != nil {
 		session.ownershipMu.RUnlock()
@@ -147,28 +128,62 @@ func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest)
 	if attached {
 		session.ownershipMu.RUnlock()
 	} else {
-		session.sessionMu.RLock()
-		unreconciled := session.operationContextUnreconciled
-		contextMatches := session.AircraftID != "" && session.AircraftID == binding.GetAircraftId() &&
-			session.FlightID == binding.GetFlightId() &&
-			session.IntentID == binding.GetIntentId() && session.IntentVersion == binding.GetIntentVersion()
-		session.sessionMu.RUnlock()
-		if unreconciled {
-			session.ownershipMu.RUnlock()
-			return nil, status.Error(codes.FailedPrecondition, "operation context must be reconciled before mission deployment")
+		// Exact retries of running or retained deployments never contend for the
+		// cross-operation gate. Only a request that may initiate a stream write
+		// waits here. Do not hold the ownership lease while waiting: session
+		// retirement and replacement must remain able to make progress.
+		session.ownershipMu.RUnlock()
+		release, acquireErr := acquireOperationCommandSlot(waitCtx, session)
+		if acquireErr != nil {
+			return nil, acquireErr
 		}
-		if !contextMatches {
-			session.ownershipMu.RUnlock()
-			return nil, status.Error(codes.FailedPrecondition, "mission binding does not match the reconciled Agent operation context")
+		gateRelease := release
+		defer func() {
+			if gateRelease != nil {
+				gateRelease()
+			}
+		}()
+
+		sessionID, err = s.lockCurrentMissionSession(agentID, session)
+		if err != nil {
+			return nil, err
 		}
-		state, owner, err = beginMissionDeployment(waitCtx, session, command)
+		// Another caller may have admitted this exact deployment while this
+		// request waited for the gate. Reattach instead of redelivering it.
+		state, attached, err = attachMissionDeployment(session, command)
 		if err != nil {
 			session.ownershipMu.RUnlock()
 			relayMissionDeploymentsTotal.WithLabelValues("delivery_failed").Inc()
 			return nil, err
 		}
-		if !owner {
+		if attached {
 			session.ownershipMu.RUnlock()
+			gateRelease()
+			gateRelease = nil
+		} else {
+			session.sessionMu.RLock()
+			unreconciled := session.operationContextUnreconciled
+			contextMatches := session.AircraftID != "" && session.AircraftID == binding.GetAircraftId() &&
+				session.FlightID == binding.GetFlightId() &&
+				session.IntentID == binding.GetIntentId() && session.IntentVersion == binding.GetIntentVersion()
+			session.sessionMu.RUnlock()
+			if unreconciled {
+				session.ownershipMu.RUnlock()
+				return nil, status.Error(codes.FailedPrecondition, "operation context must be reconciled before mission deployment")
+			}
+			if !contextMatches {
+				session.ownershipMu.RUnlock()
+				return nil, status.Error(codes.FailedPrecondition, "mission binding does not match the reconciled Agent operation context")
+			}
+			state, owner, err = beginMissionDeployment(waitCtx, session, command)
+			if err != nil {
+				session.ownershipMu.RUnlock()
+				relayMissionDeploymentsTotal.WithLabelValues("delivery_failed").Inc()
+				return nil, err
+			}
+			if !owner {
+				session.ownershipMu.RUnlock()
+			}
 		}
 	}
 	if owner {
@@ -214,6 +229,29 @@ func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest)
 		relayMissionDeploymentsTotal.WithLabelValues("wait_ended").Inc()
 		return nil, requestErr
 	}
+}
+
+// lockCurrentMissionSession pins session as the active, connected session for
+// agentID. On success the caller owns session.ownershipMu's read lease and must
+// release it, or transfer it to an admitted asynchronous delivery.
+func (s *Relay) lockCurrentMissionSession(agentID string, session *DroneSession) (string, error) {
+	session.ownershipMu.RLock()
+	s.sessionsMu.RLock()
+	current := s.grpcSessions[agentID] == session && !session.retired
+	s.sessionsMu.RUnlock()
+	if !current {
+		session.ownershipMu.RUnlock()
+		return "", status.Error(codes.NotFound, "agent session is no longer active")
+	}
+	session.sessionMu.RLock()
+	connected := session.stream != nil
+	sessionID := session.SessionID
+	session.sessionMu.RUnlock()
+	if !connected {
+		session.ownershipMu.RUnlock()
+		return "", status.Error(codes.NotFound, "agent stream is not connected")
+	}
+	return sessionID, nil
 }
 
 func missionDeploymentFingerprint(command *agentv1.DeployMissionCommand) (string, error) {

--- a/internal/relay/mission_deployment.go
+++ b/internal/relay/mission_deployment.go
@@ -63,6 +63,10 @@ func isSupportedMissionCommand(value uint32) bool {
 	}
 }
 
+func isPositiveZero(value float64) bool {
+	return math.Float64bits(value) == 0
+}
+
 // DeployMission authenticates a control-plane caller and delivers one bounded,
 // immutable mission to the exact Agent session active at admission. It refuses
 // delivery unless the configured Agent mapping and reconciled operation context
@@ -235,11 +239,24 @@ func validateDeployMissionCommand(command *agentv1.DeployMissionCommand) error {
 		if item.GetCurrent() {
 			return status.Errorf(codes.InvalidArgument, "mission item %d sets reserved current flag", i)
 		}
+		if !isPositiveZero(item.GetParam1()) || !isPositiveZero(item.GetParam2()) || !isPositiveZero(item.GetParam3()) {
+			return status.Errorf(codes.InvalidArgument, "mission item %d params 1 through 3 must be positive zero", i)
+		}
 		if !isSupportedMissionFrame(item.GetFrame()) {
 			return status.Errorf(codes.InvalidArgument, "mission item %d uses unsupported frame %d", i, item.GetFrame())
 		}
 		if !isSupportedMissionCommand(item.GetCommand()) {
 			return status.Errorf(codes.InvalidArgument, "mission item %d uses unsupported command %d", i, item.GetCommand())
+		}
+		switch item.GetCommand() {
+		case uint32(common.MAV_CMD_NAV_WAYPOINT), uint32(common.MAV_CMD_NAV_TAKEOFF):
+			if !isPositiveZero(item.GetParam4()) {
+				return status.Errorf(codes.InvalidArgument, "mission item %d param4 must be positive zero for command %d", i, item.GetCommand())
+			}
+		case uint32(common.MAV_CMD_NAV_LAND):
+			if item.GetParam4() != 1 {
+				return status.Errorf(codes.InvalidArgument, "mission item %d param4 must be +1 for NAV_LAND", i)
+			}
 		}
 		if item.GetLatitudeE7() < -900000000 || item.GetLatitudeE7() > 900000000 || item.GetLongitudeE7() < -1800000000 || item.GetLongitudeE7() > 1800000000 {
 			return status.Errorf(codes.InvalidArgument, "mission item %d has invalid coordinates", i)

--- a/internal/relay/mission_deployment.go
+++ b/internal/relay/mission_deployment.go
@@ -77,10 +77,10 @@ func isPositiveZero(value float64) bool {
 //     retryable, and outcome-unknown application statuses.
 //   - error: reports authorization or canonical-plan validation failure, mapping
 //     or operation-context mismatch, missing/replaced session, command-ID payload
-//     conflict, retention exhaustion, stream delivery failure, malformed Agent
-//     evidence, or caller/Relay wait timeout. An RPC error after admission leaves
-//     the effect uncertain and requires an exact retry with the same command ID
-//     and payload.
+//     or kind conflict, retention exhaustion, stream delivery failure, malformed
+//     Agent evidence, or caller/Relay wait timeout. An RPC error after admission
+//     leaves the effect uncertain and requires an exact retry with the same
+//     command ID and payload.
 func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest) (*pb.DeployMissionResponse, error) {
 	if err := s.authorizeControlMutation(ctx); err != nil {
 		return nil, err
@@ -240,10 +240,9 @@ func attachMissionDeployment(session *DroneSession, command *agentv1.DeployMissi
 	defer session.controlStreamMu.RUnlock()
 	session.pendingMu.Lock()
 	defer session.pendingMu.Unlock()
-	if session.missionDeployments == nil {
-		return nil, false, nil
+	if err := prepareCommandIDAdmissionLocked(session, command.GetCommandId(), retainedMissionDeployment, time.Now()); err != nil {
+		return nil, false, err
 	}
-	expireMissionDeploymentsLocked(session, time.Now())
 	existing := session.missionDeployments[command.GetCommandId()]
 	if existing == nil {
 		return nil, false, nil
@@ -338,13 +337,13 @@ func validateDeployMissionCommand(command *agentv1.DeployMissionCommand) error {
 				return status.Errorf(codes.InvalidArgument, "mission item %d contains a non-finite value", i)
 			}
 		}
-		altitudeCM := math.Round(float64(item.GetAltitudeM()) * 100)
+		altitudeCM := item.GetAltitudeM() * float32(100)
 		if altitudeCM < -8388608 || altitudeCM > 8388607 {
-			return status.Errorf(codes.InvalidArgument, "mission item %d altitude must round-trip through ArduPilot signed-centimeter storage", i)
+			return status.Errorf(codes.InvalidArgument, "mission item %d altitude exceeds ArduPilot signed-centimeter storage", i)
 		}
-		altitudeReadback := float32(int32(altitudeCM)) / 100
+		altitudeReadback := float32(int32(altitudeCM)) * float32(0.01)
 		if math.Float32bits(altitudeReadback) != math.Float32bits(item.GetAltitudeM()) {
-			return status.Errorf(codes.InvalidArgument, "mission item %d altitude must round-trip through ArduPilot signed-centimeter storage", i)
+			return status.Errorf(codes.InvalidArgument, "mission item %d altitude must round-trip through ArduPilot truncating signed-centimeter storage", i)
 		}
 	}
 	digest, err := missionPlanDigest(plan)
@@ -365,10 +364,14 @@ func beginMissionDeployment(session *DroneSession, command *agentv1.DeployMissio
 
 	session.controlStreamMu.RLock()
 	session.pendingMu.Lock()
+	if err := prepareCommandIDAdmissionLocked(session, command.GetCommandId(), retainedMissionDeployment, time.Now()); err != nil {
+		session.pendingMu.Unlock()
+		session.controlStreamMu.RUnlock()
+		return nil, false, err
+	}
 	if session.missionDeployments == nil {
 		session.missionDeployments = make(map[string]*missionDeploymentState)
 	}
-	expireMissionDeploymentsLocked(session, time.Now())
 	session.sessionMu.RLock()
 	currentStream := session.stream
 	session.sessionMu.RUnlock()

--- a/internal/relay/mission_deployment.go
+++ b/internal/relay/mission_deployment.go
@@ -70,8 +70,10 @@ func isPositiveZero(value float64) bool {
 // DeployMission authenticates a control-plane caller and delivers one bounded,
 // immutable mission to the exact Agent session active at admission. It refuses
 // delivery unless the configured Agent mapping and reconciled operation context
-// exactly match the mission binding. Exact retries coalesce; a command ID may
-// never identify a different payload.
+// exactly match the mission binding. Concurrent exact attempts coalesce,
+// terminal results replay, and retryable Agent outcomes may start one new
+// delivery on the original stream binding. A command ID may never identify a
+// different payload.
 func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest) (*pb.DeployMissionResponse, error) {
 	if err := s.authorizeControlMutation(ctx); err != nil {
 		return nil, err
@@ -292,19 +294,26 @@ func beginMissionDeployment(session *DroneSession, command *agentv1.DeployMissio
 		session.missionDeployments = make(map[string]*missionDeploymentState)
 	}
 	expireMissionDeploymentsLocked(session, time.Now())
+	session.sessionMu.RLock()
+	currentStream := session.stream
+	session.sessionMu.RUnlock()
+	var recoveringOutcome bool
 	if existing := session.missionDeployments[command.GetCommandId()]; existing != nil {
 		if existing.fingerprint != fingerprint {
 			session.pendingMu.Unlock()
 			session.controlStreamMu.RUnlock()
 			return nil, false, status.Error(codes.AlreadyExists, "mission command ID was already used with a different payload")
 		}
-		existing.waiters++
-		session.pendingMu.Unlock()
-		session.controlStreamMu.RUnlock()
-		return existing, false, nil
+		if !existing.completed || !retryableMissionDeployment(existing) || existing.deliveryStream != currentStream {
+			existing.waiters++
+			session.pendingMu.Unlock()
+			session.controlStreamMu.RUnlock()
+			return existing, false, nil
+		}
+		recoveringOutcome = existing.result.GetStatus() == agentv1.MissionDeploymentResult_STATUS_OUTCOME_UNKNOWN
 	}
 	now := time.Now()
-	if now.UnixMilli() >= command.GetExpiresAtUnixMs() {
+	if now.UnixMilli() >= command.GetExpiresAtUnixMs() && !recoveringOutcome {
 		session.pendingMu.Unlock()
 		session.controlStreamMu.RUnlock()
 		return nil, false, status.Error(codes.DeadlineExceeded, "mission command has expired")
@@ -319,8 +328,11 @@ func beginMissionDeployment(session *DroneSession, command *agentv1.DeployMissio
 		session.controlStreamMu.RUnlock()
 		return nil, false, status.Error(codes.InvalidArgument, "mission command validity window is too long")
 	}
-	makeMissionDeploymentRoomLocked(session)
-	if len(session.missionDeployments) >= maxOperationCommands {
+	_, replacing := session.missionDeployments[command.GetCommandId()]
+	if !replacing {
+		makeMissionDeploymentRoomLocked(session)
+	}
+	if !replacing && len(session.missionDeployments) >= maxOperationCommands {
 		session.pendingMu.Unlock()
 		session.controlStreamMu.RUnlock()
 		return nil, false, status.Error(codes.ResourceExhausted, "mission deployment retention is full")
@@ -328,7 +340,7 @@ func beginMissionDeployment(session *DroneSession, command *agentv1.DeployMissio
 	deliveryCtx, deliveryCancel := context.WithCancel(context.Background())
 	cloned := proto.Clone(command).(*agentv1.DeployMissionCommand)
 	state := &missionDeploymentState{
-		fingerprint: fingerprint, command: cloned, done: make(chan struct{}),
+		fingerprint: fingerprint, command: cloned, deliveryStream: currentStream, done: make(chan struct{}),
 		deliveryCancel: deliveryCancel, waiters: 1,
 	}
 	session.missionDeployments[command.GetCommandId()] = state
@@ -355,6 +367,19 @@ func beginMissionDeployment(session *DroneSession, command *agentv1.DeployMissio
 		}
 	}()
 	return state, true, nil
+}
+
+func retryableMissionDeployment(state *missionDeploymentState) bool {
+	if state == nil || !state.completed || state.err != nil || state.result == nil {
+		return false
+	}
+	switch state.result.GetStatus() {
+	case agentv1.MissionDeploymentResult_STATUS_TEMPORARY_ERROR,
+		agentv1.MissionDeploymentResult_STATUS_OUTCOME_UNKNOWN:
+		return true
+	default:
+		return false
+	}
 }
 
 func validateMissionDeploymentResult(command *agentv1.DeployMissionCommand, result *agentv1.MissionDeploymentResult) error {

--- a/internal/relay/mission_deployment.go
+++ b/internal/relay/mission_deployment.go
@@ -35,26 +35,12 @@ const (
 )
 
 func isSupportedMissionFrame(value uint32) bool {
-	switch value {
-	case uint32(common.MAV_FRAME_GLOBAL),
-		uint32(common.MAV_FRAME_GLOBAL_RELATIVE_ALT),
-		uint32(common.MAV_FRAME_GLOBAL_INT),
-		uint32(common.MAV_FRAME_GLOBAL_RELATIVE_ALT_INT),
-		uint32(common.MAV_FRAME_GLOBAL_TERRAIN_ALT),
-		uint32(common.MAV_FRAME_GLOBAL_TERRAIN_ALT_INT):
-		return true
-	default:
-		return false
-	}
+	return value == uint32(common.MAV_FRAME_GLOBAL)
 }
 
 func isSupportedMissionCommand(value uint32) bool {
 	switch value {
 	case uint32(common.MAV_CMD_NAV_WAYPOINT),
-		uint32(common.MAV_CMD_NAV_LOITER_UNLIM),
-		uint32(common.MAV_CMD_NAV_LOITER_TURNS),
-		uint32(common.MAV_CMD_NAV_LOITER_TIME),
-		uint32(common.MAV_CMD_NAV_RETURN_TO_LAUNCH),
 		uint32(common.MAV_CMD_NAV_LAND),
 		uint32(common.MAV_CMD_NAV_TAKEOFF):
 		return true
@@ -73,7 +59,27 @@ func isPositiveZero(value float64) bool {
 // exactly match the mission binding. Concurrent exact attempts coalesce,
 // terminal results replay, and retryable Agent outcomes may start one new
 // delivery on the original stream binding. A command ID may never identify a
-// different payload.
+// different payload. Relay forwards an expired command because its in-memory
+// retention may have been lost during restart; only an Agent with a matching
+// durable uncertain record may reconcile it by readback. The Agent must reject
+// a first expired effect and must not replace an expired mission after a
+// mismatching recovery readback.
+//
+// Parameters:
+//   - ctx: authenticates the control caller, bounds admission and result waiting,
+//     and may detach without canceling an already admitted stream delivery.
+//   - req: identifies the connected Agent and carries the immutable, bound
+//     command. Relay clones the command before asynchronous delivery.
+//
+// Returns:
+//   - *pb.DeployMissionResponse: the correlated Agent result, including terminal,
+//     retryable, and outcome-unknown application statuses.
+//   - error: reports authorization or canonical-plan validation failure, mapping
+//     or operation-context mismatch, missing/replaced session, command-ID payload
+//     conflict, retention exhaustion, stream delivery failure, malformed Agent
+//     evidence, or caller/Relay wait timeout. An RPC error after admission leaves
+//     the effect uncertain and requires an exact retry with the same command ID
+//     and payload.
 func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest) (*pb.DeployMissionResponse, error) {
 	if err := s.authorizeControlMutation(ctx); err != nil {
 		return nil, err
@@ -241,6 +247,9 @@ func validateDeployMissionCommand(command *agentv1.DeployMissionCommand) error {
 		if item.GetCurrent() {
 			return status.Errorf(codes.InvalidArgument, "mission item %d sets reserved current flag", i)
 		}
+		if !item.GetAutocontinue() {
+			return status.Errorf(codes.InvalidArgument, "mission item %d must enable autocontinue", i)
+		}
 		if !isPositiveZero(item.GetParam1()) || !isPositiveZero(item.GetParam2()) || !isPositiveZero(item.GetParam3()) {
 			return status.Errorf(codes.InvalidArgument, "mission item %d params 1 through 3 must be positive zero", i)
 		}
@@ -263,11 +272,19 @@ func validateDeployMissionCommand(command *agentv1.DeployMissionCommand) error {
 		if item.GetLatitudeE7() < -900000000 || item.GetLatitudeE7() > 900000000 || item.GetLongitudeE7() < -1800000000 || item.GetLongitudeE7() > 1800000000 {
 			return status.Errorf(codes.InvalidArgument, "mission item %d has invalid coordinates", i)
 		}
-		values := []float64{item.GetParam1(), item.GetParam2(), item.GetParam3(), item.GetParam4(), item.GetAltitudeM()}
+		values := []float64{item.GetParam1(), item.GetParam2(), item.GetParam3(), item.GetParam4(), float64(item.GetAltitudeM())}
 		for _, value := range values {
 			if math.IsNaN(value) || math.IsInf(value, 0) {
 				return status.Errorf(codes.InvalidArgument, "mission item %d contains a non-finite value", i)
 			}
+		}
+		altitudeCM := math.Round(float64(item.GetAltitudeM()) * 100)
+		if altitudeCM < -8388608 || altitudeCM > 8388607 {
+			return status.Errorf(codes.InvalidArgument, "mission item %d altitude must round-trip through ArduPilot signed-centimeter storage", i)
+		}
+		altitudeReadback := float32(int32(altitudeCM)) / 100
+		if math.Float32bits(altitudeReadback) != math.Float32bits(item.GetAltitudeM()) {
+			return status.Errorf(codes.InvalidArgument, "mission item %d altitude must round-trip through ArduPilot signed-centimeter storage", i)
 		}
 	}
 	digest, err := missionPlanDigest(plan)
@@ -297,7 +314,6 @@ func beginMissionDeployment(session *DroneSession, command *agentv1.DeployMissio
 	session.sessionMu.RLock()
 	currentStream := session.stream
 	session.sessionMu.RUnlock()
-	var recoveringOutcome bool
 	if existing := session.missionDeployments[command.GetCommandId()]; existing != nil {
 		if existing.fingerprint != fingerprint {
 			session.pendingMu.Unlock()
@@ -310,14 +326,8 @@ func beginMissionDeployment(session *DroneSession, command *agentv1.DeployMissio
 			session.controlStreamMu.RUnlock()
 			return existing, false, nil
 		}
-		recoveringOutcome = existing.result.GetStatus() == agentv1.MissionDeploymentResult_STATUS_OUTCOME_UNKNOWN
 	}
 	now := time.Now()
-	if now.UnixMilli() >= command.GetExpiresAtUnixMs() && !recoveringOutcome {
-		session.pendingMu.Unlock()
-		session.controlStreamMu.RUnlock()
-		return nil, false, status.Error(codes.DeadlineExceeded, "mission command has expired")
-	}
 	if command.GetIssuedAtUnixMs() > now.Add(maxMissionClockSkew).UnixMilli() {
 		session.pendingMu.Unlock()
 		session.controlStreamMu.RUnlock()

--- a/internal/relay/mission_deployment.go
+++ b/internal/relay/mission_deployment.go
@@ -668,9 +668,15 @@ func beginMissionDeployment(ctx context.Context, session *DroneSession, command 
 	go func() {
 		defer session.ownershipMu.RUnlock()
 		defer session.controlStreamMu.RUnlock()
-		attempted, sendErr := sendToSessionWithWritePolicy(deliveryCtx, session, &agentv1.RelayStreamMessage{
+		attempted, sendErr := sendToSessionWithWritePolicyAndFinish(deliveryCtx, session, &agentv1.RelayStreamMessage{
 			Payload: &agentv1.RelayStreamMessage_DeployMission{DeployMission: cloned},
-		}, true)
+		}, true, func() {
+			session.pendingMu.Lock()
+			if session.missionDeployments[cloned.GetCommandId()] == state && !state.completed {
+				state.resultAdmissionOpen = true
+			}
+			session.pendingMu.Unlock()
+		})
 		session.pendingMu.Lock()
 		if session.missionDeployments[cloned.GetCommandId()] == state && !state.completed {
 			// Any invoked Send is outcome-uncertain: the peer can apply the

--- a/internal/relay/mission_deployment.go
+++ b/internal/relay/mission_deployment.go
@@ -372,10 +372,14 @@ func attachMissionDeployment(waitCtx context.Context, session *DroneSession, com
 		// cross-operation gate. Concurrent exact retries attach to this shared
 		// state even if the next Agent result arrives before the gate is released.
 		cloned := proto.Clone(command).(*agentv1.DeployMissionCommand)
+		admission, registered := newMissionAdmission(waitCtx)
+		if !registered {
+			return nil, false, false, status.FromContextError(waitCtx.Err()).Err()
+		}
 		reserved := &missionDeploymentState{
 			fingerprint: fingerprint, command: cloned, deliveryStream: currentStream,
 			done: make(chan struct{}), waiters: 1, reserved: true,
-			admission: newMissionAdmission(waitCtx),
+			admission: admission,
 		}
 		session.missionDeployments[command.GetCommandId()] = reserved
 		return reserved, false, true, nil
@@ -387,11 +391,14 @@ func attachMissionDeployment(waitCtx context.Context, session *DroneSession, com
 	return existing, true, false, nil
 }
 
-func newMissionAdmission(waiterCtx context.Context) *missionAdmission {
-	ctx, cancel := context.WithTimeout(context.Background(), maxMissionDeploymentWait)
+func newMissionAdmission(waiterCtx context.Context) (*missionAdmission, bool) {
+	ctx, cancel := context.WithCancel(context.Background())
 	admission := &missionAdmission{ctx: ctx, cancel: cancel}
-	admission.add(waiterCtx)
-	return admission
+	if !admission.add(waiterCtx) {
+		cancel()
+		return nil, false
+	}
+	return admission, true
 }
 
 func (a *missionAdmission) add(waiterCtx context.Context) bool {

--- a/internal/relay/mission_deployment.go
+++ b/internal/relay/mission_deployment.go
@@ -111,7 +111,9 @@ func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest)
 	if session == nil {
 		return nil, status.Error(codes.NotFound, "agent is not connected")
 	}
-	release, err := acquireOperationCommandSlot(ctx, session)
+	waitCtx, cancel := context.WithTimeout(ctx, maxMissionDeploymentWait)
+	defer cancel()
+	release, err := acquireOperationCommandSlot(waitCtx, session)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +161,7 @@ func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest)
 			session.ownershipMu.RUnlock()
 			return nil, status.Error(codes.FailedPrecondition, "mission binding does not match the reconciled Agent operation context")
 		}
-		state, owner, err = beginMissionDeployment(ctx, session, command)
+		state, owner, err = beginMissionDeployment(waitCtx, session, command)
 		if err != nil {
 			session.ownershipMu.RUnlock()
 			relayMissionDeploymentsTotal.WithLabelValues("delivery_failed").Inc()
@@ -183,8 +185,6 @@ func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest)
 		)
 	}
 
-	waitCtx, cancel := context.WithTimeout(ctx, maxMissionDeploymentWait)
-	defer cancel()
 	select {
 	case <-state.done:
 		result, err := takeMissionDeploymentResult(session, state)

--- a/internal/relay/mission_deployment.go
+++ b/internal/relay/mission_deployment.go
@@ -730,8 +730,18 @@ func validateMissionDeploymentResult(command *agentv1.DeployMissionCommand, resu
 		return status.Error(codes.Internal, "agent returned a mission result without completion time")
 	}
 	if result.GetStatus() == agentv1.MissionDeploymentResult_STATUS_APPLIED || result.GetStatus() == agentv1.MissionDeploymentResult_STATUS_ALREADY_APPLIED {
-		if result.GetOnboardMissionDigest() != command.GetBinding().GetMissionDigest() || int(result.GetUploadedItemCount()) != len(command.GetPlan().GetItems()) {
+		if result.GetOnboardMissionDigest() != command.GetBinding().GetMissionDigest() {
 			return status.Error(codes.Internal, "agent success result does not prove the expected onboard mission")
+		}
+	}
+	switch result.GetStatus() {
+	case agentv1.MissionDeploymentResult_STATUS_APPLIED:
+		if int(result.GetUploadedItemCount()) != len(command.GetPlan().GetItems()) {
+			return status.Error(codes.Internal, "agent applied result does not report the canonical uploaded item count")
+		}
+	case agentv1.MissionDeploymentResult_STATUS_ALREADY_APPLIED:
+		if result.GetUploadedItemCount() != 0 {
+			return status.Error(codes.Internal, "agent already-applied result ambiguously reports newly uploaded items")
 		}
 	}
 	return nil

--- a/internal/relay/mission_deployment.go
+++ b/internal/relay/mission_deployment.go
@@ -385,7 +385,33 @@ func attachMissionDeployment(waitCtx context.Context, session *DroneSession, com
 		return reserved, false, true, nil
 	}
 	if existing.reserved && existing.admission != nil {
-		existing.admission.add(waitCtx)
+		if existing.admission.add(waitCtx) {
+			existing.waiters++
+			return existing, true, false, nil
+		}
+		// The last waiter can close the admission controller before its RPC
+		// decrements state.waiters. A fresh exact retry must not attach to that
+		// doomed generation. Supersede it while pendingMu still makes the map
+		// transition atomic; the old reservation worker is fenced by identity in
+		// beginMissionDeployment and cannot activate or join the replacement.
+		admission, registered := newMissionAdmission(waitCtx)
+		if !registered {
+			return nil, false, false, status.FromContextError(waitCtx.Err()).Err()
+		}
+		existing.err = status.Error(codes.Canceled, "mission retry admission closed before a live waiter attached")
+		existing.admissionFailed = true
+		existing.completed = true
+		existing.completedAt = time.Now()
+		existing.admission.cancel()
+		close(existing.done)
+		cloned := proto.Clone(command).(*agentv1.DeployMissionCommand)
+		replacement := &missionDeploymentState{
+			fingerprint: fingerprint, command: cloned, deliveryStream: currentStream,
+			done: make(chan struct{}), waiters: 1, reserved: true,
+			admission: admission,
+		}
+		session.missionDeployments[command.GetCommandId()] = replacement
+		return replacement, false, true, nil
 	}
 	existing.waiters++
 	return existing, true, false, nil
@@ -573,6 +599,14 @@ func beginMissionDeployment(ctx context.Context, session *DroneSession, command 
 			session.pendingMu.Unlock()
 			session.controlStreamMu.RUnlock()
 			return nil, false, status.Error(codes.AlreadyExists, "mission command ID was already used with a different payload")
+		}
+		if reservation != nil && existing != reservation {
+			// A live waiter superseded this closing pre-admission generation. The
+			// old worker must only release the gate; it is not a waiter on, and may
+			// not activate, the replacement generation.
+			session.pendingMu.Unlock()
+			session.controlStreamMu.RUnlock()
+			return nil, false, status.Error(codes.Canceled, "mission retry admission was superseded")
 		}
 		if existing == reservation && existing.reserved && !existing.completed {
 			// The caller owns this pre-gate delivery reservation. Activate the same

--- a/internal/relay/mission_deployment.go
+++ b/internal/relay/mission_deployment.go
@@ -232,6 +232,9 @@ func validateDeployMissionCommand(command *agentv1.DeployMissionCommand) error {
 		if item.GetSequence() != uint32(i) {
 			return status.Errorf(codes.InvalidArgument, "mission item %d has non-contiguous sequence", i)
 		}
+		if item.GetCurrent() {
+			return status.Errorf(codes.InvalidArgument, "mission item %d sets reserved current flag", i)
+		}
 		if !isSupportedMissionFrame(item.GetFrame()) {
 			return status.Errorf(codes.InvalidArgument, "mission item %d uses unsupported frame %d", i, item.GetFrame())
 		}

--- a/internal/relay/mission_deployment.go
+++ b/internal/relay/mission_deployment.go
@@ -159,7 +159,7 @@ func (s *Relay) DeployMission(ctx context.Context, req *pb.DeployMissionRequest)
 			session.ownershipMu.RUnlock()
 			return nil, status.Error(codes.FailedPrecondition, "mission binding does not match the reconciled Agent operation context")
 		}
-		state, owner, err = beginMissionDeployment(session, command)
+		state, owner, err = beginMissionDeployment(ctx, session, command)
 		if err != nil {
 			session.ownershipMu.RUnlock()
 			relayMissionDeploymentsTotal.WithLabelValues("delivery_failed").Inc()
@@ -356,7 +356,7 @@ func validateDeployMissionCommand(command *agentv1.DeployMissionCommand) error {
 	return nil
 }
 
-func beginMissionDeployment(session *DroneSession, command *agentv1.DeployMissionCommand) (*missionDeploymentState, bool, error) {
+func beginMissionDeployment(ctx context.Context, session *DroneSession, command *agentv1.DeployMissionCommand) (*missionDeploymentState, bool, error) {
 	fingerprint, err := missionDeploymentFingerprint(command)
 	if err != nil {
 		return nil, false, err
@@ -388,6 +388,11 @@ func beginMissionDeployment(session *DroneSession, command *agentv1.DeployMissio
 			return existing, false, nil
 		}
 	}
+	if err := ctx.Err(); err != nil {
+		session.pendingMu.Unlock()
+		session.controlStreamMu.RUnlock()
+		return nil, false, status.FromContextError(err).Err()
+	}
 	now := time.Now()
 	if command.GetIssuedAtUnixMs() > now.Add(maxMissionClockSkew).UnixMilli() {
 		session.pendingMu.Unlock()
@@ -407,6 +412,11 @@ func beginMissionDeployment(session *DroneSession, command *agentv1.DeployMissio
 		session.pendingMu.Unlock()
 		session.controlStreamMu.RUnlock()
 		return nil, false, status.Error(codes.ResourceExhausted, "mission deployment retention is full")
+	}
+	if err := ctx.Err(); err != nil {
+		session.pendingMu.Unlock()
+		session.controlStreamMu.RUnlock()
+		return nil, false, status.FromContextError(err).Err()
 	}
 	deliveryCtx, deliveryCancel := context.WithCancel(context.Background())
 	cloned := proto.Clone(command).(*agentv1.DeployMissionCommand)

--- a/internal/relay/mission_deployment_test.go
+++ b/internal/relay/mission_deployment_test.go
@@ -97,6 +97,10 @@ func TestDeployMissionValidatesCanonicalPlanAndBinding(t *testing.T) {
 			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[0].Sequence = 1 },
 			code:   codes.InvalidArgument,
 		},
+		"dynamic current flag": {
+			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[0].Current = true },
+			code:   codes.InvalidArgument,
+		},
 		"too many items": {
 			mutate: func(c *agentv1.DeployMissionCommand) {
 				c.Plan.Items = make([]*agentv1.MissionItem, maxMissionItems+1)

--- a/internal/relay/mission_deployment_test.go
+++ b/internal/relay/mission_deployment_test.go
@@ -79,6 +79,51 @@ func TestDeployMissionDeliversOnceAndRetainsCorrelatedResult(t *testing.T) {
 	}
 }
 
+func TestDeployMissionReplaysRetainedTerminalResultAfterContextAdvances(t *testing.T) {
+	relay, session, stream := testMissionRelay(t)
+	command := testMissionCommand(t)
+	request := &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command}
+	completed := make(chan error, 1)
+	go func() {
+		_, err := relay.DeployMission(context.Background(), request)
+		completed <- err
+	}()
+	<-stream.sentAckChan
+	result := testAppliedMissionResult(command)
+	session.handleMissionDeploymentResult(result)
+	if err := <-completed; err != nil {
+		t.Fatal(err)
+	}
+
+	session.sessionMu.Lock()
+	session.FlightID = "flight-2"
+	session.IntentID = "intent-2"
+	session.IntentVersion = 4
+	session.sessionMu.Unlock()
+
+	replayed, err := relay.DeployMission(context.Background(), request)
+	if err != nil || !proto.Equal(replayed.GetResult(), result) {
+		t.Fatalf("retained replay after context advance = %+v, %v", replayed, err)
+	}
+	select {
+	case message := <-stream.sentAckChan:
+		t.Fatalf("retained replay redelivered after context advance: %+v", message)
+	default:
+	}
+
+	newCommand := proto.Clone(command).(*agentv1.DeployMissionCommand)
+	newCommand.CommandId = "deploy-command-2"
+	_, err = relay.DeployMission(context.Background(), &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: newCommand})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("new delivery with stale context error = %v, want FailedPrecondition", err)
+	}
+	select {
+	case message := <-stream.sentAckChan:
+		t.Fatalf("new delivery bypassed active-context fence: %+v", message)
+	default:
+	}
+}
+
 func TestDeployMissionTemporaryErrorRetryRedispatchesOnceThenApplies(t *testing.T) {
 	relay, session, stream := testMissionRelay(t)
 	command := testMissionCommand(t)
@@ -150,6 +195,43 @@ func TestDeployMissionTemporaryErrorRetryRedispatchesOnceThenApplies(t *testing.
 	select {
 	case duplicate := <-stream.sentAckChan:
 		t.Fatalf("terminal replay redelivered: %+v", duplicate)
+	default:
+	}
+}
+
+func TestDeployMissionRetryableResultRequiresCurrentContextBeforeRedispatch(t *testing.T) {
+	relay, session, stream := testMissionRelay(t)
+	command := testMissionCommand(t)
+	request := &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command}
+	completed := make(chan error, 1)
+	go func() {
+		_, err := relay.DeployMission(context.Background(), request)
+		completed <- err
+	}()
+	<-stream.sentAckChan
+	temporary := &agentv1.MissionDeploymentResult{
+		CommandId: command.GetCommandId(), Binding: proto.Clone(command.GetBinding()).(*agentv1.MissionBinding),
+		Status: agentv1.MissionDeploymentResult_STATUS_TEMPORARY_ERROR, Message: "retry later",
+		CompletedAtUnixMs: time.Now().UnixMilli(),
+	}
+	session.handleMissionDeploymentResult(temporary)
+	if err := <-completed; err != nil {
+		t.Fatal(err)
+	}
+
+	session.sessionMu.Lock()
+	session.FlightID = "flight-2"
+	session.IntentID = "intent-2"
+	session.IntentVersion = 4
+	session.sessionMu.Unlock()
+
+	_, err := relay.DeployMission(context.Background(), request)
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("retryable redispatch with stale context error = %v, want FailedPrecondition", err)
+	}
+	select {
+	case message := <-stream.sentAckChan:
+		t.Fatalf("retryable result was redispatched with stale context: %+v", message)
 	default:
 	}
 }

--- a/internal/relay/mission_deployment_test.go
+++ b/internal/relay/mission_deployment_test.go
@@ -380,12 +380,32 @@ func TestCommandIDCannotBeReusedAcrossCommandKinds(t *testing.T) {
 			case retainedMissionDeployment:
 				command := testMissionCommand(t)
 				command.CommandId = commandID
-				_, _, err = beginMissionDeployment(session, command)
+				_, _, err = beginMissionDeployment(context.Background(), session, command)
 			}
 			if status.Code(err) != codes.AlreadyExists {
 				t.Fatalf("cross-kind admission error = %v, want AlreadyExists", err)
 			}
 		})
+	}
+}
+
+func TestBeginMissionDeploymentRejectsCanceledAdmission(t *testing.T) {
+	_, session, stream := testMissionRelay(t)
+	command := testMissionCommand(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	state, owner, err := beginMissionDeployment(ctx, session, command)
+	if status.Code(err) != codes.Canceled || state != nil || owner {
+		t.Fatalf("canceled admission = (%+v, %v, %v), want (nil, false, Canceled)", state, owner, err)
+	}
+	if session.missionDeployments[command.GetCommandId()] != nil {
+		t.Fatal("canceled request retained a mission deployment state")
+	}
+	select {
+	case message := <-stream.sentAckChan:
+		t.Fatalf("canceled request delivered a mission: %+v", message)
+	default:
 	}
 }
 

--- a/internal/relay/mission_deployment_test.go
+++ b/internal/relay/mission_deployment_test.go
@@ -373,6 +373,87 @@ func testDeployMissionConcurrentRetryableGenerationRedispatchesOnce(t *testing.T
 	}
 }
 
+func TestDeployMissionIgnoresPriorAttemptResultWhileRetryIsReserved(t *testing.T) {
+	relay, session, stream := testMissionRelay(t)
+	command := testMissionCommand(t)
+	request := &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command}
+	type outcome struct {
+		response *relayv1.DeployMissionResponse
+		err      error
+	}
+
+	initial := make(chan outcome, 1)
+	go func() {
+		response, err := relay.DeployMission(context.Background(), request)
+		initial <- outcome{response: response, err: err}
+	}()
+	<-stream.sentAckChan
+	temporary := &agentv1.MissionDeploymentResult{
+		CommandId: command.GetCommandId(), Binding: proto.Clone(command.GetBinding()).(*agentv1.MissionBinding),
+		Status: agentv1.MissionDeploymentResult_STATUS_TEMPORARY_ERROR, CompletedAtUnixMs: time.Now().UnixMilli(),
+	}
+	session.handleMissionDeploymentResult(temporary)
+	if got := <-initial; got.err != nil || !proto.Equal(got.response.GetResult(), temporary) {
+		t.Fatalf("initial temporary result = %+v, %v", got.response, got.err)
+	}
+
+	release, err := acquireOperationCommandSlot(context.Background(), session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	retried := make(chan outcome, 1)
+	go func() {
+		response, err := relay.DeployMission(context.Background(), request)
+		retried <- outcome{response: response, err: err}
+	}()
+	deadline := time.Now().Add(time.Second)
+	for {
+		session.pendingMu.Lock()
+		state := session.missionDeployments[command.GetCommandId()]
+		reserved := state != nil && state.reserved && !state.completed
+		session.pendingMu.Unlock()
+		if reserved {
+			break
+		}
+		if time.Now().After(deadline) {
+			release()
+			t.Fatal("exact retry did not reserve a generation behind the busy gate")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// A delayed terminal result from the preceding attempt is valid for the
+	// same command ID, but it must not complete a generation that has not yet
+	// passed retry admission or been delivered.
+	stale := testAppliedMissionResult(command)
+	session.handleMissionDeploymentResult(stale)
+	session.pendingMu.Lock()
+	state := session.missionDeployments[command.GetCommandId()]
+	ignored := state != nil && state.reserved && !state.completed && state.result == nil
+	session.pendingMu.Unlock()
+	if !ignored {
+		release()
+		t.Fatal("prior-attempt result completed the reserved retry generation")
+	}
+	select {
+	case got := <-retried:
+		release()
+		t.Fatalf("reserved retry completed from prior-attempt evidence: %+v, %v", got.response, got.err)
+	default:
+	}
+
+	release()
+	if message := <-stream.sentAckChan; !proto.Equal(message.GetDeployMission(), command) {
+		t.Fatalf("admitted retry delivered = %+v, want %+v", message.GetDeployMission(), command)
+	}
+	fresh := testAppliedMissionResult(command)
+	fresh.Message = "fresh generation"
+	session.handleMissionDeploymentResult(fresh)
+	if got := <-retried; got.err != nil || !proto.Equal(got.response.GetResult(), fresh) {
+		t.Fatalf("admitted retry result = %+v, %v", got.response, got.err)
+	}
+}
+
 func TestDeployMissionFailedRetryReservationCanBeRetried(t *testing.T) {
 	relay, session, stream := testMissionRelay(t)
 	command := testMissionCommand(t)

--- a/internal/relay/mission_deployment_test.go
+++ b/internal/relay/mission_deployment_test.go
@@ -425,6 +425,69 @@ func TestDeployMissionFailedRetryReservationCanBeRetried(t *testing.T) {
 	}
 }
 
+func TestDeployMissionRejectsCanceledRetryReservation(t *testing.T) {
+	relay, session, stream := testMissionRelay(t)
+	command := testMissionCommand(t)
+	request := &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command}
+	completed := make(chan error, 1)
+	go func() {
+		_, err := relay.DeployMission(context.Background(), request)
+		completed <- err
+	}()
+	<-stream.sentAckChan
+	temporary := &agentv1.MissionDeploymentResult{
+		CommandId: command.GetCommandId(), Binding: proto.Clone(command.GetBinding()).(*agentv1.MissionBinding),
+		Status: agentv1.MissionDeploymentResult_STATUS_TEMPORARY_ERROR, CompletedAtUnixMs: time.Now().UnixMilli(),
+	}
+	session.handleMissionDeploymentResult(temporary)
+	if err := <-completed; err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := relay.DeployMission(ctx, request)
+	if status.Code(err) != codes.Canceled {
+		t.Fatalf("canceled retry reservation = %v, want Canceled", err)
+	}
+	select {
+	case duplicate := <-stream.sentAckChan:
+		t.Fatalf("canceled retry reservation delivered a mission: %+v", duplicate)
+	default:
+	}
+	session.pendingMu.Lock()
+	state := session.missionDeployments[command.GetCommandId()]
+	stillRetained := state != nil && state.completed && !state.reserved && proto.Equal(state.result, temporary)
+	session.pendingMu.Unlock()
+	if !stillRetained {
+		t.Fatal("canceled retry replaced the retained retryable result")
+	}
+}
+
+func TestMissionAdmissionUsesEveryWaiterWindow(t *testing.T) {
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	admission, registered := newMissionAdmission(firstCtx)
+	if !registered {
+		t.Fatal("first live waiter was not registered")
+	}
+	secondCtx, cancelSecond := context.WithCancel(context.Background())
+	if !admission.add(secondCtx) {
+		t.Fatal("second live waiter was not registered")
+	}
+	cancelFirst()
+	select {
+	case <-admission.ctx.Done():
+		t.Fatal("first waiter cancellation ended the later waiter's admission window")
+	case <-time.After(20 * time.Millisecond):
+	}
+	cancelSecond()
+	select {
+	case <-admission.ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("admission remained live after its last waiter ended")
+	}
+}
+
 func TestDeployMissionRetryReservationSurvivesOneCallerDeadline(t *testing.T) {
 	relay, session, stream := testMissionRelay(t)
 	command := testMissionCommand(t)

--- a/internal/relay/mission_deployment_test.go
+++ b/internal/relay/mission_deployment_test.go
@@ -373,7 +373,7 @@ func testDeployMissionConcurrentRetryableGenerationRedispatchesOnce(t *testing.T
 	}
 }
 
-func TestDeployMissionIgnoresPriorAttemptResultUntilRetrySendReturns(t *testing.T) {
+func TestDeployMissionCommitsSendBeforeAcceptingRetryResults(t *testing.T) {
 	relay, session, stream := testMissionRelay(t)
 	command := testMissionCommand(t)
 	request := &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command}
@@ -477,7 +477,7 @@ func TestDeployMissionIgnoresPriorAttemptResultUntilRetrySendReturns(t *testing.
 	ignored = state != nil && !state.resultAdmissionOpen && !state.completed && state.result == nil
 	session.pendingMu.Unlock()
 	if !ignored {
-		t.Fatal("prior-attempt result completed the retry before its stream Send returned")
+		t.Fatal("prior-attempt result completed the retry before effect-start commit")
 	}
 	select {
 	case got := <-retried:
@@ -485,30 +485,36 @@ func TestDeployMissionIgnoresPriorAttemptResultUntilRetrySendReturns(t *testing.
 	default:
 	}
 
+	// Simulate an Agent that responds from inside Send. Effect-start commit has
+	// already opened command-level evidence, but completing the state cancels
+	// deliveryCtx. Send must still run to completion exactly once.
+	fresh := testAppliedMissionResult(command)
+	fresh.Message = "fast current generation"
+	resultHandledDuringSend := make(chan struct{}, 1)
+	stream.sendHook = func(message *agentv1.RelayStreamMessage) {
+		if message.GetDeployMission() == nil {
+			return
+		}
+		session.handleMissionDeploymentResult(fresh)
+		resultHandledDuringSend <- struct{}{}
+	}
 	deliveryStream.sendMu.Unlock()
 	sendLocked = false
 	if message := <-stream.sentAckChan; !proto.Equal(message.GetDeployMission(), command) {
 		t.Fatalf("admitted retry delivered = %+v, want %+v", message.GetDeployMission(), command)
 	}
-	deadline = time.Now().Add(time.Second)
-	for {
-		session.pendingMu.Lock()
-		state = session.missionDeployments[command.GetCommandId()]
-		deliveryFinished := state != nil && state.resultAdmissionOpen && !state.completed
-		session.pendingMu.Unlock()
-		if deliveryFinished {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("retry stream Send did not finish")
-		}
-		time.Sleep(time.Millisecond)
+	select {
+	case <-resultHandledDuringSend:
+	default:
+		t.Fatal("fast current result was not accepted at command effect start")
 	}
-	fresh := testAppliedMissionResult(command)
-	fresh.Message = "fresh generation"
-	session.handleMissionDeploymentResult(fresh)
 	if got := <-retried; got.err != nil || !proto.Equal(got.response.GetResult(), fresh) {
 		t.Fatalf("admitted retry result = %+v, %v", got.response, got.err)
+	}
+	select {
+	case duplicate := <-stream.sentAckChan:
+		t.Fatalf("effect-start result caused an extra delivery: %+v", duplicate)
+	default:
 	}
 }
 

--- a/internal/relay/mission_deployment_test.go
+++ b/internal/relay/mission_deployment_test.go
@@ -373,7 +373,7 @@ func testDeployMissionConcurrentRetryableGenerationRedispatchesOnce(t *testing.T
 	}
 }
 
-func TestDeployMissionIgnoresPriorAttemptResultWhileRetryIsReserved(t *testing.T) {
+func TestDeployMissionIgnoresPriorAttemptResultUntilRetrySendReturns(t *testing.T) {
 	relay, session, stream := testMissionRelay(t)
 	command := testMissionCommand(t)
 	request := &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command}
@@ -442,9 +442,67 @@ func TestDeployMissionIgnoresPriorAttemptResultWhileRetryIsReserved(t *testing.T
 	default:
 	}
 
+	session.sessionMu.RLock()
+	deliveryStream := session.stream
+	session.sessionMu.RUnlock()
+	if err := deliveryStream.sendMu.Lock(context.Background()); err != nil {
+		release()
+		t.Fatal(err)
+	}
+	sendLocked := true
+	defer func() {
+		if sendLocked {
+			deliveryStream.sendMu.Unlock()
+		}
+	}()
 	release()
+
+	deadline = time.Now().Add(time.Second)
+	for {
+		session.pendingMu.Lock()
+		state = session.missionDeployments[command.GetCommandId()]
+		waitingForSend := state != nil && !state.reserved && !state.resultAdmissionOpen && !state.completed
+		session.pendingMu.Unlock()
+		if waitingForSend {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("retry did not activate while its stream send remained blocked")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	session.handleMissionDeploymentResult(stale)
+	session.pendingMu.Lock()
+	state = session.missionDeployments[command.GetCommandId()]
+	ignored = state != nil && !state.resultAdmissionOpen && !state.completed && state.result == nil
+	session.pendingMu.Unlock()
+	if !ignored {
+		t.Fatal("prior-attempt result completed the retry before its stream Send returned")
+	}
+	select {
+	case got := <-retried:
+		t.Fatalf("pre-send retry completed from prior-attempt evidence: %+v, %v", got.response, got.err)
+	default:
+	}
+
+	deliveryStream.sendMu.Unlock()
+	sendLocked = false
 	if message := <-stream.sentAckChan; !proto.Equal(message.GetDeployMission(), command) {
 		t.Fatalf("admitted retry delivered = %+v, want %+v", message.GetDeployMission(), command)
+	}
+	deadline = time.Now().Add(time.Second)
+	for {
+		session.pendingMu.Lock()
+		state = session.missionDeployments[command.GetCommandId()]
+		deliveryFinished := state != nil && state.resultAdmissionOpen && !state.completed
+		session.pendingMu.Unlock()
+		if deliveryFinished {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("retry stream Send did not finish")
+		}
+		time.Sleep(time.Millisecond)
 	}
 	fresh := testAppliedMissionResult(command)
 	fresh.Message = "fresh generation"

--- a/internal/relay/mission_deployment_test.go
+++ b/internal/relay/mission_deployment_test.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"context"
+	"encoding/hex"
 	"math"
 	"strings"
 	"testing"
@@ -9,6 +10,7 @@ import (
 
 	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
 	relayv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
+	"github.com/aero-arc/aero-arc-protos/missiondigest"
 	"github.com/bluenviron/gomavlib/v2/pkg/dialects/common"
 	"github.com/makinje/aero-arc-relay/internal/config"
 	"google.golang.org/grpc/codes"
@@ -240,7 +242,7 @@ func TestDeployMissionValidatesCanonicalPlanAndBinding(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			command := proto.Clone(valid).(*agentv1.DeployMissionCommand)
 			tt.mutate(command)
-			if name != "digest mismatch" {
+			if name != "digest mismatch" && name != "too many items" {
 				digest, err := missionPlanDigest(command.GetPlan())
 				if err != nil {
 					t.Fatal(err)
@@ -251,6 +253,25 @@ func TestDeployMissionValidatesCanonicalPlanAndBinding(t *testing.T) {
 				t.Fatalf("validateDeployMissionCommand() = %v, want %v", err, tt.code)
 			}
 		})
+	}
+}
+
+func TestMissionPlanCanonicalV1MatchesContractGoldenVector(t *testing.T) {
+	plan := &agentv1.MissionPlan{SchemaVersion: 1, Items: []*agentv1.MissionItem{{
+		Sequence: 0, Frame: 0, Command: 16, Current: false, Autocontinue: true,
+		LatitudeE7: -353632620, LongitudeE7: 1491652370, AltitudeM: 20.1,
+	}}}
+	canonical, err := missiondigest.CanonicalBytes(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const wantCanonicalHex = "6165726f6172632d6d697373696f6e2d706c616e2d7631000000000100000000000000000000001000010000000000000000000000000000000000000000000000000000000000000000eaebfe9458e8cf1241a0cccd"
+	if got := hex.EncodeToString(canonical); got != wantCanonicalHex {
+		t.Fatalf("canonical bytes = %q, want %q", got, wantCanonicalHex)
+	}
+	const wantDigest = "6efa96b36af29a800d53ee7d7baf57d4b24f00d9ce2b408327281e74824acf4f"
+	if got, err := missionPlanDigest(plan); err != nil || got != wantDigest {
+		t.Fatalf("missionPlanDigest() = %q, %v, want %q", got, err, wantDigest)
 	}
 }
 

--- a/internal/relay/mission_deployment_test.go
+++ b/internal/relay/mission_deployment_test.go
@@ -290,6 +290,141 @@ func TestDeployMissionTemporaryErrorRetryRedispatchesOnceThenApplies(t *testing.
 	}
 }
 
+func TestDeployMissionConcurrentRetryableGenerationRedispatchesOnce(t *testing.T) {
+	tests := map[string]agentv1.MissionDeploymentResult_Status{
+		"temporary error": agentv1.MissionDeploymentResult_STATUS_TEMPORARY_ERROR,
+		"outcome unknown": agentv1.MissionDeploymentResult_STATUS_OUTCOME_UNKNOWN,
+	}
+	for name, resultStatus := range tests {
+		t.Run(name, func(t *testing.T) {
+			testDeployMissionConcurrentRetryableGenerationRedispatchesOnce(t, resultStatus)
+		})
+	}
+}
+
+func testDeployMissionConcurrentRetryableGenerationRedispatchesOnce(t *testing.T, resultStatus agentv1.MissionDeploymentResult_Status) {
+	t.Helper()
+	relay, session, stream := testMissionRelay(t)
+	command := testMissionCommand(t)
+	request := &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command}
+	type outcome struct {
+		response *relayv1.DeployMissionResponse
+		err      error
+	}
+
+	first := make(chan outcome, 1)
+	go func() {
+		response, err := relay.DeployMission(context.Background(), request)
+		first <- outcome{response: response, err: err}
+	}()
+	<-stream.sentAckChan
+	temporary := &agentv1.MissionDeploymentResult{
+		CommandId: command.GetCommandId(), Binding: proto.Clone(command.GetBinding()).(*agentv1.MissionBinding),
+		Status: resultStatus, Message: "retry together",
+		CompletedAtUnixMs: time.Now().UnixMilli(),
+	}
+	session.handleMissionDeploymentResult(temporary)
+	if got := <-first; got.err != nil || !proto.Equal(got.response.GetResult(), temporary) {
+		t.Fatalf("initial temporary result = %+v, %v", got.response, got.err)
+	}
+
+	release, err := acquireOperationCommandSlot(context.Background(), session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	retried := make(chan outcome, 2)
+	for range 2 {
+		go func() {
+			response, err := relay.DeployMission(context.Background(), request)
+			retried <- outcome{response: response, err: err}
+		}()
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		session.pendingMu.Lock()
+		state := session.missionDeployments[command.GetCommandId()]
+		reservedTogether := state != nil && state.reserved && state.waiters == 2
+		session.pendingMu.Unlock()
+		if reservedTogether {
+			break
+		}
+		if time.Now().After(deadline) {
+			release()
+			t.Fatal("concurrent exact retries did not share one pending generation")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	release()
+
+	if message := <-stream.sentAckChan; !proto.Equal(message.GetDeployMission(), command) {
+		t.Fatalf("retry generation delivered = %+v, want %+v", message.GetDeployMission(), command)
+	}
+	session.handleMissionDeploymentResult(temporary)
+	for range 2 {
+		got := <-retried
+		if got.err != nil || !proto.Equal(got.response.GetResult(), temporary) {
+			t.Fatalf("coalesced retryable generation = %+v, %v", got.response, got.err)
+		}
+	}
+	select {
+	case duplicate := <-stream.sentAckChan:
+		t.Fatalf("concurrent retryable generation redelivered sequentially: %+v", duplicate)
+	default:
+	}
+}
+
+func TestDeployMissionFailedRetryReservationCanBeRetried(t *testing.T) {
+	relay, session, stream := testMissionRelay(t)
+	command := testMissionCommand(t)
+	request := &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command}
+	completed := make(chan error, 1)
+	go func() {
+		_, err := relay.DeployMission(context.Background(), request)
+		completed <- err
+	}()
+	<-stream.sentAckChan
+	temporary := &agentv1.MissionDeploymentResult{
+		CommandId: command.GetCommandId(), Binding: proto.Clone(command.GetBinding()).(*agentv1.MissionBinding),
+		Status: agentv1.MissionDeploymentResult_STATUS_TEMPORARY_ERROR, CompletedAtUnixMs: time.Now().UnixMilli(),
+	}
+	session.handleMissionDeploymentResult(temporary)
+	if err := <-completed; err != nil {
+		t.Fatal(err)
+	}
+
+	release, err := acquireOperationCommandSlot(context.Background(), session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, err = relay.DeployMission(ctx, request)
+	if status.Code(err) != codes.DeadlineExceeded {
+		release()
+		t.Fatalf("reserved retry behind busy gate = %v, want DeadlineExceeded", err)
+	}
+	release()
+	select {
+	case duplicate := <-stream.sentAckChan:
+		t.Fatalf("failed retry reservation delivered a mission: %+v", duplicate)
+	default:
+	}
+
+	retried := make(chan error, 1)
+	go func() {
+		_, err := relay.DeployMission(context.Background(), request)
+		retried <- err
+	}()
+	if message := <-stream.sentAckChan; !proto.Equal(message.GetDeployMission(), command) {
+		t.Fatalf("retry after failed reservation delivered = %+v, want %+v", message.GetDeployMission(), command)
+	}
+	applied := testAppliedMissionResult(command)
+	session.handleMissionDeploymentResult(applied)
+	if err := <-retried; err != nil {
+		t.Fatalf("retry after failed reservation = %v", err)
+	}
+}
+
 func TestDeployMissionRetryableResultRequiresCurrentContextBeforeRedispatch(t *testing.T) {
 	relay, session, stream := testMissionRelay(t)
 	command := testMissionCommand(t)
@@ -471,7 +606,7 @@ func TestCommandIDCannotBeReusedAcrossCommandKinds(t *testing.T) {
 			case retainedMissionDeployment:
 				command := testMissionCommand(t)
 				command.CommandId = commandID
-				_, _, err = beginMissionDeployment(context.Background(), session, command)
+				_, _, err = beginMissionDeployment(context.Background(), session, command, nil)
 			}
 			if status.Code(err) != codes.AlreadyExists {
 				t.Fatalf("cross-kind admission error = %v, want AlreadyExists", err)
@@ -486,7 +621,7 @@ func TestBeginMissionDeploymentRejectsCanceledAdmission(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	state, owner, err := beginMissionDeployment(ctx, session, command)
+	state, owner, err := beginMissionDeployment(ctx, session, command, nil)
 	if status.Code(err) != codes.Canceled || state != nil || owner {
 		t.Fatalf("canceled admission = (%+v, %v, %v), want (nil, false, Canceled)", state, owner, err)
 	}

--- a/internal/relay/mission_deployment_test.go
+++ b/internal/relay/mission_deployment_test.go
@@ -76,6 +76,81 @@ func TestDeployMissionDeliversOnceAndRetainsCorrelatedResult(t *testing.T) {
 	}
 }
 
+func TestDeployMissionTemporaryErrorRetryRedispatchesOnceThenApplies(t *testing.T) {
+	relay, session, stream := testMissionRelay(t)
+	command := testMissionCommand(t)
+	request := &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command}
+	type outcome struct {
+		response *relayv1.DeployMissionResponse
+		err      error
+	}
+
+	first := make(chan outcome, 1)
+	go func() {
+		response, err := relay.DeployMission(context.Background(), request)
+		first <- outcome{response: response, err: err}
+	}()
+	if message := <-stream.sentAckChan; !proto.Equal(message.GetDeployMission(), command) {
+		t.Fatalf("initial delivered command = %+v, want %+v", message.GetDeployMission(), command)
+	}
+	temporary := &agentv1.MissionDeploymentResult{
+		CommandId: command.GetCommandId(), Binding: proto.Clone(command.GetBinding()).(*agentv1.MissionBinding),
+		Status: agentv1.MissionDeploymentResult_STATUS_TEMPORARY_ERROR, Message: "fresh heartbeat required",
+		CompletedAtUnixMs: time.Now().UnixMilli(),
+	}
+	session.handleMissionDeploymentResult(temporary)
+	if got := <-first; got.err != nil || !proto.Equal(got.response.GetResult(), temporary) {
+		t.Fatalf("initial temporary result = %+v, %v", got.response, got.err)
+	}
+
+	retried := make(chan outcome, 2)
+	for range 2 {
+		go func() {
+			response, err := relay.DeployMission(context.Background(), request)
+			retried <- outcome{response: response, err: err}
+		}()
+	}
+	if message := <-stream.sentAckChan; !proto.Equal(message.GetDeployMission(), command) {
+		t.Fatalf("retry delivered command = %+v, want %+v", message.GetDeployMission(), command)
+	}
+	select {
+	case duplicate := <-stream.sentAckChan:
+		t.Fatalf("concurrent exact retry redelivered: %+v", duplicate)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	uncorrelated := testAppliedMissionResult(command)
+	uncorrelated.CommandId = "another-command"
+	session.handleMissionDeploymentResult(uncorrelated)
+	select {
+	case got := <-retried:
+		t.Fatalf("uncorrelated result completed retry: %+v, %v", got.response, got.err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	applied := testAppliedMissionResult(command)
+	session.handleMissionDeploymentResult(applied)
+	for range 2 {
+		select {
+		case got := <-retried:
+			if got.err != nil || !proto.Equal(got.response.GetResult(), applied) {
+				t.Fatalf("retry result = %+v, %v", got.response, got.err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for coalesced mission retry")
+		}
+	}
+
+	replayed, err := relay.DeployMission(context.Background(), request)
+	if err != nil || !proto.Equal(replayed.GetResult(), applied) {
+		t.Fatalf("terminal replay = %+v, %v", replayed, err)
+	}
+	select {
+	case duplicate := <-stream.sentAckChan:
+		t.Fatalf("terminal replay redelivered: %+v", duplicate)
+	default:
+	}
+}
+
 func TestDeployMissionValidatesCanonicalPlanAndBinding(t *testing.T) {
 	valid := testMissionCommand(t)
 	tests := map[string]struct {
@@ -183,8 +258,8 @@ func TestDeployMissionRejectsUnsafeDeliveryWindow(t *testing.T) {
 	}
 }
 
-func TestDeployMissionCallerDeadlineRetainsOutcomeUnknown(t *testing.T) {
-	relay, _, stream := testMissionRelay(t)
+func TestDeployMissionCallerDeadlineRedispatchesOutcomeUnknownOnSameStream(t *testing.T) {
+	relay, session, stream := testMissionRelay(t)
 	command := testMissionCommand(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
@@ -197,14 +272,69 @@ func TestDeployMissionCallerDeadlineRetainsOutcomeUnknown(t *testing.T) {
 	if err := <-completed; status.Code(err) != codes.DeadlineExceeded {
 		t.Fatalf("DeployMission() = %v, want DeadlineExceeded", err)
 	}
-	retry, err := relay.DeployMission(context.Background(), &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command})
-	if err != nil || retry.GetResult().GetStatus() != agentv1.MissionDeploymentResult_STATUS_OUTCOME_UNKNOWN {
-		t.Fatalf("retry after waiter deadline = %+v, %v", retry, err)
+	type outcome struct {
+		response *relayv1.DeployMissionResponse
+		err      error
 	}
+	retried := make(chan outcome, 1)
+	go func() {
+		response, err := relay.DeployMission(context.Background(), &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command})
+		retried <- outcome{response: response, err: err}
+	}()
 	select {
 	case message := <-stream.sentAckChan:
-		t.Fatalf("deadline retry redelivered: %+v", message)
-	default:
+		if !proto.Equal(message.GetDeployMission(), command) {
+			t.Fatalf("deadline retry delivered = %+v, want %+v", message.GetDeployMission(), command)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("deadline retry was not redelivered for Agent recovery")
+	}
+	applied := testAppliedMissionResult(command)
+	applied.Status = agentv1.MissionDeploymentResult_STATUS_ALREADY_APPLIED
+	session.handleMissionDeploymentResult(applied)
+	got := <-retried
+	if got.err != nil || !proto.Equal(got.response.GetResult(), applied) {
+		t.Fatalf("retry after waiter deadline = %+v, %v", got.response, got.err)
+	}
+}
+
+func TestDeployMissionOutcomeUnknownRecoversAfterCommandExpiry(t *testing.T) {
+	relay, session, stream := testMissionRelay(t)
+	command := testMissionCommand(t)
+	command.ExpiresAtUnixMs = time.Now().Add(50 * time.Millisecond).UnixMilli()
+	request := &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command}
+	type outcome struct {
+		response *relayv1.DeployMissionResponse
+		err      error
+	}
+	first := make(chan outcome, 1)
+	go func() {
+		response, err := relay.DeployMission(context.Background(), request)
+		first <- outcome{response: response, err: err}
+	}()
+	<-stream.sentAckChan
+	unknown := uncertainMissionDeploymentResult(command, time.Now(), "upload outcome unknown")
+	session.handleMissionDeploymentResult(unknown)
+	if got := <-first; got.err != nil || got.response.GetResult().GetStatus() != agentv1.MissionDeploymentResult_STATUS_OUTCOME_UNKNOWN {
+		t.Fatalf("initial unknown result = %+v, %v", got.response, got.err)
+	}
+	time.Sleep(60 * time.Millisecond)
+	retried := make(chan outcome, 1)
+	go func() {
+		response, err := relay.DeployMission(context.Background(), request)
+		retried <- outcome{response: response, err: err}
+	}()
+	select {
+	case <-stream.sentAckChan:
+	case <-time.After(time.Second):
+		t.Fatal("expired uncertain command was not redelivered for readback recovery")
+	}
+	reconciled := testAppliedMissionResult(command)
+	reconciled.Status = agentv1.MissionDeploymentResult_STATUS_ALREADY_APPLIED
+	session.handleMissionDeploymentResult(reconciled)
+	got := <-retried
+	if got.err != nil || !proto.Equal(got.response.GetResult(), reconciled) {
+		t.Fatalf("expired outcome recovery = %+v, %v", got.response, got.err)
 	}
 }
 

--- a/internal/relay/mission_deployment_test.go
+++ b/internal/relay/mission_deployment_test.go
@@ -9,6 +9,7 @@ import (
 
 	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
 	relayv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
+	"github.com/bluenviron/gomavlib/v2/pkg/dialects/common"
 	"github.com/makinje/aero-arc-relay/internal/config"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -177,6 +178,10 @@ func TestDeployMissionValidatesCanonicalPlanAndBinding(t *testing.T) {
 			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[0].Current = true },
 			code:   codes.InvalidArgument,
 		},
+		"autocontinue disabled": {
+			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[0].Autocontinue = false },
+			code:   codes.InvalidArgument,
+		},
 		"nonzero param1": {
 			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[0].Param1 = 1 },
 			code:   codes.InvalidArgument,
@@ -193,6 +198,34 @@ func TestDeployMissionValidatesCanonicalPlanAndBinding(t *testing.T) {
 			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[2].Param4 = 0 },
 			code:   codes.InvalidArgument,
 		},
+		"relative altitude frame": {
+			mutate: func(c *agentv1.DeployMissionCommand) {
+				c.Plan.Items[0].Frame = uint32(common.MAV_FRAME_GLOBAL_RELATIVE_ALT)
+			},
+			code: codes.InvalidArgument,
+		},
+		"loiter command": {
+			mutate: func(c *agentv1.DeployMissionCommand) {
+				c.Plan.Items[0].Command = uint32(common.MAV_CMD_NAV_LOITER_TIME)
+			},
+			code: codes.InvalidArgument,
+		},
+		"altitude not centimeter stable": {
+			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[0].AltitudeM = math.Float32frombits(0x3f800001) },
+			code:   codes.InvalidArgument,
+		},
+		"negative zero altitude": {
+			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[0].AltitudeM = math.Float32frombits(0x80000000) },
+			code:   codes.InvalidArgument,
+		},
+		"non-finite altitude": {
+			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[0].AltitudeM = float32(math.Inf(1)) },
+			code:   codes.InvalidArgument,
+		},
+		"altitude outside ArduPilot signed centimeter range": {
+			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[0].AltitudeM = 83887 },
+			code:   codes.InvalidArgument,
+		},
 		"too many items": {
 			mutate: func(c *agentv1.DeployMissionCommand) {
 				c.Plan.Items = make([]*agentv1.MissionItem, maxMissionItems+1)
@@ -207,6 +240,13 @@ func TestDeployMissionValidatesCanonicalPlanAndBinding(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			command := proto.Clone(valid).(*agentv1.DeployMissionCommand)
 			tt.mutate(command)
+			if name != "digest mismatch" {
+				digest, err := missionPlanDigest(command.GetPlan())
+				if err != nil {
+					t.Fatal(err)
+				}
+				command.Binding.MissionDigest = digest
+			}
 			if err := validateDeployMissionCommand(command); status.Code(err) != tt.code {
 				t.Fatalf("validateDeployMissionCommand() = %v, want %v", err, tt.code)
 			}
@@ -214,19 +254,37 @@ func TestDeployMissionValidatesCanonicalPlanAndBinding(t *testing.T) {
 	}
 }
 
-func TestDeployMissionRejectsExpiredInitialDelivery(t *testing.T) {
-	relay, _, stream := testMissionRelay(t)
+func TestDeployMissionForwardsExpiredCommandToAgentDurableFence(t *testing.T) {
+	relay, session, stream := testMissionRelay(t)
 	command := testMissionCommand(t)
 	command.IssuedAtUnixMs = time.Now().Add(-2 * time.Second).UnixMilli()
 	command.ExpiresAtUnixMs = time.Now().Add(-time.Second).UnixMilli()
-	_, err := relay.DeployMission(context.Background(), &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command})
-	if status.Code(err) != codes.DeadlineExceeded {
-		t.Fatalf("DeployMission() = %v, want DeadlineExceeded", err)
+	type outcome struct {
+		response *relayv1.DeployMissionResponse
+		err      error
 	}
+	completed := make(chan outcome, 1)
+	go func() {
+		response, err := relay.DeployMission(context.Background(), &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command})
+		completed <- outcome{response: response, err: err}
+	}()
 	select {
 	case message := <-stream.sentAckChan:
-		t.Fatalf("expired mission was delivered: %+v", message)
-	default:
+		if !proto.Equal(message.GetDeployMission(), command) {
+			t.Fatalf("expired reconciliation command = %+v, want %+v", message.GetDeployMission(), command)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expired command was not forwarded to the Agent's durable reconciliation fence")
+	}
+	rejected := &agentv1.MissionDeploymentResult{
+		CommandId: command.GetCommandId(), Binding: proto.Clone(command.GetBinding()).(*agentv1.MissionBinding),
+		Status: agentv1.MissionDeploymentResult_STATUS_REJECTED, Message: "first effect expired",
+		CompletedAtUnixMs: time.Now().UnixMilli(),
+	}
+	session.handleMissionDeploymentResult(rejected)
+	got := <-completed
+	if got.err != nil || !proto.Equal(got.response.GetResult(), rejected) {
+		t.Fatalf("DeployMission() = %+v, %v, want Agent expiry rejection", got.response, got.err)
 	}
 }
 
@@ -505,16 +563,16 @@ func testMissionRelay(t *testing.T) (*Relay, *DroneSession, *mockTelemetryStream
 func testMissionCommand(t *testing.T) *agentv1.DeployMissionCommand {
 	t.Helper()
 	plan := &agentv1.MissionPlan{SchemaVersion: 1, Items: []*agentv1.MissionItem{
-		{Sequence: 0, Frame: 3, Command: 22, Autocontinue: true, LatitudeE7: 389000000, LongitudeE7: -770000000, AltitudeM: 20},
-		{Sequence: 1, Frame: 3, Command: 16, Autocontinue: true, LatitudeE7: 389001000, LongitudeE7: -770001000, AltitudeM: 30},
-		{Sequence: 2, Frame: 3, Command: 21, Autocontinue: true, Param4: 1, LatitudeE7: 389000000, LongitudeE7: -770000000},
+		{Sequence: 0, Frame: 0, Command: 22, Autocontinue: true, LatitudeE7: 389000000, LongitudeE7: -770000000, AltitudeM: 20},
+		{Sequence: 1, Frame: 0, Command: 16, Autocontinue: true, LatitudeE7: 389001000, LongitudeE7: -770001000, AltitudeM: 30},
+		{Sequence: 2, Frame: 0, Command: 21, Autocontinue: true, Param4: 1, LatitudeE7: 389000000, LongitudeE7: -770000000},
 	}}
 	digest, err := missionPlanDigest(plan)
 	if err != nil {
 		t.Fatal(err)
 	}
 	now := time.Now()
-	return &agentv1.DeployMissionCommand{
+	command := &agentv1.DeployMissionCommand{
 		CommandId: "deploy-command-1",
 		Binding: &agentv1.MissionBinding{
 			MissionId: "mission-1", MissionVersion: 2, MissionDigest: digest, DeploymentId: "deployment-1",
@@ -522,6 +580,10 @@ func testMissionCommand(t *testing.T) *agentv1.DeployMissionCommand {
 		},
 		Plan: plan, IssuedAtUnixMs: now.UnixMilli(), ExpiresAtUnixMs: now.Add(time.Minute).UnixMilli(),
 	}
+	if err := validateDeployMissionCommand(command); err != nil {
+		t.Fatalf("test mission command is invalid: %v", err)
+	}
+	return command
 }
 
 func testAppliedMissionResult(command *agentv1.DeployMissionCommand) *agentv1.MissionDeploymentResult {

--- a/internal/relay/mission_deployment_test.go
+++ b/internal/relay/mission_deployment_test.go
@@ -488,6 +488,70 @@ func TestMissionAdmissionUsesEveryWaiterWindow(t *testing.T) {
 	}
 }
 
+func TestAttachMissionDeploymentReplacesClosingRetryReservation(t *testing.T) {
+	_, session, _ := testMissionRelay(t)
+	command := testMissionCommand(t)
+	temporary := &agentv1.MissionDeploymentResult{
+		CommandId: command.GetCommandId(), Binding: proto.Clone(command.GetBinding()).(*agentv1.MissionBinding),
+		Status: agentv1.MissionDeploymentResult_STATUS_TEMPORARY_ERROR, CompletedAtUnixMs: time.Now().UnixMilli(),
+	}
+	fingerprint, err := missionDeploymentFingerprint(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session.sessionMu.RLock()
+	currentStream := session.stream
+	session.sessionMu.RUnlock()
+	session.missionDeployments = map[string]*missionDeploymentState{
+		command.GetCommandId(): {
+			fingerprint: fingerprint, command: proto.Clone(command).(*agentv1.DeployMissionCommand),
+			deliveryStream: currentStream, done: make(chan struct{}),
+			result: temporary, completed: true, completedAt: time.Now(),
+		},
+	}
+
+	closingCtx, cancelClosing := context.WithCancel(context.Background())
+	closing, attached, owner, err := attachMissionDeployment(closingCtx, session, command)
+	if err != nil || attached || !owner {
+		t.Fatalf("first retry reservation = (%v, attached=%t, owner=%t), want owner: %v", closing, attached, owner, err)
+	}
+	cancelClosing()
+	<-closing.admission.ctx.Done()
+
+	replacement, attached, owner, err := attachMissionDeployment(context.Background(), session, command)
+	if err != nil || attached || !owner {
+		t.Fatalf("retry at closing reservation = (%v, attached=%t, owner=%t), want replacement owner: %v", replacement, attached, owner, err)
+	}
+	if replacement == closing {
+		t.Fatal("live retry attached to the closing reservation")
+	}
+	select {
+	case <-closing.done:
+	default:
+		t.Fatal("superseded closing reservation was not completed")
+	}
+	if !closing.completed || !closing.admissionFailed || status.Code(closing.err) != codes.Canceled {
+		t.Fatalf("closing reservation = completed %t admissionFailed %t err %v", closing.completed, closing.admissionFailed, closing.err)
+	}
+	session.pendingMu.Lock()
+	retained := session.missionDeployments[command.GetCommandId()]
+	session.pendingMu.Unlock()
+	if retained != replacement || !replacement.reserved || replacement.completed || replacement.waiters != 1 {
+		t.Fatalf("retained replacement = %+v, want one live pending retry", retained)
+	}
+
+	state, owner, err := beginMissionDeployment(context.Background(), session, command, closing)
+	if status.Code(err) != codes.Canceled || owner || state != nil {
+		t.Fatalf("superseded worker begin = (%v, owner=%t, err=%v), want canceled", state, owner, err)
+	}
+	session.pendingMu.Lock()
+	retained = session.missionDeployments[command.GetCommandId()]
+	session.pendingMu.Unlock()
+	if retained != replacement || replacement.waiters != 1 {
+		t.Fatal("superseded worker joined or changed the replacement reservation")
+	}
+}
+
 func TestDeployMissionRetryReservationSurvivesOneCallerDeadline(t *testing.T) {
 	relay, session, stream := testMissionRelay(t)
 	command := testMissionCommand(t)

--- a/internal/relay/mission_deployment_test.go
+++ b/internal/relay/mission_deployment_test.go
@@ -79,6 +79,97 @@ func TestDeployMissionDeliversOnceAndRetainsCorrelatedResult(t *testing.T) {
 	}
 }
 
+func TestDeployMissionExactRetryAttachesBeforeOperationGate(t *testing.T) {
+	relay, session, stream := testMissionRelay(t)
+	command := testMissionCommand(t)
+	request := &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command}
+	type outcome struct {
+		response *relayv1.DeployMissionResponse
+		err      error
+	}
+
+	originalCtx, cancelOriginal := context.WithCancel(context.Background())
+	defer cancelOriginal()
+	original := make(chan outcome, 1)
+	go func() {
+		response, err := relay.DeployMission(originalCtx, request)
+		original <- outcome{response: response, err: err}
+	}()
+	if message := <-stream.sentAckChan; !proto.Equal(message.GetDeployMission(), command) {
+		t.Fatalf("initial delivered command = %+v, want %+v", message.GetDeployMission(), command)
+	}
+
+	retry := make(chan outcome, 1)
+	go func() {
+		response, err := relay.DeployMission(context.Background(), request)
+		retry <- outcome{response: response, err: err}
+	}()
+	deadline := time.Now().Add(time.Second)
+	for {
+		session.pendingMu.Lock()
+		state := session.missionDeployments[command.GetCommandId()]
+		attached := state != nil && state.waiters == 2
+		session.pendingMu.Unlock()
+		if attached {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("exact retry did not attach while the original held the operation gate")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	cancelOriginal()
+	if got := <-original; status.Code(got.err) != codes.Canceled {
+		t.Fatalf("original DeployMission() = %+v, %v, want Canceled", got.response, got.err)
+	}
+	select {
+	case duplicate := <-stream.sentAckChan:
+		t.Fatalf("attached retry redelivered after original caller canceled: %+v", duplicate)
+	default:
+	}
+
+	applied := testAppliedMissionResult(command)
+	session.handleMissionDeploymentResult(applied)
+	if got := <-retry; got.err != nil || !proto.Equal(got.response.GetResult(), applied) {
+		t.Fatalf("attached retry = %+v, %v", got.response, got.err)
+	}
+}
+
+func TestDeployMissionRetainedRetryBypassesBusyOperationGate(t *testing.T) {
+	relay, session, stream := testMissionRelay(t)
+	command := testMissionCommand(t)
+	request := &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command}
+	completed := make(chan error, 1)
+	go func() {
+		_, err := relay.DeployMission(context.Background(), request)
+		completed <- err
+	}()
+	<-stream.sentAckChan
+	result := testAppliedMissionResult(command)
+	session.handleMissionDeploymentResult(result)
+	if err := <-completed; err != nil {
+		t.Fatal(err)
+	}
+
+	release, err := acquireOperationCommandSlot(context.Background(), session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	replayed, err := relay.DeployMission(ctx, request)
+	if err != nil || !proto.Equal(replayed.GetResult(), result) {
+		t.Fatalf("retained retry behind busy operation gate = %+v, %v", replayed, err)
+	}
+	select {
+	case duplicate := <-stream.sentAckChan:
+		t.Fatalf("retained retry redelivered behind busy operation gate: %+v", duplicate)
+	default:
+	}
+}
+
 func TestDeployMissionReplaysRetainedTerminalResultAfterContextAdvances(t *testing.T) {
 	relay, session, stream := testMissionRelay(t)
 	command := testMissionCommand(t)

--- a/internal/relay/mission_deployment_test.go
+++ b/internal/relay/mission_deployment_test.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"context"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -99,6 +100,22 @@ func TestDeployMissionValidatesCanonicalPlanAndBinding(t *testing.T) {
 		},
 		"dynamic current flag": {
 			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[0].Current = true },
+			code:   codes.InvalidArgument,
+		},
+		"nonzero param1": {
+			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[0].Param1 = 1 },
+			code:   codes.InvalidArgument,
+		},
+		"negative zero param2": {
+			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[0].Param2 = math.Copysign(0, -1) },
+			code:   codes.InvalidArgument,
+		},
+		"waypoint param4": {
+			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[1].Param4 = 1 },
+			code:   codes.InvalidArgument,
+		},
+		"land param4 zero": {
+			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[2].Param4 = 0 },
 			code:   codes.InvalidArgument,
 		},
 		"too many items": {
@@ -360,6 +377,7 @@ func testMissionCommand(t *testing.T) *agentv1.DeployMissionCommand {
 	plan := &agentv1.MissionPlan{SchemaVersion: 1, Items: []*agentv1.MissionItem{
 		{Sequence: 0, Frame: 3, Command: 22, Autocontinue: true, LatitudeE7: 389000000, LongitudeE7: -770000000, AltitudeM: 20},
 		{Sequence: 1, Frame: 3, Command: 16, Autocontinue: true, LatitudeE7: 389001000, LongitudeE7: -770001000, AltitudeM: 30},
+		{Sequence: 2, Frame: 3, Command: 21, Autocontinue: true, Param4: 1, LatitudeE7: 389000000, LongitudeE7: -770000000},
 	}}
 	digest, err := missionPlanDigest(plan)
 	if err != nil {

--- a/internal/relay/mission_deployment_test.go
+++ b/internal/relay/mission_deployment_test.go
@@ -950,6 +950,7 @@ func TestDeployMissionCallerDeadlineRedispatchesOutcomeUnknownOnSameStream(t *te
 	}
 	applied := testAppliedMissionResult(command)
 	applied.Status = agentv1.MissionDeploymentResult_STATUS_ALREADY_APPLIED
+	applied.UploadedItemCount = 0
 	session.handleMissionDeploymentResult(applied)
 	got := <-retried
 	if got.err != nil || !proto.Equal(got.response.GetResult(), applied) {
@@ -990,6 +991,7 @@ func TestDeployMissionOutcomeUnknownRecoversAfterCommandExpiry(t *testing.T) {
 	}
 	reconciled := testAppliedMissionResult(command)
 	reconciled.Status = agentv1.MissionDeploymentResult_STATUS_ALREADY_APPLIED
+	reconciled.UploadedItemCount = 0
 	session.handleMissionDeploymentResult(reconciled)
 	got := <-retried
 	if got.err != nil || !proto.Equal(got.response.GetResult(), reconciled) {
@@ -1192,5 +1194,51 @@ func testAppliedMissionResult(command *agentv1.DeployMissionCommand) *agentv1.Mi
 		CommandId: command.GetCommandId(), Binding: proto.Clone(command.GetBinding()).(*agentv1.MissionBinding),
 		Status: agentv1.MissionDeploymentResult_STATUS_APPLIED, UploadedItemCount: uint32(len(command.GetPlan().GetItems())),
 		OnboardMissionDigest: command.GetBinding().GetMissionDigest(), CompletedAtUnixMs: time.Now().UnixMilli(),
+	}
+}
+
+func TestValidateMissionDeploymentSuccessEvidence(t *testing.T) {
+	command := testMissionCommand(t)
+	tests := map[string]struct {
+		mutate  func(*agentv1.MissionDeploymentResult)
+		wantErr bool
+	}{
+		"applied exact upload count": {},
+		"applied zero upload count": {
+			mutate:  func(result *agentv1.MissionDeploymentResult) { result.UploadedItemCount = 0 },
+			wantErr: true,
+		},
+		"already applied readback only": {
+			mutate: func(result *agentv1.MissionDeploymentResult) {
+				result.Status = agentv1.MissionDeploymentResult_STATUS_ALREADY_APPLIED
+				result.UploadedItemCount = 0
+			},
+		},
+		"already applied with ambiguous upload count": {
+			mutate: func(result *agentv1.MissionDeploymentResult) {
+				result.Status = agentv1.MissionDeploymentResult_STATUS_ALREADY_APPLIED
+			},
+			wantErr: true,
+		},
+		"already applied with mismatched digest": {
+			mutate: func(result *agentv1.MissionDeploymentResult) {
+				result.Status = agentv1.MissionDeploymentResult_STATUS_ALREADY_APPLIED
+				result.UploadedItemCount = 0
+				result.OnboardMissionDigest = strings.Repeat("f", 64)
+			},
+			wantErr: true,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := testAppliedMissionResult(command)
+			if test.mutate != nil {
+				test.mutate(result)
+			}
+			err := validateMissionDeploymentResult(command, result)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("validateMissionDeploymentResult() error = %v, wantErr %t", err, test.wantErr)
+			}
+		})
 	}
 }

--- a/internal/relay/mission_deployment_test.go
+++ b/internal/relay/mission_deployment_test.go
@@ -425,6 +425,80 @@ func TestDeployMissionFailedRetryReservationCanBeRetried(t *testing.T) {
 	}
 }
 
+func TestDeployMissionRetryReservationSurvivesOneCallerDeadline(t *testing.T) {
+	relay, session, stream := testMissionRelay(t)
+	command := testMissionCommand(t)
+	request := &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command}
+	completed := make(chan error, 1)
+	go func() {
+		_, err := relay.DeployMission(context.Background(), request)
+		completed <- err
+	}()
+	<-stream.sentAckChan
+	temporary := &agentv1.MissionDeploymentResult{
+		CommandId: command.GetCommandId(), Binding: proto.Clone(command.GetBinding()).(*agentv1.MissionBinding),
+		Status: agentv1.MissionDeploymentResult_STATUS_TEMPORARY_ERROR, CompletedAtUnixMs: time.Now().UnixMilli(),
+	}
+	session.handleMissionDeploymentResult(temporary)
+	if err := <-completed; err != nil {
+		t.Fatal(err)
+	}
+
+	release, err := acquireOperationCommandSlot(context.Background(), session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	shortCtx, cancelShort := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancelShort()
+	short := make(chan error, 1)
+	go func() {
+		_, err := relay.DeployMission(shortCtx, request)
+		short <- err
+	}()
+	long := make(chan error, 1)
+	go func() {
+		_, err := relay.DeployMission(context.Background(), request)
+		long <- err
+	}()
+	deadline := time.Now().Add(time.Second)
+	for {
+		session.pendingMu.Lock()
+		state := session.missionDeployments[command.GetCommandId()]
+		coalesced := state != nil && state.reserved && state.waiters == 2
+		session.pendingMu.Unlock()
+		if coalesced {
+			break
+		}
+		if time.Now().After(deadline) {
+			release()
+			t.Fatal("retry callers did not coalesce on the shared reservation")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if err := <-short; status.Code(err) != codes.DeadlineExceeded {
+		release()
+		t.Fatalf("short retry = %v, want DeadlineExceeded", err)
+	}
+	session.pendingMu.Lock()
+	state := session.missionDeployments[command.GetCommandId()]
+	stillPending := state != nil && state.reserved && !state.completed && state.waiters == 1
+	session.pendingMu.Unlock()
+	if !stillPending {
+		release()
+		t.Fatal("short caller deadline canceled the live shared reservation")
+	}
+	release()
+
+	if message := <-stream.sentAckChan; !proto.Equal(message.GetDeployMission(), command) {
+		t.Fatalf("surviving reservation delivered = %+v, want %+v", message.GetDeployMission(), command)
+	}
+	applied := testAppliedMissionResult(command)
+	session.handleMissionDeploymentResult(applied)
+	if err := <-long; err != nil {
+		t.Fatalf("surviving retry = %v", err)
+	}
+}
+
 func TestDeployMissionRetryableResultRequiresCurrentContextBeforeRedispatch(t *testing.T) {
 	relay, session, stream := testMissionRelay(t)
 	command := testMissionCommand(t)

--- a/internal/relay/mission_deployment_test.go
+++ b/internal/relay/mission_deployment_test.go
@@ -1,0 +1,381 @@
+package relay
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
+	relayv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/relay/v1"
+	"github.com/makinje/aero-arc-relay/internal/config"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestDeployMissionDeliversOnceAndRetainsCorrelatedResult(t *testing.T) {
+	relay, session, stream := testMissionRelay(t)
+	command := testMissionCommand(t)
+	request := &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command}
+
+	type outcome struct {
+		response *relayv1.DeployMissionResponse
+		err      error
+	}
+	completed := make(chan outcome, 2)
+	for range 2 {
+		go func() {
+			response, err := relay.DeployMission(context.Background(), request)
+			completed <- outcome{response: response, err: err}
+		}()
+	}
+
+	select {
+	case message := <-stream.sentAckChan:
+		if !proto.Equal(message.GetDeployMission(), command) {
+			t.Fatalf("delivered command = %+v, want %+v", message.GetDeployMission(), command)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for mission delivery")
+	}
+	select {
+	case duplicate := <-stream.sentAckChan:
+		t.Fatalf("concurrent exact retry redelivered: %+v", duplicate)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	result := testAppliedMissionResult(command)
+	session.handleMissionDeploymentResult(result)
+	for range 2 {
+		select {
+		case got := <-completed:
+			if got.err != nil || !proto.Equal(got.response.GetResult(), result) {
+				t.Fatalf("DeployMission() = %+v, %v", got.response, got.err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for DeployMission")
+		}
+	}
+
+	retry, err := relay.DeployMission(context.Background(), request)
+	if err != nil || !proto.Equal(retry.GetResult(), result) {
+		t.Fatalf("retained exact retry = %+v, %v", retry, err)
+	}
+	select {
+	case duplicate := <-stream.sentAckChan:
+		t.Fatalf("terminal exact retry redelivered: %+v", duplicate)
+	default:
+	}
+
+	conflict := proto.Clone(command).(*agentv1.DeployMissionCommand)
+	conflict.ExpiresAtUnixMs++
+	if _, err := relay.DeployMission(context.Background(), &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: conflict}); status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("conflicting command ID error = %v, want AlreadyExists", err)
+	}
+}
+
+func TestDeployMissionValidatesCanonicalPlanAndBinding(t *testing.T) {
+	valid := testMissionCommand(t)
+	tests := map[string]struct {
+		mutate func(*agentv1.DeployMissionCommand)
+		code   codes.Code
+	}{
+		"digest mismatch": {
+			mutate: func(c *agentv1.DeployMissionCommand) { c.Binding.MissionDigest = strings.Repeat("0", 64) },
+			code:   codes.InvalidArgument,
+		},
+		"unsupported frame": {
+			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[0].Frame = 2 },
+			code:   codes.InvalidArgument,
+		},
+		"unsupported command": {
+			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[0].Command = 999 },
+			code:   codes.InvalidArgument,
+		},
+		"bad sequence": {
+			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[0].Sequence = 1 },
+			code:   codes.InvalidArgument,
+		},
+		"too many items": {
+			mutate: func(c *agentv1.DeployMissionCommand) {
+				c.Plan.Items = make([]*agentv1.MissionItem, maxMissionItems+1)
+				for i := range c.Plan.Items {
+					c.Plan.Items[i] = &agentv1.MissionItem{Sequence: uint32(i), Frame: 3, Command: 16}
+				}
+			},
+			code: codes.InvalidArgument,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			command := proto.Clone(valid).(*agentv1.DeployMissionCommand)
+			tt.mutate(command)
+			if err := validateDeployMissionCommand(command); status.Code(err) != tt.code {
+				t.Fatalf("validateDeployMissionCommand() = %v, want %v", err, tt.code)
+			}
+		})
+	}
+}
+
+func TestDeployMissionRejectsExpiredInitialDelivery(t *testing.T) {
+	relay, _, stream := testMissionRelay(t)
+	command := testMissionCommand(t)
+	command.IssuedAtUnixMs = time.Now().Add(-2 * time.Second).UnixMilli()
+	command.ExpiresAtUnixMs = time.Now().Add(-time.Second).UnixMilli()
+	_, err := relay.DeployMission(context.Background(), &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command})
+	if status.Code(err) != codes.DeadlineExceeded {
+		t.Fatalf("DeployMission() = %v, want DeadlineExceeded", err)
+	}
+	select {
+	case message := <-stream.sentAckChan:
+		t.Fatalf("expired mission was delivered: %+v", message)
+	default:
+	}
+}
+
+func TestDeployMissionRejectsUnsafeDeliveryWindow(t *testing.T) {
+	tests := map[string]func(*agentv1.DeployMissionCommand){
+		"future issue time": func(command *agentv1.DeployMissionCommand) {
+			command.IssuedAtUnixMs = time.Now().Add(time.Minute).UnixMilli()
+			command.ExpiresAtUnixMs = time.Now().Add(2 * time.Minute).UnixMilli()
+		},
+		"long validity window": func(command *agentv1.DeployMissionCommand) {
+			command.ExpiresAtUnixMs = time.Now().Add(maxMissionCommandWindow + time.Minute).UnixMilli()
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			relay, _, stream := testMissionRelay(t)
+			command := testMissionCommand(t)
+			mutate(command)
+			_, err := relay.DeployMission(context.Background(), &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command})
+			if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("DeployMission() = %v, want InvalidArgument", err)
+			}
+			select {
+			case message := <-stream.sentAckChan:
+				t.Fatalf("unsafe mission was delivered: %+v", message)
+			default:
+			}
+		})
+	}
+}
+
+func TestDeployMissionCallerDeadlineRetainsOutcomeUnknown(t *testing.T) {
+	relay, _, stream := testMissionRelay(t)
+	command := testMissionCommand(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	completed := make(chan error, 1)
+	go func() {
+		_, err := relay.DeployMission(ctx, &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command})
+		completed <- err
+	}()
+	<-stream.sentAckChan
+	if err := <-completed; status.Code(err) != codes.DeadlineExceeded {
+		t.Fatalf("DeployMission() = %v, want DeadlineExceeded", err)
+	}
+	retry, err := relay.DeployMission(context.Background(), &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command})
+	if err != nil || retry.GetResult().GetStatus() != agentv1.MissionDeploymentResult_STATUS_OUTCOME_UNKNOWN {
+		t.Fatalf("retry after waiter deadline = %+v, %v", retry, err)
+	}
+	select {
+	case message := <-stream.sentAckChan:
+		t.Fatalf("deadline retry redelivered: %+v", message)
+	default:
+	}
+}
+
+func TestDeployMissionRetainedResultSurvivesCommandExpiry(t *testing.T) {
+	relay, session, stream := testMissionRelay(t)
+	command := testMissionCommand(t)
+	command.ExpiresAtUnixMs = time.Now().Add(100 * time.Millisecond).UnixMilli()
+	type outcome struct {
+		response *relayv1.DeployMissionResponse
+		err      error
+	}
+	completed := make(chan outcome, 1)
+	go func() {
+		response, err := relay.DeployMission(context.Background(), &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command})
+		completed <- outcome{response: response, err: err}
+	}()
+	<-stream.sentAckChan
+	result := testAppliedMissionResult(command)
+	session.handleMissionDeploymentResult(result)
+	if got := <-completed; got.err != nil {
+		t.Fatal(got.err)
+	}
+	time.Sleep(110 * time.Millisecond)
+	retry, err := relay.DeployMission(context.Background(), &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command})
+	if err != nil || !proto.Equal(retry.GetResult(), result) {
+		t.Fatalf("expired retained retry = %+v, %v", retry, err)
+	}
+}
+
+func TestDeployMissionRequiresMappingAndReconciledExactContext(t *testing.T) {
+	tests := map[string]struct {
+		mutate func(*Relay, *DroneSession)
+		code   codes.Code
+	}{
+		"missing mapping": {
+			mutate: func(r *Relay, _ *DroneSession) { r.config.Telemetry.AgentMappings = nil },
+			code:   codes.FailedPrecondition,
+		},
+		"aircraft mapping mismatch": {
+			mutate: func(r *Relay, _ *DroneSession) {
+				r.config.Telemetry.AgentMappings["agent-1"] = config.AgentMapping{OperatorID: "operator-1", AircraftID: "other"}
+			},
+			code: codes.FailedPrecondition,
+		},
+		"unreconciled": {
+			mutate: func(_ *Relay, s *DroneSession) { s.operationContextUnreconciled = true },
+			code:   codes.FailedPrecondition,
+		},
+		"legacy context missing aircraft": {
+			mutate: func(_ *Relay, s *DroneSession) { s.AircraftID = "" },
+			code:   codes.FailedPrecondition,
+		},
+		"context aircraft mismatch": {
+			mutate: func(_ *Relay, s *DroneSession) { s.AircraftID = "other" },
+			code:   codes.FailedPrecondition,
+		},
+		"flight mismatch": {
+			mutate: func(_ *Relay, s *DroneSession) { s.FlightID = "other" },
+			code:   codes.FailedPrecondition,
+		},
+		"intent version mismatch": {
+			mutate: func(_ *Relay, s *DroneSession) { s.IntentVersion++ },
+			code:   codes.FailedPrecondition,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			relay, session, stream := testMissionRelay(t)
+			tt.mutate(relay, session)
+			_, err := relay.DeployMission(context.Background(), &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: testMissionCommand(t)})
+			if status.Code(err) != tt.code {
+				t.Fatalf("DeployMission() error = %v, want %v", err, tt.code)
+			}
+			select {
+			case message := <-stream.sentAckChan:
+				t.Fatalf("invalid mission was delivered: %+v", message)
+			default:
+			}
+		})
+	}
+}
+
+func TestDeployMissionRejectsMalformedCorrelatedResult(t *testing.T) {
+	relay, session, stream := testMissionRelay(t)
+	command := testMissionCommand(t)
+	completed := make(chan error, 1)
+	go func() {
+		_, err := relay.DeployMission(context.Background(), &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command})
+		completed <- err
+	}()
+	<-stream.sentAckChan
+	result := testAppliedMissionResult(command)
+	result.OnboardMissionDigest = strings.Repeat("f", 64)
+	session.handleMissionDeploymentResult(result)
+	if err := <-completed; status.Code(err) != codes.Internal {
+		t.Fatalf("DeployMission() malformed result error = %v, want Internal", err)
+	}
+	_, err := relay.DeployMission(context.Background(), &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command})
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("retained malformed result error = %v, want Internal", err)
+	}
+}
+
+func TestDeployMissionSessionReplacementReturnsOutcomeUnknownWithoutRedelivery(t *testing.T) {
+	relay, session, oldStream := testMissionRelay(t)
+	command := testMissionCommand(t)
+	completed := make(chan *relayv1.DeployMissionResponse, 1)
+	errors := make(chan error, 1)
+	go func() {
+		response, err := relay.DeployMission(context.Background(), &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command})
+		completed <- response
+		errors <- err
+	}()
+	<-oldStream.sentAckChan
+
+	newStream := &mockTelemetryStream{ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 1)}
+	session.controlStreamMu.Lock()
+	session.abortPendingCommandsForStreamReplacement()
+	session.sessionMu.Lock()
+	session.stream = &telemetryStreamBinding{stream: newStream, generation: 2}
+	session.sessionMu.Unlock()
+	session.controlStreamMu.Unlock()
+
+	response := <-completed
+	if err := <-errors; err != nil {
+		t.Fatal(err)
+	}
+	if got := response.GetResult().GetStatus(); got != agentv1.MissionDeploymentResult_STATUS_OUTCOME_UNKNOWN {
+		t.Fatalf("replacement result = %v, want OUTCOME_UNKNOWN", got)
+	}
+	retry, err := relay.DeployMission(context.Background(), &relayv1.DeployMissionRequest{AgentId: "agent-1", Command: command})
+	if err != nil || retry.GetResult().GetStatus() != agentv1.MissionDeploymentResult_STATUS_OUTCOME_UNKNOWN {
+		t.Fatalf("retry after replacement = %+v, %v", retry, err)
+	}
+	select {
+	case message := <-newStream.sentAckChan:
+		t.Fatalf("mission was delivered to replacement stream: %+v", message)
+	default:
+	}
+}
+
+func TestDeployMissionAuthenticatesBeforeValidation(t *testing.T) {
+	want := status.Error(codes.PermissionDenied, "denied")
+	relay := &Relay{controlAuthorizer: func(context.Context) error { return want }}
+	_, err := relay.DeployMission(context.Background(), nil)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("DeployMission() = %v, want PermissionDenied", err)
+	}
+}
+
+func testMissionRelay(t *testing.T) (*Relay, *DroneSession, *mockTelemetryStream) {
+	t.Helper()
+	stream := &mockTelemetryStream{ctx: context.Background(), sentAckChan: make(chan *agentv1.RelayStreamMessage, 4)}
+	session := &DroneSession{
+		agentID: "agent-1", SessionID: "session-1", stream: &telemetryStreamBinding{stream: stream, generation: 1},
+		AircraftID: "aircraft-1", FlightID: "flight-1", IntentID: "intent-1", IntentVersion: 3,
+	}
+	relay := &Relay{
+		config: &config.Config{Telemetry: config.TelemetryConfig{AgentMappings: map[string]config.AgentMapping{
+			"agent-1": {OperatorID: "operator-1", AircraftID: "aircraft-1"},
+		}}},
+		controlAuthorizer: func(context.Context) error { return nil },
+		grpcSessions:      map[string]*DroneSession{"agent-1": session},
+	}
+	return relay, session, stream
+}
+
+func testMissionCommand(t *testing.T) *agentv1.DeployMissionCommand {
+	t.Helper()
+	plan := &agentv1.MissionPlan{SchemaVersion: 1, Items: []*agentv1.MissionItem{
+		{Sequence: 0, Frame: 3, Command: 22, Autocontinue: true, LatitudeE7: 389000000, LongitudeE7: -770000000, AltitudeM: 20},
+		{Sequence: 1, Frame: 3, Command: 16, Autocontinue: true, LatitudeE7: 389001000, LongitudeE7: -770001000, AltitudeM: 30},
+	}}
+	digest, err := missionPlanDigest(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	return &agentv1.DeployMissionCommand{
+		CommandId: "deploy-command-1",
+		Binding: &agentv1.MissionBinding{
+			MissionId: "mission-1", MissionVersion: 2, MissionDigest: digest, DeploymentId: "deployment-1",
+			OperatorId: "operator-1", AircraftId: "aircraft-1", FlightId: "flight-1", IntentId: "intent-1", IntentVersion: 3,
+		},
+		Plan: plan, IssuedAtUnixMs: now.UnixMilli(), ExpiresAtUnixMs: now.Add(time.Minute).UnixMilli(),
+	}
+}
+
+func testAppliedMissionResult(command *agentv1.DeployMissionCommand) *agentv1.MissionDeploymentResult {
+	return &agentv1.MissionDeploymentResult{
+		CommandId: command.GetCommandId(), Binding: proto.Clone(command.GetBinding()).(*agentv1.MissionBinding),
+		Status: agentv1.MissionDeploymentResult_STATUS_APPLIED, UploadedItemCount: uint32(len(command.GetPlan().GetItems())),
+		OnboardMissionDigest: command.GetBinding().GetMissionDigest(), CompletedAtUnixMs: time.Now().UnixMilli(),
+	}
+}

--- a/internal/relay/mission_deployment_test.go
+++ b/internal/relay/mission_deployment_test.go
@@ -298,6 +298,10 @@ func TestDeployMissionValidatesCanonicalPlanAndBinding(t *testing.T) {
 			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[0].AltitudeM = math.Float32frombits(0x3f800001) },
 			code:   codes.InvalidArgument,
 		},
+		"altitude changed by ArduPilot truncation": {
+			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[0].AltitudeM = 16.8 },
+			code:   codes.InvalidArgument,
+		},
 		"negative zero altitude": {
 			mutate: func(c *agentv1.DeployMissionCommand) { c.Plan.Items[0].AltitudeM = math.Float32frombits(0x80000000) },
 			code:   codes.InvalidArgument,
@@ -333,6 +337,53 @@ func TestDeployMissionValidatesCanonicalPlanAndBinding(t *testing.T) {
 			}
 			if err := validateDeployMissionCommand(command); status.Code(err) != tt.code {
 				t.Fatalf("validateDeployMissionCommand() = %v, want %v", err, tt.code)
+			}
+		})
+	}
+}
+
+func TestCommandIDCannotBeReusedAcrossCommandKinds(t *testing.T) {
+	const commandID = "cross-kind-command"
+	tests := []struct {
+		name     string
+		retained retainedCommandKind
+		admit    retainedCommandKind
+	}{
+		{name: "mission after operation context", retained: retainedOperationCommand, admit: retainedMissionDeployment},
+		{name: "mission after aircraft", retained: retainedAircraftCommand, admit: retainedMissionDeployment},
+		{name: "aircraft after operation context", retained: retainedOperationCommand, admit: retainedAircraftCommand},
+		{name: "aircraft after mission", retained: retainedMissionDeployment, admit: retainedAircraftCommand},
+		{name: "operation context after aircraft", retained: retainedAircraftCommand, admit: retainedOperationCommand},
+		{name: "operation context after mission", retained: retainedMissionDeployment, admit: retainedOperationCommand},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := &DroneSession{}
+			switch tt.retained {
+			case retainedOperationCommand:
+				session.operationCommands = map[string]*operationCommandState{commandID: {}}
+			case retainedAircraftCommand:
+				session.aircraftCommands = map[string]*aircraftCommandState{commandID: {}}
+			case retainedMissionDeployment:
+				session.missionDeployments = map[string]*missionDeploymentState{commandID: {}}
+			}
+
+			var err error
+			switch tt.admit {
+			case retainedOperationCommand:
+				_, _, err = beginOperationCommand(session, commandID, "new-operation-fingerprint", nil)
+			case retainedAircraftCommand:
+				_, _, err = beginAircraftCommandDelivery(session, &agentv1.AircraftCommand{
+					CommandId: commandID, AircraftId: "aircraft-1",
+					Type: agentv1.AircraftCommandType_AIRCRAFT_COMMAND_TYPE_ARM,
+				})
+			case retainedMissionDeployment:
+				command := testMissionCommand(t)
+				command.CommandId = commandID
+				_, _, err = beginMissionDeployment(session, command)
+			}
+			if status.Code(err) != codes.AlreadyExists {
+				t.Fatalf("cross-kind admission error = %v, want AlreadyExists", err)
 			}
 		})
 	}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -226,20 +226,21 @@ type aircraftCommandState struct {
 }
 
 type missionDeploymentState struct {
-	fingerprint     string
-	command         *agentv1.DeployMissionCommand
-	deliveryStream  *telemetryStreamBinding
-	done            chan struct{}
-	deliveryCancel  context.CancelFunc
-	admission       *missionAdmission
-	reserved        bool
-	admissionFailed bool
-	waiters         int
-	result          *agentv1.MissionDeploymentResult
-	err             error
-	delivered       bool
-	completed       bool
-	completedAt     time.Time
+	fingerprint         string
+	command             *agentv1.DeployMissionCommand
+	deliveryStream      *telemetryStreamBinding
+	done                chan struct{}
+	deliveryCancel      context.CancelFunc
+	admission           *missionAdmission
+	reserved            bool
+	admissionFailed     bool
+	waiters             int
+	result              *agentv1.MissionDeploymentResult
+	err                 error
+	resultAdmissionOpen bool
+	delivered           bool
+	completed           bool
+	completedAt         time.Time
 }
 
 type missionAdmission struct {

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -173,7 +173,7 @@ type DroneSession struct {
 	// Relay process with context control enabled. Telemetry remains retryable
 	// until the API replays an authoritative Set/Clear command. Authenticated
 	// same-process replacements inherit the previous session's reconciled state;
-	// authentication-free replacements remain unreconciled.
+	// control-enabled authentication-free replacements remain unreconciled.
 	operationContextUnreconciled bool
 	// emptyContextCommandID retains the one durable command permitted to assert
 	// an authoritative empty context, including exact retries after admission

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -148,6 +148,7 @@ type missionDeploymentState struct {
 	deliveryStream  *telemetryStreamBinding
 	done            chan struct{}
 	deliveryCancel  context.CancelFunc
+	admission       *missionAdmission
 	reserved        bool
 	admissionFailed bool
 	waiters         int
@@ -156,6 +157,14 @@ type missionDeploymentState struct {
 	delivered       bool
 	completed       bool
 	completedAt     time.Time
+}
+
+type missionAdmission struct {
+	mu     sync.Mutex
+	ctx    context.Context
+	cancel context.CancelFunc
+	active int
+	closed bool
 }
 
 type telemetryStreamBinding struct {

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -44,6 +44,11 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
+const (
+	disconnectedOperationContextTTL      = 5 * time.Minute
+	maxDisconnectedOperationContextCount = 1024
+)
+
 // Relay manages MAVLink connections and data forwarding to sinks
 type Relay struct {
 	config             *config.Config
@@ -54,9 +59,10 @@ type Relay struct {
 	grpcServer         *grpc.Server
 	grpcSessions       map[string]*DroneSession
 	// disconnectedOperationContexts retains the last API-authoritative context
-	// for an authenticated Agent whose active stream disconnected. The cache is
-	// process-local: a Relay restart still requires an explicit API replay.
-	disconnectedOperationContexts map[string]operationContextSnapshot
+	// for an Agent whose active stream disconnected. Registration must pass any
+	// configured authentication before consuming it. The cache is process-local:
+	// a Relay restart still requires an explicit API replay.
+	disconnectedOperationContexts map[string]retainedOperationContext
 	sessionsMu                    sync.RWMutex
 	closeOnce                     sync.Once
 	closeErr                      error
@@ -77,6 +83,11 @@ type operationContextSnapshot struct {
 	emptyContextCommandID string
 }
 
+type retainedOperationContext struct {
+	snapshot  operationContextSnapshot
+	expiresAt time.Time
+}
+
 func (snapshot operationContextSnapshot) restoreInto(session *DroneSession) {
 	session.AircraftID = snapshot.aircraftID
 	session.FlightID = snapshot.flightID
@@ -84,6 +95,56 @@ func (snapshot operationContextSnapshot) restoreInto(session *DroneSession) {
 	session.IntentVersion = snapshot.intentVersion
 	session.operationContextUnreconciled = snapshot.unreconciled
 	session.emptyContextCommandID = snapshot.emptyContextCommandID
+}
+
+func (snapshot operationContextSnapshot) isEmptyAndReconciled() bool {
+	return snapshot.aircraftID == "" && snapshot.flightID == "" && snapshot.intentID == "" &&
+		snapshot.intentVersion == 0 && !snapshot.unreconciled && snapshot.emptyContextCommandID == ""
+}
+
+// retainDisconnectedOperationContextLocked stores bounded, short-lived
+// reconnect state. The caller must hold sessionsMu for writing.
+func (r *Relay) retainDisconnectedOperationContextLocked(agentID string, snapshot operationContextSnapshot, now time.Time) {
+	if snapshot.isEmptyAndReconciled() {
+		delete(r.disconnectedOperationContexts, agentID)
+		return
+	}
+	if r.disconnectedOperationContexts == nil {
+		r.disconnectedOperationContexts = make(map[string]retainedOperationContext)
+	}
+	for retainedAgentID, retained := range r.disconnectedOperationContexts {
+		if !now.Before(retained.expiresAt) {
+			delete(r.disconnectedOperationContexts, retainedAgentID)
+		}
+	}
+	if _, exists := r.disconnectedOperationContexts[agentID]; !exists &&
+		len(r.disconnectedOperationContexts) >= maxDisconnectedOperationContextCount {
+		var evictedAgentID string
+		var oldestExpiry time.Time
+		for retainedAgentID, retained := range r.disconnectedOperationContexts {
+			if evictedAgentID == "" || retained.expiresAt.Before(oldestExpiry) ||
+				(retained.expiresAt.Equal(oldestExpiry) && retainedAgentID < evictedAgentID) {
+				evictedAgentID = retainedAgentID
+				oldestExpiry = retained.expiresAt
+			}
+		}
+		delete(r.disconnectedOperationContexts, evictedAgentID)
+	}
+	r.disconnectedOperationContexts[agentID] = retainedOperationContext{
+		snapshot:  snapshot,
+		expiresAt: now.Add(disconnectedOperationContextTTL),
+	}
+}
+
+// takeDisconnectedOperationContextLocked consumes reconnect state exactly once.
+// The caller must hold sessionsMu for writing.
+func (r *Relay) takeDisconnectedOperationContextLocked(agentID string, now time.Time) (operationContextSnapshot, bool) {
+	retained, ok := r.disconnectedOperationContexts[agentID]
+	delete(r.disconnectedOperationContexts, agentID)
+	if !ok || !now.Before(retained.expiresAt) {
+		return operationContextSnapshot{}, false
+	}
+	return retained.snapshot, true
 }
 
 type agentRegistryReporter interface {

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -143,17 +143,19 @@ type aircraftCommandState struct {
 }
 
 type missionDeploymentState struct {
-	fingerprint    string
-	command        *agentv1.DeployMissionCommand
-	deliveryStream *telemetryStreamBinding
-	done           chan struct{}
-	deliveryCancel context.CancelFunc
-	waiters        int
-	result         *agentv1.MissionDeploymentResult
-	err            error
-	delivered      bool
-	completed      bool
-	completedAt    time.Time
+	fingerprint     string
+	command         *agentv1.DeployMissionCommand
+	deliveryStream  *telemetryStreamBinding
+	done            chan struct{}
+	deliveryCancel  context.CancelFunc
+	reserved        bool
+	admissionFailed bool
+	waiters         int
+	result          *agentv1.MissionDeploymentResult
+	err             error
+	delivered       bool
+	completed       bool
+	completedAt     time.Time
 }
 
 type telemetryStreamBinding struct {

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -145,6 +145,7 @@ type aircraftCommandState struct {
 type missionDeploymentState struct {
 	fingerprint    string
 	command        *agentv1.DeployMissionCommand
+	deliveryStream *telemetryStreamBinding
 	done           chan struct{}
 	deliveryCancel context.CancelFunc
 	waiters        int

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -97,18 +97,9 @@ func (snapshot operationContextSnapshot) restoreInto(session *DroneSession) {
 	session.emptyContextCommandID = snapshot.emptyContextCommandID
 }
 
-func (snapshot operationContextSnapshot) isEmptyAndReconciled() bool {
-	return snapshot.aircraftID == "" && snapshot.flightID == "" && snapshot.intentID == "" &&
-		snapshot.intentVersion == 0 && !snapshot.unreconciled && snapshot.emptyContextCommandID == ""
-}
-
 // retainDisconnectedOperationContextLocked stores bounded, short-lived
 // reconnect state. The caller must hold sessionsMu for writing.
 func (r *Relay) retainDisconnectedOperationContextLocked(agentID string, snapshot operationContextSnapshot, now time.Time) {
-	if snapshot.isEmptyAndReconciled() {
-		delete(r.disconnectedOperationContexts, agentID)
-		return
-	}
 	if r.disconnectedOperationContexts == nil {
 		r.disconnectedOperationContexts = make(map[string]retainedOperationContext)
 	}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -53,15 +53,37 @@ type Relay struct {
 	outputsInitialized bool
 	grpcServer         *grpc.Server
 	grpcSessions       map[string]*DroneSession
-	sessionsMu         sync.RWMutex
-	closeOnce          sync.Once
-	closeErr           error
-	registryReporter   agentRegistryReporter
-	registryLifecycle  registryLifecycle
-	agentAuthenticator func(context.Context, string) error
-	controlAuthorizer  controlPlaneAuthorizer
+	// disconnectedOperationContexts retains the last API-authoritative context
+	// for an authenticated Agent whose active stream disconnected. The cache is
+	// process-local: a Relay restart still requires an explicit API replay.
+	disconnectedOperationContexts map[string]operationContextSnapshot
+	sessionsMu                    sync.RWMutex
+	closeOnce                     sync.Once
+	closeErr                      error
+	registryReporter              agentRegistryReporter
+	registryLifecycle             registryLifecycle
+	agentAuthenticator            func(context.Context, string) error
+	controlAuthorizer             controlPlaneAuthorizer
 	relayv1.UnimplementedRelayControlServer
 	agentv1.UnimplementedAgentGatewayServer
+}
+
+type operationContextSnapshot struct {
+	aircraftID            string
+	flightID              string
+	intentID              string
+	intentVersion         uint32
+	unreconciled          bool
+	emptyContextCommandID string
+}
+
+func (snapshot operationContextSnapshot) restoreInto(session *DroneSession) {
+	session.AircraftID = snapshot.aircraftID
+	session.FlightID = snapshot.flightID
+	session.IntentID = snapshot.intentID
+	session.IntentVersion = snapshot.intentVersion
+	session.operationContextUnreconciled = snapshot.unreconciled
+	session.emptyContextCommandID = snapshot.emptyContextCommandID
 }
 
 type agentRegistryReporter interface {

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -171,8 +171,9 @@ type DroneSession struct {
 	IntentVersion    uint32
 	// operationContextUnreconciled is set for the first Agent session seen by a
 	// Relay process with context control enabled. Telemetry remains retryable
-	// until the API replays an authoritative Set/Clear command; same-process
-	// replacements inherit the previous session's reconciled state.
+	// until the API replays an authoritative Set/Clear command. Authenticated
+	// same-process replacements inherit the previous session's reconciled state;
+	// authentication-free replacements remain unreconciled.
 	operationContextUnreconciled bool
 	// emptyContextCommandID retains the one durable command permitted to assert
 	// an authoritative empty context, including exact retries after admission

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -91,6 +91,7 @@ type DroneSession struct {
 	Attitude         *common.MessageAttitude
 	VfrHud           *common.MessageVfrHud
 	SystemStatus     *common.MessageSysStatus
+	AircraftID       string
 	FlightID         string
 	IntentID         string
 	IntentVersion    uint32
@@ -109,6 +110,7 @@ type DroneSession struct {
 	operationCommands     map[string]*operationCommandState
 	operationGate         chan struct{}
 	aircraftCommands      map[string]*aircraftCommandState
+	missionDeployments    map[string]*missionDeploymentState
 	// controlStreamMu keeps command writes and command evidence on one active
 	// telemetry-stream binding. Same-session stream replacement takes the write
 	// side only for the binding swap, not for Registry publication or telemetry.
@@ -136,6 +138,19 @@ type aircraftCommandState struct {
 	waiters        int
 	result         *agentv1.AircraftCommandResult
 	err            error
+	completed      bool
+	completedAt    time.Time
+}
+
+type missionDeploymentState struct {
+	fingerprint    string
+	command        *agentv1.DeployMissionCommand
+	done           chan struct{}
+	deliveryCancel context.CancelFunc
+	waiters        int
+	result         *agentv1.MissionDeploymentResult
+	err            error
+	delivered      bool
 	completed      bool
 	completedAt    time.Time
 }
@@ -206,6 +221,16 @@ var (
 		Name: "aero_relay_aircraft_command_duration_seconds",
 		Help: "Time from Relay command receipt to Agent result.",
 	}, []string{"command_type"})
+
+	relayMissionDeploymentsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "aero_relay_mission_deployments_total",
+		Help: "Mission deployment requests completed by the relay.",
+	}, []string{"result"})
+
+	relayMissionDeploymentDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name: "aero_relay_mission_deployment_duration_seconds",
+		Help: "Time from Relay mission deployment receipt to Agent result.",
+	})
 )
 
 // New validates Agent authentication requirements and constructs a Relay with

--- a/internal/relay/streams.go
+++ b/internal/relay/streams.go
@@ -13,6 +13,7 @@ package relay
 
 import (
 	"context"
+	"time"
 
 	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
 )
@@ -158,10 +159,7 @@ func (r *Relay) deleteStream(agentID string, expectedSession *DroneSession, expe
 		session.retired = true
 		retainedContext := session.snapshotContextAndAbortPending()
 		if r.controlAuthorizer != nil {
-			if r.disconnectedOperationContexts == nil {
-				r.disconnectedOperationContexts = make(map[string]operationContextSnapshot)
-			}
-			r.disconnectedOperationContexts[agentID] = retainedContext
+			r.retainDisconnectedOperationContextLocked(agentID, retainedContext, time.Now())
 		}
 		delete(r.grpcSessions, agentID)
 		// Stop liveness before releasing the session-map lock. Otherwise a new

--- a/internal/relay/streams.go
+++ b/internal/relay/streams.go
@@ -158,7 +158,7 @@ func (r *Relay) deleteStream(agentID string, expectedSession *DroneSession, expe
 	if isCurrentStream {
 		session.retired = true
 		retainedContext := session.snapshotContextAndAbortPending()
-		if r.controlAuthorizer != nil {
+		if r.controlAuthorizer != nil && r.agentAuthenticator != nil {
 			r.retainDisconnectedOperationContextLocked(agentID, retainedContext, time.Now())
 		}
 		delete(r.grpcSessions, agentID)

--- a/internal/relay/streams.go
+++ b/internal/relay/streams.go
@@ -156,7 +156,13 @@ func (r *Relay) deleteStream(agentID string, expectedSession *DroneSession, expe
 	session.sessionMu.Unlock()
 	if isCurrentStream {
 		session.retired = true
-		session.abortPendingCommands()
+		retainedContext := session.snapshotContextAndAbortPending()
+		if r.controlAuthorizer != nil {
+			if r.disconnectedOperationContexts == nil {
+				r.disconnectedOperationContexts = make(map[string]operationContextSnapshot)
+			}
+			r.disconnectedOperationContexts[agentID] = retainedContext
+		}
 		delete(r.grpcSessions, agentID)
 		// Stop liveness before releasing the session-map lock. Otherwise a new
 		// registration could publish and activate a replacement stream between


### PR DESCRIPTION
## Purpose and demo role

This PR adds the Relay leg of Aero Arc's intent-bound mission deployment path. It accepts an API control request, validates the immutable mission and operation binding, and routes the command only to the exact active Agent session/stream for the mapped aircraft. In the integrated demo this is the cloud-to-aircraft hop between mission import/deployment and the live telemetry used by conformance and deconfliction.

Mission deployment remains separate from operational-intent geometry: this route does not create, reshape, authorize, or deconflict a flight volume.

## What changed

- add `DeployMission` routing and result correlation on the existing bidirectional Agent stream
- bind each deployment to operator, aircraft, flight, intent ID/version, mission ID/version, deployment ID, and canonical mission digest
- validate schema-v1 missions with the shared Protos canonical digest contract and ArduPilot-stable parameter/altitude rules
- retain bounded command fingerprints and results so exact retries coalesce or replay without conflicting-payload reuse
- serialize genuinely new vehicle-effecting control work while allowing exact running/terminal mission retries to attach without unnecessary redelivery
- preserve exact session, stream-generation, ownership, binding, and result-correlation fences through reconnect and replacement
- document the telemetry/control lifecycle and the fail-closed operation-context reconciliation path

## Safety, security, and recovery invariants

- A new delivery requires the Relay's exact active aircraft/flight/intent/version context to match the mission binding. An exact retained terminal result may still be replayed after context advances because replay has no vehicle effect.
- Command IDs are immutable payload identities. Reuse with a different command kind or payload is rejected; concurrent exact retries share one pending delivery generation.
- Mission bytes are validated locally and hashed with `missiondigest.Digest`; unsupported frames/commands, dynamic `current`, noncanonical parameters, non-float32 values, and values that do not round-trip through ArduPilot's signed-centimeter storage fail before stream delivery.
- `APPLIED` requires a matching onboard digest and the exact canonical plan item count. Readback-only `ALREADY_APPLIED` requires the matching digest and permits/requires `uploaded_item_count == 0`; it does not falsely claim that this execution uploaded the plan.
- Expired previously admitted uncertainty is forwarded only for same-command reconciliation. The Agent contract remains the final fail-closed fence: post-expiry recovery is readback-only and may return `ALREADY_APPLIED` on a digest match or `ONBOARD_MISSION_MISMATCH` without replacement upload.
- Retry result admission uses a **command-level effect-start barrier**, not per-attempt provenance. While a retry is reserved or queued, delayed evidence is ignored. Immediately before `Send`, Relay atomically commits the exact immutable command and opens result admission, then performs that send unconditionally. Evidence after the barrier is authoritative for that command/payload and cannot suppress the committed send. The protocol has no per-attempt nonce, so this PR intentionally does not claim to distinguish which attempt produced later exact-command evidence.
- Live-session replacement aborts pending work. Prior API-authoritative context is inherited only when Agent authentication is configured and has succeeded; authentication-free replacement inherits no context and remains API-reconciliation-fenced when context control is enabled.
- Authenticated quick reconnects may restore the last authoritative context, including an acknowledged empty/Clear context. The process-local cache is auth-gated, expires after 5 minutes, is capped at 1,024 Agents, and evicts the deterministic oldest entry. It is not durable across Relay restart; API replay is the backstop.

## Cross-repository contract and rollout

This head is `9ccb2e14887906b60f26ad2a355aef1e7ba51f80` and pins Protos PR [#15](https://github.com/Aero-Arc/aero-arc-protos/pull/15) at:

```text
github.com/aero-arc/aero-arc-protos v0.0.0-20260830133103-af0b6757de47
```

Recommended merge/deployment order:

1. Protos [#15](https://github.com/Aero-Arc/aero-arc-protos/pull/15), head `af0b6757de4780370cfcbd7b076a9050392aa271`.
2. Agent [#28](https://github.com/Aero-Arc/aero-arc-agent/pull/28), head `5115055458b77c8b25f4ae25838c1014273e32f3`, and this Relay PR. Deploy Agent before enabling API mission effects; Relay and Agent must agree on digest, HOME/readback, expiry, and result semantics.
3. API [#40](https://github.com/Aero-Arc/aero-arc-api/pull/40), head `056c0ff36cf27d8396b5eec50a67711c03020b42`, which pins the same Protos pseudo-version and owns durable deployment/reconciliation state.
4. Ops [#6](https://github.com/Aero-Arc/aero-arc-ops/pull/6), head `166ec38419ffa7856895134f24f649944e3d60c0`, after the API restoration/reconciliation endpoints are live.

Conformance [#8](https://github.com/Aero-Arc/aero-arc-conformance/pull/8) is mission-contract independent, but should be deployed for the demo's post-window spatial behavior before relying on the Ops presentation.

## Validation and evidence

- focused reconnect, replacement, retry-generation, command-barrier, and fast-result regressions; concurrency interleavings repeated 100 times
- `go test ./...`
- `go test -race ./...`
- `go test -tags=integration ./...`
- exact-head CI: Unit Test, Lint, Integration Test, DCO, and codecov patch all successful
- fresh exact-head Codex review found no major issues and the paginated review-thread audit is clear
- integrated no-seed ArduCopter SITL exercised mission delivery, disconnect/reconciliation, and readback-only `ALREADY_APPLIED` with matching digest and zero uploaded count

## Scope boundaries

- Relay command/result retention is bounded and process-local; durable mission admission/effect recovery belongs to Agent and durable workflow/reconciliation belongs to API.
- This does not add a per-attempt nonce, mission authoring, operational-intent authorization, deconfliction, or an autonomous retry that can create a new expired effect.
- This does not close the separate telemetry ACK-after-queue durability gap. Live throughput diagnosis also identified Agent per-frame SQLite transaction cost—not Relay per-frame ACK latency—as the observed SITL backlog source.

